### PR TITLE
change to use curl image for plugin download

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,11 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.5]
+* replace `rjkernick/alpine-wget` with `curlimages/curl`
+* update `install-plugins` script
+* fix possible issue with prometheus init container and `env` set in the `values.yaml` 
+
 ## [1.0.4]
 * fix for missing `serviceAccountName` in STS deployment kind
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 1.0.4
+version: 1.0.5
 appVersion: 8.9-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
       {{- end }}
       {{- if .Values.plugins.install }}
         - name: install-plugins
-          image: {{ default "rjkernick/alpine-wget:latest" .Values.plugins.image }}
+          image: {{ default "curlimages/curl:7.76.1" .Values.plugins.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
           command: ["sh",
             "-e",
@@ -133,8 +133,14 @@ spec:
           {{- end }}
           resources:
 {{ toYaml (default .Values.initContainers.resources .Values.plugins.resource) | indent 12 }}
-          {{- with .Values.env }}
           env:
+            - name: http_proxy
+              value: {{ default "" .Values.plugins.httpProxy }}
+            - name: https_proxy
+              value: {{ default "" .Values.plugins.httpsProxy }}
+            - name: no_proxy
+              value: {{ default "" .Values.plugins.noProxy }}
+          {{- with .Values.env }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -9,21 +9,12 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   install_plugins.sh: |-
-    {{- if .Values.plugins.httpProxy }}
-    export http_proxy={{ .Values.plugins.httpProxy }}
-    {{- end }}
-    {{- if .Values.plugins.httpsProxy }}
-    export https_proxy={{ .Values.plugins.httpsProxy }}
-    {{- end }}
-    {{- if .Values.plugins.noProxy }}
-    export no_proxy={{ .Values.plugins.noProxy }}
-    {{- end }}
     {{- if .Values.plugins.install }}
       [ -e {{ .Values.sonarqubeFolder }}/extensions/downloads/* ] && rm {{ .Values.sonarqubeFolder }}/extensions/downloads/*
-      {{ range $index, $val := .Values.plugins.install }}
-      echo {{ $val | quote }} >> {{ $.Values.sonarqubeFolder }}/extensions/downloads/list{{ end }}
-      cat {{ .Values.sonarqubeFolder }}/extensions/downloads/list | xargs -n 1 -P 8 wget --directory-prefix {{ .Values.sonarqubeFolder }}/extensions/downloads --no-verbose{{ if .Values.plugins.noCheckCertificate }} --no-check-certificate{{ end }}
-      rm {{ .Values.sonarqubeFolder }}/extensions/downloads/list
+      cd {{ .Values.sonarqubeFolder }}/extensions/downloads
+      {{- range $index, $val := .Values.plugins.install }}
+      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} -fsSLO {{ $val | quote }}
+      {{- end }}
     {{- end }}
     {{- if .Values.plugins.lib }}
     {{- range $index, $val := .Values.plugins.lib }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -120,6 +120,9 @@ spec:
               value: {{ default "" .Values.prometheusExporter.httpsProxy }}
             - name: no_proxy
               value: {{ default "" .Values.prometheusExporter.noProxy }}
+          {{- with .Values.env }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if and .Values.persistence.enabled .Values.initFs.enabeld }}
         - name: init-fs
@@ -183,14 +186,10 @@ spec:
               subPath: logs
             - mountPath: /tmp
               name: tmp-dir
-          {{- with .Values.env }}
-          env:
-            {{- . | toYaml | trim | nindent 12 }}
-          {{- end }}
       {{- end }}
       {{- if .Values.plugins.install }}
         - name: install-plugins
-          image: {{ default "rjkernick/alpine-wget:latest" .Values.plugins.image }}
+          image: {{ default "curlimages/curl:7.76.1" .Values.plugins.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
           command: ["sh",
             "-e",
@@ -214,8 +213,14 @@ spec:
           {{- end }}
           resources:
 {{ toYaml (default .Values.initContainers.resources .Values.plugins.resource) | indent 12 }}
-          {{- with .Values.env }}
           env:
+            - name: http_proxy
+              value: {{ default "" .Values.plugins.httpProxy }}
+            - name: https_proxy
+              value: {{ default "" .Values.plugins.httpsProxy }}
+            - name: no_proxy
+              value: {{ default "" .Values.plugins.noProxy }}
+          {{- with .Values.env }}
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -208,7 +208,7 @@ plugins:
   # httpsProxy: ""
   # noProxy: ""
 
-  # image: rjkernick/alpine-wget:latest
+  # image: curlimages/curl:7.76.1
   # resources: {}
 
   # .netrc secret file with a key "netrc" to use basic auth while downloading plugins


### PR DESCRIPTION
### Description

Since the currently used `rjkernick/alpine-wget:latest` is unmaintained it can be seen as a security risk and might get blocked by security restrictions in certain deployments. To circumvent this this PR replicates what #10 started and moved the only use of the image to use a up to date `curl` image. This in turn required an update of the plugin install script to use `curl`.

### Changes

* migrates plugin-install init container to use `curlimages/curl:7.76.1` instead of `rjkernick/alpine-wget:latest`
* updated plugin install script to use `curl` instead of `wget`
* change how proxy settings are handled for the plugin script (unifies it with the Prometheus init container) 
* fix a possible bug with the Prometheus init container if `env` would have been set in values

### Issue(s)

* closes #15 

### Notes

* The `Deployment` kind is actually missing the Prometheus init container, is that intended?
* Proposal: unify the 2 proxy settings in the `values.yaml` since its unlike to have 2 different proxies set for each of them