### PR TITLE
[skip ci] SONAR-15402 fixup to set the right image tags

### DIFF
--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `searchNodes.image.repository` | search image repository | `sonarqube` |
-| `searchNodes.image.tag` | search image tag | `9.1-datacenter-search` |
+| `searchNodes.image.tag` | search image tag | `9.1.0-datacenter-search` |
 | `searchNodes.image.pullPolicy` | search image pull policy | `IfNotPresent` |
 | `searchNodes.image.pullSecret` | search imagePullSecret to use for private repository | `nil` |
 | `searchNodes.env` | Environment variables to attach to the search pods | `nil` |

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 9.1-datacenter-search
+    tag: 9.1.0-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the name of the imagePullSecret to use
     # pullSecret: my-repo-secret
@@ -71,7 +71,7 @@ searchNodes:
 ApplicationNodes:
   image:
     repository: sonarqube
-    tag: 9.1-datacenter-app
+    tag: 9.1.0-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the name of the imagePullSecret to use
     # pullSecret: my-repo-secret

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -12,7 +12,7 @@ Please note that this chart only supports SonarQube Community, Developer, and En
 
 | SonarQube Version | Kubernetes Version | Helm Chart Version |
 |-------------------|--------------------|--------------------|
-| 9.0               | 1.19, 1.20, 1.21   | 1.1                |
+| 9.1               | 1.19, 1.20, 1.21   | 1.1                |
 
 ## Installing the chart
 
@@ -123,7 +123,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `OpenShift.enabled`                                      | Define if this deployment is for OpenShift                                                                                | `false`                         |
 | `OpenShift.createSCC`                                    | If this deployment is for OpenShift, define if SCC should be created for sonarqube pod                                    | `true`                          |
 | `image.repository`                                       | image repository                                                                                                          | `sonarqube`                     |
-| `image.tag`                                              | `sonarqube` image tag.                                                                                                    | `9.0.1-community`                 |
+| `image.tag`                                              | `sonarqube` image tag.                                                                                                    | `9.1.0-community`                 |
 | `image.pullPolicy`                                       | Image pull policy                                                                                                         | `IfNotPresent`                  |
 | `image.pullSecret`                                       | imagePullSecret to use for private repository (commented out)                                                             | `my-repo-secret`                |
 | `securityContext.fsGroup`                                | Group applied to mounted directories/files                                                                                | `1000`                          |


### PR DESCRIPTION
Documentation changes do not need CI to pass and the `9.1` tag is the same hash as `9.1.0` 