### PR TITLE
Issue-139 Fixes and improvements on use of monitoring passcode

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [0.6.0]
+* update `livenessProbe` to use exec probes and reuse `SONAR_WEB_SYSTEMPASSCODE` environment variable
+
 ## [0.5.0]
 * added support for additional sidecar container
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 0.5.0
+version: 0.6.0
 appVersion: 9.2.4
 keywords:
   - coverage
@@ -43,6 +43,8 @@ annotations:
       description: "admin hook now honors web context"
     - kind: added
       description: "added support for additional sidecar containers"
+    - kind: changed
+      description: "livenessProbe changed to exec probe to reuse value of SONAR_WEB_SYSTEMPASSCODE"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -233,13 +233,14 @@ spec:
                 name: {{ . }}
 {{- end }}
           livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: {{ .Values.ApplicationNodes.livenessProbe.sonarWebContext }}api/system/liveness
-              port: http
-              httpHeaders:
-                - name: X-Sonar-Passcode
-                  value: {{ .Values.monitoringPasscode }}
+            exec:
+              command:
+                - bash
+                - -c
+                - wget
+                - -qO-
+                - --header="X-Sonar-Passcode:${SONAR_WEB_SYSTEMPASSCODE}"
+                - http://localhost:{{ .Values.service.internalPort }}{{ .Values.ApplicationNodes.livenessProbe.sonarWebContext }}api/system/liveness
             initialDelaySeconds: {{ .Values.ApplicationNodes.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.ApplicationNodes.livenessProbe.periodSeconds }}
           readinessProbe:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.6.0]
+* fix missing `SONAR_WEB_SYSTEMPASSCODE` environment variable causing failed liveness checks
+* update `livenessProbe` to use exec probes and reuse `SONAR_WEB_SYSTEMPASSCODE` environment variable
+
 ## [1.5.0]
 * detached sonarqube edition from version
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.5.0
+version: 1.6.0
 appVersion: 9.2.4
 keywords:
   - coverage
@@ -41,6 +41,10 @@ annotations:
       description: "admin hook now honors web context"
     - kind: changed
       description: "detached sonarqube version from edition"
+    - kind: fixed
+      description: "SONAR_WEB_SYSTEMPASSCODE env var is available with deploymentType=Deployment"
+    - kind: changed
+      description: "livenessProbe changed to exec probe to reuse value of SONAR_WEB_SYSTEMPASSCODE"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -238,13 +238,14 @@ spec:
                 name: {{ . }}
 {{- end }}
           livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: {{ .Values.livenessProbe.sonarWebContext }}api/system/liveness
-              port: http
-              httpHeaders:
-                - name: X-Sonar-Passcode
-                  value: {{ .Values.monitoringPasscode }}
+              exec:
+                command:
+                  - bash
+                  - -c
+                  - wget
+                  - -qO-
+                  - --header="X-Sonar-Passcode:${SONAR_WEB_SYSTEMPASSCODE}"
+                  - http://localhost:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -82,6 +82,11 @@ spec:
               name: ca-certs
           {{- with .Values.env }}
           env:
+            - name: SONAR_WEB_SYSTEMPASSCODE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "sonarqube.fullname" . }}-monitoring-passcode
+                  key: SONAR_WEB_SYSTEMPASSCODE
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -308,13 +308,14 @@ spec:
                 name: {{ . }}
 {{- end }}
           livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: {{ .Values.livenessProbe.sonarWebContext }}api/system/liveness
-              port: http
-              httpHeaders:
-                - name: X-Sonar-Passcode
-                  value: {{ .Values.monitoringPasscode }}
+            exec:
+              command:
+                - bash
+                - -c
+                - wget
+                - -qO-
+                - --header="X-Sonar-Passcode:${SONAR_WEB_SYSTEMPASSCODE}"
+                - http://localhost:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:


### PR DESCRIPTION
This PR should address issue #139. Please let me know if I'm missing anything or if there is a better way to handle this.

Changes:

- Add missing passcode from list of environment variables ( sonarqube )
- update livenessProbe to use exec commands and prevent the passcode from being templated in plaintext in the manifest ( sonarqube, sonarqube-dce )
