### PR TITLE
Add new ingress parameter ingressClassName

### DIFF
--- a/charts/sonarqube-lts/templates/ingress.yaml
+++ b/charts/sonarqube-lts/templates/ingress.yaml
@@ -27,6 +27,9 @@ metadata:
 {{- end }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ printf "%s" .name }}

--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -27,6 +27,9 @@ metadata:
 {{- end }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ printf "%s" .name }}


### PR DESCRIPTION
Adding new optional parameter `ingressClassName` to both `sonarqube` and `sonarqube-lts` charts. 

For more information on `ingressClassName` see [here](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/)