### PR TITLE
Add support for multiple image.pullSecrets

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -2,10 +2,14 @@
 All changes to this chart will be documented in this file.
 
 ## [0.3.0]
-* added support multiple image pull secrets
-  * replaced `searchNodes.image.pullSecret` with `searchNodes.image.pullSecrets`
-  * replaced `ApplicationNodes.image.pullSecret` with `ApplicationNodes.image.pullSecrets`
+* added support for multiple image pull secrets
+  * added `searchNodes.image.pullSecrets`
+  * added `ApplicationNodes.image.pullSecrets`
+* deprecated support for singular image pull secret
+  * deprecated `searchNodes.image.pullSecret`
+  * deprecated `ApplicationNodes.image.pullSecret`
 * fixed missing image pull secret in admin hook job
+
 ## [0.2.5]
 * updated SonarQube to 9.2.4
 

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,11 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.3.0]
+* added support multiple image pull secrets
+  * replaced `searchNodes.image.pullSecret` with `searchNodes.image.pullSecrets`
+  * replaced `ApplicationNodes.image.pullSecret` with `ApplicationNodes.image.pullSecrets`
+* fixed missing image pull secret in admin hook job
 ## [0.2.5]
 * updated SonarQube to 9.2.4
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -21,8 +21,10 @@ annotations:
     - name: support
       url: https://community.sonarsource.com/
   artifacthub.io/changes: |
-    - kind: changed
-      description: "updated SonarQube to 9.2.4"
+    - kind: added
+      description: "added support multiple image pull secrets"
+    - kind: fixed
+      description: "fixed missing image pull secret in admin hook job"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 0.2.5
+version: 0.3.0
 appVersion: 9.2.4
 keywords:
   - coverage

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -23,6 +23,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: "added support multiple image pull secrets"
+    - kind: deprecated
+      description: "deprecated support for singular image pull secret"
     - kind: fixed
       description: "fixed missing image pull secret in admin hook job"
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -115,7 +115,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `searchNodes.image.repository` | search image repository | `sonarqube` |
 | `searchNodes.image.tag` | search image tag | `9.2.0-datacenter-search` |
 | `searchNodes.image.pullPolicy` | search image pull policy | `IfNotPresent` |
-| `searchNodes.image.pullSecret` | search imagePullSecret to use for private repository | `nil` |
+| `searchNodes.image.pullSecrets` | search imagePullSecrets to use for private repository | `nil` |
 | `searchNodes.env` | Environment variables to attach to the search pods | `nil` |
 | `searchNodes.searchAuthentication.enabled` | Securing the Search Cluster with basic authentication and TLS in between search nodes | `false` |
 | `searchNodes.searchAuthentication.keyStoreSecret` | Existing PKCS#12 Container as Keystore/Truststore to be used | `""` |
@@ -153,7 +153,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ApplicationNodes.image.repository` | app image repository | `sonarqube` |
 | `ApplicationNodes.image.tag` | app image tag | `9.2.0-datacenter-app` |
 | `ApplicationNodes.image.pullPolicy` | app image pull policy | `IfNotPresent` |
-| `ApplicationNodes.image.pullSecret` | app imagePullSecret to use for private repository | `nil` |
+| `ApplicationNodes.image.pullSecrets` | app imagePullSecrets to use for private repository | `nil` |
 | `ApplicationNodes.env` | Environment variables to attach to the app pods | `nil` |
 | `ApplicationNodes.replicaCount` | Replica count of the app Nodes | `2` |
 | `ApplicationNodes.securityContext.fsGroup` | Group applied to mounted directories/files on app nodes | `1000` |

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -115,6 +115,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `searchNodes.image.repository` | search image repository | `sonarqube` |
 | `searchNodes.image.tag` | search image tag | `9.2.0-datacenter-search` |
 | `searchNodes.image.pullPolicy` | search image pull policy | `IfNotPresent` |
+| `searchNodes.image.pullSecret` | (DEPRECATED) search imagePullSecret to use for private repository | `nil` |
 | `searchNodes.image.pullSecrets` | search imagePullSecrets to use for private repository | `nil` |
 | `searchNodes.env` | Environment variables to attach to the search pods | `nil` |
 | `searchNodes.searchAuthentication.enabled` | Securing the Search Cluster with basic authentication and TLS in between search nodes | `false` |
@@ -153,6 +154,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ApplicationNodes.image.repository` | app image repository | `sonarqube` |
 | `ApplicationNodes.image.tag` | app image tag | `9.2.0-datacenter-app` |
 | `ApplicationNodes.image.pullPolicy` | app image pull policy | `IfNotPresent` |
+| `ApplicationNodes.image.pullSecret` | (DEPRECATED) app imagePullSecret to use for private repository | `nil` |
 | `ApplicationNodes.image.pullSecrets` | app imagePullSecrets to use for private repository | `nil` |
 | `ApplicationNodes.env` | Environment variables to attach to the app pods | `nil` |
 | `ApplicationNodes.replicaCount` | Replica count of the app Nodes | `2` |

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -33,7 +33,7 @@ spec:
       restartPolicy: OnFailure
       {{- if .Values.ApplicationNodes.image.pullSecrets }}
       imagePullSecrets:
-{{- toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
+{{ toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -31,6 +31,10 @@ spec:
       {{- end }}
     spec:
       restartPolicy: OnFailure
+      {{- if .Values.ApplicationNodes.image.pullSecrets }}
+      imagePullSecrets:
+{{- toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password
         image: {{ default "curlimages/curl:latest" .Values.curlContainerImage }}

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -31,9 +31,14 @@ spec:
       {{- end }}
     spec:
       restartPolicy: OnFailure
-      {{- if .Values.ApplicationNodes.image.pullSecrets }}
+      {{- if or .Values.ApplicationNodes.image.pullSecrets .Values.ApplicationNodes.image.pullSecret }}
       imagePullSecrets:
-{{ toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
+        {{- if .Values.ApplicationNodes.image.pullSecret }}
+        - name: {{ .Values.ApplicationNodes.image.pullSecret }}
+        {{- end }}
+        {{- if .Values.ApplicationNodes.image.pullSecrets }}
+{{ toYaml .Values.ApplicationNodes.image.pullSecrets | indent 8 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -43,9 +43,14 @@ spec:
       {{- end }}
 {{- end }}
     spec:
-      {{- if .Values.ApplicationNodes.image.pullSecrets }}
+      {{- if or .Values.ApplicationNodes.image.pullSecrets .Values.ApplicationNodes.image.pullSecret }}
       imagePullSecrets:
-{{ toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
+        {{- if .Values.ApplicationNodes.image.pullSecret }}
+        - name: {{ .Values.ApplicationNodes.image.pullSecret }}
+        {{- end }}
+        {{- if .Values.ApplicationNodes.image.pullSecrets }}
+{{ toYaml .Values.ApplicationNodes.image.pullSecrets | indent 8 }}
+        {{- end }}
       {{- end }}
       initContainers:
       {{- if .Values.ApplicationNodes.extraInitContainers }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -43,9 +43,9 @@ spec:
       {{- end }}
 {{- end }}
     spec:
-      {{- if .Values.ApplicationNodes.image.pullSecret }}
+      {{- if .Values.ApplicationNodes.image.pullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.ApplicationNodes.image.pullSecret }}
+{{ toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
       {{- if .Values.ApplicationNodes.extraInitContainers }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -66,9 +66,9 @@ spec:
       {{- end }}
 {{- end }}
     spec:
-      {{- if .Values.searchNodes.image.pullSecret }}
+      {{- if .Values.searchNodes.image.pullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.searchNodes.image.pullSecret }}
+{{- toYaml .Values.searchNodes.image.pullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -66,9 +66,14 @@ spec:
       {{- end }}
 {{- end }}
     spec:
-      {{- if .Values.searchNodes.image.pullSecrets }}
+      {{- if or .Values.searchNodes.image.pullSecrets .Values.searchNodes.image.pullSecret }}
       imagePullSecrets:
-{{ toYaml .Values.searchNodes.image.pullSecrets | nindent 8 }}
+        {{- if .Values.searchNodes.image.pullSecret }}
+        - name: {{ .Values.searchNodes.image.pullSecret }}
+        {{- end }}
+        {{- if .Values.searchNodes.image.pullSecrets }}
+{{ toYaml .Values.searchNodes.image.pullSecrets | indent 8 }}
+        {{- end }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -68,7 +68,7 @@ spec:
     spec:
       {{- if .Values.searchNodes.image.pullSecrets }}
       imagePullSecrets:
-{{- toYaml .Values.searchNodes.image.pullSecrets | nindent 8 }}
+{{ toYaml .Values.searchNodes.image.pullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
+++ b/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   {{- if .Values.ApplicationNodes.image.pullSecrets }}
   imagePullSecrets:
-{{- toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
+{{ toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
   {{- end }}
   initContainers:
     - name: "bats"

--- a/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
+++ b/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
@@ -11,9 +11,14 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  {{- if .Values.ApplicationNodes.image.pullSecrets }}
+  {{- if or .Values.ApplicationNodes.image.pullSecrets .Values.ApplicationNodes.image.pullSecret }}
   imagePullSecrets:
-{{ toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
+    {{- if .Values.ApplicationNodes.image.pullSecret }}
+    - name: {{ .Values.ApplicationNodes.image.pullSecret }}
+    {{- end }}
+    {{- if .Values.ApplicationNodes.image.pullSecrets }}
+{{ toYaml .Values.ApplicationNodes.image.pullSecrets | indent 4 }}
+    {{- end }}
   {{- end }}
   initContainers:
     - name: "bats"

--- a/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
+++ b/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
@@ -11,6 +11,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if .Values.ApplicationNodes.image.pullSecrets }}
+  imagePullSecrets:
+{{- toYaml .Values.ApplicationNodes.image.pullSecrets | nindent 8 }}
+  {{- end }}
   initContainers:
     - name: "bats"
       image: "bats/bats:1.2.1"

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -7,8 +7,9 @@ searchNodes:
     repository: sonarqube
     tag: 9.2.4-datacenter-search
     pullPolicy: IfNotPresent
-    # If using a private repository, the name of the imagePullSecret to use
-    # pullSecret: my-repo-secret
+    # If using a private repository, the imagePullSecrets to use
+    # pullSecrets:
+    #   - name: my-repo-secret
 
     ## Environment variables to attach to the search pods
     ##
@@ -89,8 +90,9 @@ ApplicationNodes:
     repository: sonarqube
     tag: 9.2.4-datacenter-app
     pullPolicy: IfNotPresent
-    # If using a private repository, the name of the imagePullSecret to use
-    # pullSecret: my-repo-secret
+    # If using a private repository, the imagePullSecrets to use
+    # pullSecrets:
+    #   - name: my-repo-secret
 
     ## Environment variables to attach to the application pods
     ##

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,7 +1,7 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [2.0.0]
+## [1.3.0]
 * added support for multiple image pull secrets
   * added `image.pullSecrets`
 * deprecated support for singular image pull secret

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,11 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.0]
+* added support multiple image pull secrets
+  * replaced `image.pullSecret` with `image.pullSecrets`
+* fixed missing image pull secret in admin hook job
+
 ## [1.2.5]
 * updated SonarQube to 9.2.4
 

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -2,8 +2,10 @@
 All changes to this chart will be documented in this file.
 
 ## [2.0.0]
-* added support multiple image pull secrets
-  * replaced `image.pullSecret` with `image.pullSecrets`
+* added support for multiple image pull secrets
+  * added `image.pullSecrets`
+* deprecated support for singular image pull secret
+  * deprecated `image.pullSecret`
 * fixed missing image pull secret in admin hook job
 
 ## [1.2.5]

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.2.5
+version: 2.0.0
 appVersion: 9.2.4
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 2.0.0
+version: 1.3.0
 appVersion: 9.2.4
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -23,6 +23,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: "added support multiple image pull secrets"
+    - kind: deprecated
+      description: "deprecated support for singular image pull secret"
     - kind: fixed
       description: "fixed missing image pull secret in admin hook job"
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -21,8 +21,10 @@ annotations:
     - name: support
       url: https://community.sonarsource.com/
   artifacthub.io/changes: |
-    - kind: changed
-      description: "updated SonarQube to 9.2.4"
+    - kind: added
+      description: "added support multiple image pull secrets"
+    - kind: fixed
+      description: "fixed missing image pull secret in admin hook job"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -144,6 +144,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `image.repository` | image repository | `sonarqube` |
 | `image.tag` | `sonarqube` image tag. | `9.2.0-community` |
 | `image.pullPolicy` | Image pull policy  | `IfNotPresent` |
+| `image.pullSecret` | (DEPRECATED) imagePullSecret to use for private repository | `None` |
 | `image.pullSecrets` | imagePullSecrets to use for private repository | `None` |
 
 ### Security

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -144,7 +144,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `image.repository` | image repository | `sonarqube` |
 | `image.tag` | `sonarqube` image tag. | `9.2.0-community` |
 | `image.pullPolicy` | Image pull policy  | `IfNotPresent` |
-| `image.pullSecret` | imagePullSecret to use for private repository | `None` |
+| `image.pullSecrets` | imagePullSecrets to use for private repository | `None` |
 
 ### Security
 

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -31,6 +31,10 @@ spec:
       {{- end }}
     spec:
       restartPolicy: OnFailure
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password
         image: {{ default "curlimages/curl:latest" .Values.curlContainerImage }}

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -31,9 +31,14 @@ spec:
       {{- end }}
     spec:
       restartPolicy: OnFailure
-      {{- if .Values.image.pullSecrets }}
+      {{- if or .Values.image.pullSecrets .Values.image.pullSecret }}
       imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | nindent 8 }}
+        {{- if .Values.image.pullSecret }}
+        - name: {{ .Values.image.pullSecret }}
+        {{- end }}
+        {{- if .Values.image.pullSecrets }}
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -33,7 +33,7 @@ spec:
       restartPolicy: OnFailure
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-{{- toYaml .Values.image.pullSecrets | nindent 8 }}
+{{ toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+{{ toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -49,9 +49,9 @@ spec:
       serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
-      {{- if .Values.image.pullSecret }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.image.pullSecret }}
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -49,9 +49,14 @@ spec:
       serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
-      {{- if .Values.image.pullSecrets }}
+      {{- if or .Values.image.pullSecrets .Values.image.pullSecret }}
       imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | nindent 8 }}
+        {{- if .Values.image.pullSecret }}
+        - name: {{ .Values.image.pullSecret }}
+        {{- end }}
+        {{- if .Values.image.pullSecrets}}
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+        {{- end }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -47,9 +47,14 @@ spec:
     spec:
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
-      {{- if .Values.image.pullSecrets }}
+      {{- if or .Values.image.pullSecrets .Values.image.pullSecret }}
       imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | nindent 8 }}
+        {{- if .Values.image.pullSecret }}
+        - name: {{ .Values.image.pullSecret }}
+        {{- end }}
+        {{- if .Values.image.pullSecrets}}
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+        {{- end }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -47,9 +47,9 @@ spec:
     spec:
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
-      {{- if .Values.image.pullSecret }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.image.pullSecret }}
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -49,7 +49,7 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+{{ toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}

--- a/charts/sonarqube/templates/tests/sonarqube-test.yaml
+++ b/charts/sonarqube/templates/tests/sonarqube-test.yaml
@@ -11,6 +11,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if or .Values.image.pullSecrets .Values.image.pullSecret }}
+  imagePullSecrets:
+    {{- if .Values.image.pullSecret }}
+    - name: {{ .Values.image.pullSecret }}
+    {{- end}}
+    {{- if .Values.image.pullSecrets}}
+{{ toYaml .Values.image.pullSecrets | indent 4 }}
+    {{- end}}
+  {{- end }}
   initContainers:
     - name: "bats"
       image: "bats/bats:1.2.1"

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -27,8 +27,9 @@ image:
   repository: sonarqube
   tag: 9.2.4-community
   pullPolicy: IfNotPresent
-  # If using a private repository, the name of the imagePullSecret to use
-  # pullSecret: my-repo-secret
+  # If using a private repository, the imagePullSecrets to use
+  # pullSecrets:
+  #   - name: my-repo-secret
 
 # Set security context for sonarqube pod
 securityContext:


### PR DESCRIPTION
At the moment it is only possible to set one pull secret through `image.pullSecret`. But for my use-case I would like to be able to use multiple `imagePullSecrets` to be able to pull the images from different private registries.

Some changes along the lines of this PR would be required, would a feature like this to acceptable to merge?

---

In this PR I went for the easy way and replaced `image.pullSecret` with `image.pullSecrets` with a bit of effort it's also possible to implement this in a way that retains compatibility.

