### PR TITLE
Fix PVC `chart` label

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,7 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [1.0.16]
+## [1.1.3]
+* fixed `invalid: metadata.labels: Invalid value` error on the `chart` label of the pvc
+
+## [1.0.17]
 * release to helm repository
 * updated appversion to new LTS patch release
 
@@ -23,7 +26,7 @@ All changes to this chart will be documented in this file.
 
 ## [1.0.10]
 * added prometheusExporter.noCheckCertificate option
- 
+
 ## [1.0.9]
 * add missing imagePullSecrets in sts install type
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.16
+version: 1.0.17
 appVersion: 8.9.2
 keywords:
   - coverage

--- a/charts/sonarqube-lts/templates/pvc.yaml
+++ b/charts/sonarqube-lts/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "sonarqube.fullname" . }}
   labels:
     app: {{ template "sonarqube.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{ if .Values.persistence.annotations}}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.3]
+* fixed `invalid: metadata.labels: Invalid value` error on the `chart` label of the pvc
+
 ## [1.1.2]
 * fixed condition check to add new certificates
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.1.2
+version: 1.1.3
 appVersion: 9.0.1
 keywords:
   - coverage

--- a/charts/sonarqube/templates/pvc.yaml
+++ b/charts/sonarqube/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "sonarqube.fullname" . }}
   labels:
     app: {{ template "sonarqube.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{ if .Values.persistence.annotations}}


### PR DESCRIPTION
**What happens:**
When attempting to apply this Helm Chart with `persistence.enabled` set to `true` I receive this error:

```
Error: PersistentVolumeClaim "sonarqube-sonarqube" is invalid: metadata.labels: Invalid value: "sonarqube-1.1.1+98": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```
This seems to be due to the label `chart` on the PVC, which is set to `{{ .Chart.Name }}-{{ .Chart.Version }}`. With the versioning currently on the chart, this adds a `+` to the label, which is not allowed in Kubernetes.

**What's expected:**
All resources deploy, including the PVC

**Fix:**
As with [other resources in this chart](https://github.com/SonarSource/helm-chart-sonarqube/blob/master/charts/sonarqube/templates/service.yaml#L7), replacing `+` with `_` should fix this issue.