### PR TITLE
Add resources to tests pod templates

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.1.5]
+* added resources to ui-test pod template
+
 ## [1.1.4]
 * fixed artifacthub annotations
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.1.4
+version: 1.1.5
 appVersion: 9.0.1
 keywords:
   - coverage
@@ -19,7 +19,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "fixed artifacthub annotations"
+      description: "added resources to ui-test pod template"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/tests/sonarqube-test.yaml
+++ b/charts/sonarqube/templates/tests/sonarqube-test.yaml
@@ -20,6 +20,8 @@ spec:
         - |-
           set -ex
           cp -R /opt/bats /tools/bats/
+      resources:
+{{ toYaml .Values.tests.initContainers.resources | indent 8 }}
       volumeMounts:
         - mountPath: /tools
           name: tools
@@ -31,6 +33,8 @@ spec:
         "/tools/bats/bin/bats",
         "--tap",
         "/tests/run.sh"]
+      resources:
+{{ toYaml .Values.tests.resources | indent 8 }}
       volumeMounts:
       - mountPath: /tests
         name: tests

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -432,6 +432,9 @@ sonarqubeFolder: /opt/sonarqube
 
 tests:
   enabled: true
+  resources: {}
+  initContainers:
+    resources: {}
   # image: bitnami/minideb-extras
 
 # For OpenShift set create=true to ensure service account is created.


### PR DESCRIPTION
Currently there is no way to enable tests while deploying to a cluster with enabled ResourceQuota admission control plugin. This PR adds a few missing `resources:` keys to the templates and values.yaml.