### PR TITLE
restart SQ when only modifying the exporter agents config

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -2,6 +2,9 @@
 All changes to this chart will be documented in this file.
 
 
+## [1.0.12]
+* make sure SQ is restarted when the JMX Prometheus exporter agents configuration changes
+
 ## [1.0.11]
 * JMX Prometheus exporter agent is now also enabled on the CE process
 * `prometheusExporter.ceConfig` allows specific config of the JMX Prometheus exporter agent for the CE process

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 1.0.11
+version: 1.0.12
 appVersion: 8.9-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -35,6 +35,10 @@ spec:
         checksum/plugins: {{ include (print $.Template.BasePath "/install-plugins.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- if .Values.prometheusExporter.enabled }}
+        checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-config.yaml") . | sha256sum }}
+        checksum/prometheus-ce-config: {{ include (print $.Template.BasePath "/prometheus-ce-config.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.annotations}}
       {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
When deploying a change for the Prometheus exporter agents (just `prometheusExporter.config` and/or `prometheusExporter.esConfig`, and nothing else), SQ doesn't restart.  Too bad I did not see that before submitting #37...

Fixed by adding more checksum annotations.