### PR TITLE
"Route" support for OpenShift deployments

### DIFF
--- a/charts/sonarqube/templates/NOTES.txt
+++ b/charts/sonarqube/templates/NOTES.txt
@@ -3,6 +3,9 @@
 {{- range .Values.ingress.hosts }}
   http://{{ .name }}
 {{- end }}
+{{- else if .Values.route.enabled }}
+  export ROUTE_HOST=$(kubectl get route {{ template "sonarqube.name" . }} --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.host}")
+  echo https://$ROUTE_HOST
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "sonarqube.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/sonarqube/templates/route.yaml
+++ b/charts/sonarqube/templates/route.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.route.enabled -}}
+{{- $serviceName := include "sonarqube.fullname" . -}}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ template "sonarqube.name" . }}
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  to:
+    kind: Service
+    name: {{ default $serviceName .serviceName }}
+  port:
+    targetPort: http
+  {{- if .Values.route.tls }}
+  tls:
+{{ toYaml .Values.route.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -20,7 +20,7 @@ deploymentStrategy: {}
 
 ## Is this deployment for OpenShift? If so, we help with SCCs
 OpenShift:
-  enabled: false
+  enabled: true
   createSCC: true
 
 image:
@@ -352,7 +352,7 @@ postgresql:
   securityContext:
     # For standard Kubernetes deployment, set enabled=true
     # If using OpenShift, enabled=false for restricted SCC and enabled=true for anyuid/nonroot SCC
-    enabled: true
+    enabled: false
     # fsGroup and runAsUser specifications below are not applied if enabled=false. enabled=false is the required setting for OpenShift "restricted SCC" to work successfully.
     # postgresql dockerfile sets user as 1001
     fsGroup: 1001
@@ -360,10 +360,10 @@ postgresql:
   volumePermissions:
     # For standard Kubernetes deployment, set enabled=false
     # For OpenShift, set enabled=true and ensure to set volumepermissions.securitycontext.runAsUser below.
-    enabled: false
+    enabled: true
     # if using restricted SCC set runAsUser: "auto" and if running under anyuid/nonroot SCC - runAsUser needs to match runAsUser above
     securityContext:
-      runAsUser: 0
+      runAsUser: "auto"
   shmVolume:
     chmod:
       enabled: false
@@ -384,8 +384,9 @@ tests:
   enabled: true
   # image: bitnami/minideb-extras
 
+# For OpenShift set create=true to ensure service account is created.
 serviceAccount:
-  create: false
+  create: true
   # name:
   ## Annotations for the Service Account
   annotations: {}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -86,6 +86,14 @@ ingress:
   #   hosts:
   #     - chart-example.local
 
+# Create Route for OpenShift deployments
+route:
+  enabled: true
+
+  # Add tls section to secure traffic. TODO: extend this section with other secure route settings
+  tls:
+    termination: edge
+
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}


### PR DESCRIPTION
Added support for Route object to be used in case of OpenShift deployments instead of Ingress.

Changes:
- route.yamle in templates
- new section in values.yaml
- updated Notes to get the route URL