### PR TITLE
Updated all instances of the caCerts enabled check

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.1]
+* Updated all instances of the caCerts enabled check
+
 ## [1.0.0]
 * updated SonarQube to 9.3.0
 * officially support SonarQube DCE

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.0
+version: 1.0.1
 appVersion: 9.3.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -328,7 +328,7 @@ spec:
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
               name: secret
             {{- end }}
-            {{- if .Values.caCerts }}
+            {{- if .Values.caCerts.enabled }}
             - mountPath: {{ .Values.sonarqubeFolder }}/certs
               name: sonarqube
               subPath: certs
@@ -402,7 +402,7 @@ spec:
           - key: sonar-secret.txt
             path: sonar-secret.txt
       {{- end }}
-      {{- if .Values.caCerts }}
+      {{- if .Values.caCerts.enabled }}
       - name: ca-certs
         secret:
           secretName: {{ .Values.caCerts.secret }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.1]
+* Updated all instances of the caCerts enabled check
+
 ## [2.0.0]
 * updated SonarQube to 9.3.0
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 2.0.0
+version: 2.0.1
 appVersion: 9.3.0
 keywords:
   - coverage

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -206,7 +206,7 @@ spec:
 {{- if .Values.persistence.mounts }}
 {{ toYaml .Values.persistence.mounts | indent 12 }}
 {{- end }}
-            {{- if .Values.caCerts }}
+            {{- if .Values.caCerts.enabled }}
             - mountPath: {{ .Values.sonarqubeFolder }}/certs
               name: sonarqube
               subPath: certs
@@ -382,7 +382,7 @@ spec:
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
               name: secret
             {{- end }}
-            {{- if .Values.caCerts }}
+            {{- if .Values.caCerts.enabled }}
             - mountPath: {{ .Values.sonarqubeFolder }}/certs
               name: sonarqube
               subPath: certs
@@ -467,7 +467,7 @@ spec:
           - key: sonar-secret.txt
             path: sonar-secret.txt
       {{- end }}
-      {{- if .Values.caCerts }}
+      {{- if .Values.caCerts.enabled }}
       - name: ca-certs
         secret:
           secretName: {{ .Values.caCerts.secret }}


### PR DESCRIPTION
Not all instances of the check if caCerts were enabled were updated so it would still try to add the volumes even though it is disabled. This causes the deployment to fail.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart