### PR TITLE
add missing serviceAccountName property

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.4]
+* fix for missing `serviceAccountName` in STS deployment kind
+
 ## [1.0.3]
 * fixed prometheus config volume mount if disabled
 * switched from wget to curl image per default for downloading agent

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 1.0.3
+version: 1.0.4
 appVersion: 8.9-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -365,6 +365,13 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.create }}
+    {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+    {{- else }}
+      serviceAccountName: {{ include "sonarqube.fullname" . }}
+    {{- end }}
+    {{- end }}
       volumes:
 {{- if .Values.persistence.volumes }}
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}


### PR DESCRIPTION
### Description

This property was already present in the `Deployment` kind but was absent in the `StatefulSet` kind.

### Changes

* add `serviceAccountName` logic from `Deployment` kind template to `StatefulSet` kind

### Issues

* closes #12 