### PR TITLE
Do not automatically mount Service Account token

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,8 +1,12 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.4]
+* no longer automount service account token
+
 ## [2.0.3]
 * changed description of dependency postgresql chart
+
 ## [2.0.2]
 * changed links to get a better overview of sources
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -30,6 +30,8 @@ annotations:
       description: "Updated all instances of the caCerts enabled check"
     - kind: changed
       description: "changed description of dependency postgresql chart"
+    - kind: changed
+      description: "no longer automount service account token"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 2.0.3
+version: 2.0.4
 appVersion: 9.3.0
 keywords:
   - coverage

--- a/charts/sonarqube/templates/serviceaccount.yaml
+++ b/charts/sonarqube/templates/serviceaccount.yaml
@@ -12,4 +12,5 @@ metadata:
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
+automountServiceAccountToken: false
 {{- end -}}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

The `automountServiceAccountToken` property defaults to `true`, this PR opts out of automounting that token to reduce container vulnerabilities.