### PR TITLE
BUILD-1107 polishing

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+[0.1.1]
+* added option to use external secret as jwtSecret
+* removed initSysctl from application pods
+
 [0.1.0]
 * fixed pvc template for search nodes
 * added flag to handle hazelcast on k8s

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube is an open sourced code quality scanning tool
-version: 0.1.0
+version: 0.1.1
 appVersion: 9.1-datacenter
 keywords:
   - coverage

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -196,6 +196,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ApplicationNodes.jvmOpts` | Values to add to SONARQUBE_WEB_JVM_OPTS | `""` |
 | `ApplicationNodes.jvmCEOpts` | Values to add to SONAR_CE_JAVAOPTS | `""` |
 | `ApplicationNodes.jwtSecret` | A HS256 key encoded with base64 | `""` |
+| `ApplicationNodes.existingJwtSecret` | secret that contains the `jwtSecret` | `nil` |
 | `ApplicationNodes.resources.requests.memory` | memory request for app Nodes | `2Gi` |
 | `ApplicationNodes.resources.requests.cpu` | cpu request for app Nodes | `400m` |
 | `ApplicationNodes.resources.limits.memory` | memory limit for app Nodes. should not be under 4G | `4096M` |

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -121,3 +121,26 @@ Set prometheusExporter.downloadURL
 {{ printf "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/%s/jmx_prometheus_javaagent-%s.jar" .Values.ApplicationNodes.prometheusExporter.version .Values.ApplicationNodes.prometheusExporter.version }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set jwtSecret
+*/}}
+{{- define "jwtSecret" -}}
+{{- if .Values.ApplicationNodes.existingJwtSecret -}}
+{{- .Values.ApplicationNodes.existingJwtSecret -}}
+{{- else -}}
+{{- template "sonarqube.fullname" . -}}-jwt
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set jwtSecret.useInternalSecret
+*/}}
+{{- define "jwtSecret.useInternalSecret" -}}
+{{- if .Values.ApplicationNodes.existingJwtSecret -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+

--- a/charts/sonarqube-dce/templates/secret.yaml
+++ b/charts/sonarqube-dce/templates/secret.yaml
@@ -27,6 +27,7 @@ type: Opaque
 data:
   SONAR_WEB_SYSTEMPASSCODE: {{ .Values.monitoringPasscode | b64enc | quote }}
 
+{{- if eq (include "jwtSecret.useInternalSecret" .) "true" }}
 ---
 apiVersion: v1
 kind: Secret
@@ -40,3 +41,4 @@ metadata:
 type: Opaque
 data:
   SONAR_AUTH_JWTBASE64HS256SECRET: {{ .Values.ApplicationNodes.jwtSecret | b64enc | quote }}
+{{- end -}}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -30,7 +30,6 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        checksum/init-sysctl: {{ include (print $.Template.BasePath "/init-sysctl.yaml") . | sha256sum }}
         checksum/plugins: {{ include (print $.Template.BasePath "/install-plugins.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
@@ -84,25 +83,6 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-        - name: init-sysctl
-          image: {{ default "busybox:1.32" .Values.initSysctl.image }}
-          imagePullPolicy: {{ .Values.ApplicationNodes.image.pullPolicy  }}
-          {{- if $securityContext := (default .Values.initContainers.securityContext .Values.initSysctl.securityContext) }}
-          securityContext:
-{{ toYaml $securityContext | indent 12 }}
-          {{- end }}
-          resources:
-{{ toYaml (default .Values.initContainers.resources .Values.initSysctl.resources) | indent 12 }}
-          command: ["sh",
-            "-e",
-            "/tmp/scripts/init_sysctl.sh"]
-          volumeMounts:
-            - name: init-sysctl
-              mountPath: /tmp/scripts/
-          {{- with .Values.env }}
-          env:
-            {{- . | toYaml | trim | nindent 12 }}
-          {{- end }}
       {{- end }}
       {{- if .Values.ApplicationNodes.prometheusExporter.enabled }}
         - name: inject-prometheus-exporter
@@ -205,7 +185,7 @@ spec:
             - name: SONAR_AUTH_JWTBASE64HS256SECRET
               valueFrom:
                 secretKeyRef:
-                  name: "{{ template "sonarqube.fullname" . }}-jwt"
+                  name: "{{ template "jwtSecret" . }}"
                   key: SONAR_AUTH_JWTBASE64HS256SECRET
             - name: SONAR_WEB_JAVAOPTS
               value: {{ template "sonarqube.jvmOpts" . }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -187,6 +187,8 @@ ApplicationNodes:
 
   # SONAR_AUTH_JWTBASE64HS256SECRET
   jwtSecret: ""
+  # can use existing secret with SONAR_AUTH_JWTBASE64HS256SECRET as key
+  # existingJwtSecret: ""
 
 
   ## We usually don't make specific resource recommendations, as they are heavily dependent on
@@ -312,7 +314,7 @@ initFs:
   securityContext:
     privileged: true
 
-## a monitoring passcode needs to be defined in order to get reasonable probe results
+# a monitoring passcode needs to be defined in order to get reasonable probe results
 # not setting the monitoring passcode will result in a deployment that will never be ready
 monitoringPasscode: "define_it"
 


### PR DESCRIPTION
While working on our internal deployment i noticed two things: 

1. we can remove the `initSysctl` init container from the application pods
2. we can source the jwt secret for the application pods from an external secret

sadly this is not possible for the `monitoringPasscode` 