### PR TITLE
Allow overriding the host of a route

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.5.1]
+* added possibility to define host of a route
+
 ## [1.5.0]
 * detached sonarqube edition from version
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.5.0
+version: 1.5.1
 appVersion: 9.2.4
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -200,6 +200,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `route.enabled` | Flag to enable OpenShift Route | `false` |
+| `route.host` | Host of the route | `""` |
 | `route.tls.termination` | TLS termination type. Currently supported values are `edge` and `passthrough` | `edge` |
 
 ### Probes

--- a/charts/sonarqube/templates/route.yaml
+++ b/charts/sonarqube/templates/route.yaml
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+{{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+{{- end }}
   to:
     kind: Service
     name: {{ default $serviceName .serviceName }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -110,7 +110,7 @@ ingress:
 
 route:
   enabled: false
-
+  host: ""
   # Add tls section to secure traffic. TODO: extend this section with other secure route settings
   # Comment this out if you want plain http route created.
   tls:


### PR DESCRIPTION
Allow overriding the host a route through a value. An empty `route.host` will keep the old behaviour of a defaulted host.