### PR TITLE
Fix spelling error in sonarqube-lts App sts: "initFS.enabeld" -> "initFs.enabled"

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,7 +1,7 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [Unreleased]
+## [1.0.26]
 * Fix spelling error. "initFs.enabeld" -> "initFs.enabled"
 
 ## [1.0.25]

--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [Unreleased]
+* Fix spelling error. "initFs.enabeld" -> "initFs.enabled"
+
 ## [1.0.25]
 * updated SonarQube LTS to 8.9.7
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.25
+version: 1.0.26
 appVersion: 8.9.7
 keywords:
   - coverage
@@ -19,7 +19,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "updated SonarQube to 8.9.7"
+      description: "Fix spelling error in initFs enabled flag for App statefulset"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube-lts/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube-lts/templates/sonarqube-sts.yaml
@@ -161,7 +161,7 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- if and .Values.persistence.enabled .Values.initFs.enabled }}
+      {{- if and .Values.persistence.enabled ( or .Values.initFs.enabeld .Values.initFs.enabled ) }}
         - name: init-fs
           image: {{ default "busybox:1.32" .Values.initFs.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}

--- a/charts/sonarqube-lts/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube-lts/templates/sonarqube-sts.yaml
@@ -161,7 +161,7 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- if and .Values.persistence.enabled .Values.initFs.enabeld }}
+      {{- if and .Values.persistence.enabled .Values.initFs.enabled }}
         - name: init-fs
           image: {{ default "busybox:1.32" .Values.initFs.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -173,7 +173,7 @@ initSysctl:
   # resources: {}
 
 initFs:
-  enabeld: true
+  enabled: true
   # image: busybox:1.32
   securityContext:
     privileged: true

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -174,6 +174,7 @@ initSysctl:
 
 initFs:
   enabled: true
+  enabeld: true # deprecated, use "enabled" instead.
   # image: busybox:1.32
   securityContext:
     privileged: true


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [X] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [X] Bump the Version number of the respected chart

Fixes spelling error in the App Statefulset for enabling or disabling the initFs initContainer.