### PR TITLE
fix missaligned appVersion

### DIFF
--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -25,7 +25,7 @@ OpenShift:
 
 image:
   repository: sonarqube
-  tag: 8.8-community
+  tag: 8.9-community
   pullPolicy: IfNotPresent
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret


### PR DESCRIPTION
### Description

The version in the `values.yaml` was set to 8.8-community, while the `Chart.yaml` implies it would install 8.9-community.

### Changes

* update `values.yaml` to expected appVersion from `Chart.yaml`

### Issues

* n/a