### PR TITLE
Fix sonarqube-lts SCC

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,9 +1,12 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.25]
+* fixed wrong scc user reference if name was explicitly set
+
 ## [1.0.24]
 * fixed missing `env` key for the install-plugins container in both the Deployment and StatefulSet
-  
+
 ## [1.0.23]
 * updated SonarQube LTS to 8.9.6
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.24
+version: 1.0.25
 appVersion: 8.9.6
 keywords:
   - coverage

--- a/charts/sonarqube-lts/templates/sonarqube-scc.yaml
+++ b/charts/sonarqube-lts/templates/sonarqube-scc.yaml
@@ -52,7 +52,7 @@ volumes:
 priority: 11
 users:
 {{- if .Values.serviceAccount.name }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-{{ .Values.serviceAccount.name }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount.name }}
 {{- else  }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-sonarqube
 {{- end }}


### PR DESCRIPTION
Helm generates a wrong user entry in SCC that prefixes the specified service account name with Release.Name and does not matches the existing one
Example for serviceaccount default:
```
users:
- system:serviceaccount:namespace-x:sonarqube-lts-default
```
where the correct service account name is only default and not sonarqube-lts-default.
Expected:
```
users:
- system:serviceaccount:namespace-x:default
```

In sonarqube chart (non tls) seems already fixed in this defect fix (https://github.com/SonarSource/helm-chart-sonarqube/commit/fdd3e6d061387b01f4a36b0730f4d2578ea1afab)