### PR TITLE
Fix sonarqube-lts SCC

### DIFF
--- a/charts/sonarqube-lts/templates/sonarqube-scc.yaml
+++ b/charts/sonarqube-lts/templates/sonarqube-scc.yaml
@@ -52,7 +52,7 @@ volumes:
 priority: 11
 users:
 {{- if .Values.serviceAccount.name }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-{{ .Values.serviceAccount.name }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount.name }}
 {{- else  }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-sonarqube
 {{- end }}


### PR DESCRIPTION
Helm generates a wrong user entry in SCC that prefixes the specified service account name with Release.Name and does not matches the existing one
Example for serviceaccount default:
```
users:
- system:serviceaccount:namespace-x:sonarqube-lts-default
```
where the correct service account name is only default and not sonarqube-lts-default.
Expected:
```
users:
- system:serviceaccount:namespace-x:default
```

In sonarqube chart (non tls) seems already fixed in this defect fix (https://github.com/SonarSource/helm-chart-sonarqube/commit/fdd3e6d061387b01f4a36b0730f4d2578ea1afab)