### PR TITLE
add a Prometheus exporter for ElasticSearch

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.15]
+* added a Prometheus exporter for the ElasticSearch process
+
 ## [1.0.14]
 * added hostAliases to deploymentType statefulset
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 1.0.14
+version: 1.0.15
 appVersion: 8.9-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -112,3 +112,12 @@ Set prometheusExporter.downloadURL
 {{ printf "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/%s/jmx_prometheus_javaagent-%s.jar" .Values.prometheusExporter.version .Values.prometheusExporter.version }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set prometheusExporter.elasticsearch.args
+*/}}
+{{- define "prometheusExporter.elasticsearch.args" -}}
+{{- $esUriArg := printf "--es.uri=%s" .Values.prometheusExporter.elasticsearch.esUri -}}
+{{- $webListenAddressArg := printf "--web.listen-address=:%d" (.Values.prometheusExporter.esMetricsPort | int) -}}
+{{ concat (list $esUriArg $webListenAddressArg) .Values.prometheusExporter.elasticsearch.extraArgs | toJson }}
+{{- end -}}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -222,6 +222,22 @@ spec:
           {{- end }}
       {{- end }}
       containers:
+        {{- if .Values.prometheusExporter.enabled }}
+        - name: {{ printf "%s-elasticsearch-exporter" .Chart.Name }}
+          image: {{ .Values.prometheusExporter.elasticsearch.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: {{ template "prometheusExporter.elasticsearch.args" . }}
+          resources: {{- toYaml .Values.prometheusExporter.elasticsearch.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.prometheusExporter.esMetricsPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+          securityContext: {{- toYaml .Values.prometheusExporter.elasticsearch.securityContext | nindent 12 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -235,6 +251,9 @@ spec:
               protocol: TCP
             - name: monitoring-ce
               containerPort: {{ .Values.prometheusExporter.ceBeanPort }}
+              protocol: TCP
+            - name: monitoring-es
+              containerPort: {{ .Values.prometheusExporter.esMetricsPort }}
               protocol: TCP
             {{- end }}
           resources:

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -190,6 +190,8 @@ prometheusExporter:
   # Ports for the jmx prometheus agent to export metrics at
   webBeanPort: 8000
   ceBeanPort: 8001
+  # Listening port for the elasticsearch_exporter
+  esMetricsPort: 8002
 
   config:
     rules:
@@ -207,6 +209,23 @@ prometheusExporter:
   securityContext:
     runAsUser: 0
     runAsGroup: 0
+  # elasticsearch_exporter settings
+  elasticsearch:
+    image: bitnami/elasticsearch-exporter:1.2.0
+    esUri: http://localhost:9001
+    extraArgs:
+      - "--es.indices"
+      - "--es.shards"
+    securityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
 
 # List of plugins to install.
 # For example:


### PR DESCRIPTION
Following #37 which added the JMX exporter agent to the CE process, here is what I propose for adding an ElasticSearch exporter. It runs [elasticsearch_exporter](https://github.com/prometheus-community/elasticsearch_exporter) in an additional container of the `sonarqube` pod, using (by default) the [bitnami/elasticsearch-exporter](https://github.com/bitnami/bitnami-docker-elasticsearch-exporter) image.

Regarding configuration of the chart, this PR adds the following values:

```yaml
prometheusExporter:
  esMetricsPort: 8002
  elasticsearch:
    image: bitnami/elasticsearch-exporter:1.2.0
    esUri: http://localhost:9001
    extraArgs:
      - "--es.indices"
      - "--es.shards"
    securityContext:
      readOnlyRootFilesystem: true
      runAsNonRoot: true
    resources: ...
```

The ES exporter will be enabled/disabled together with the two other ones, via `prometheusExporter.enabled`.
I also wanted to keep the listen port value next to the other exporter ports (`prometheusExporter.{webBeanPort,ceBeanPort}`), hence the `prometheusExporter.esMetricsPort`. 
For other values (configuration of the container itself, and `elasticsearch_exporter` parameters), I thought it would be confusing to mix them with pre-existing `prometheusExporter.*` values (even if prefixed with `es`), hence the new `prometheusExporter.elasticsearch` subtree.  I'm not 100%sure it's the right choice, you let me know what you think.

Regarding backward compatibility, I think adding this container is okay. Even when it doesn't work as expected out-of-box (if the ElasticSearch address has been customized in `sonar.properties`), it should be fine, the exporter will still be running.