### PR TITLE
Secure admin password in k8s secret

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.4]
+* secure admin password in k8s secret
+
 ## [1.0.3]
 * changed description of dependency postgresql chart
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.3
+version: 1.0.4
 appVersion: 9.3.0
 keywords:
   - coverage
@@ -28,6 +28,8 @@ annotations:
       description: "changed links to get a better overview of sources"
     - kind: changed
       description: "changed description of dependency postgresql chart"
+    - kind: changed
+      description: "secure admin password in k8s secret"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -43,7 +43,18 @@ spec:
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password
         image: {{ default "curlimages/curl:latest" .Values.curlContainerImage }}
-        command: ["sh", "-c", 'until curl -v --connect-timeout 100 {{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/system/status | grep -w UP; do sleep 10; done; curl -v --connect-timeout 100 -u admin:{{ default "admin" .Values.account.currentAdminPassword }} -X POST "{{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/users/change_password?login=admin&previousPassword={{ .Values.account.currentAdminPassword | default "admin" | urlquery }}&password={{ .Values.account.adminPassword | default "admin" | urlquery }}"']
+        command: ["sh", "-c", 'until curl -v --connect-timeout 100 {{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/system/status | grep -w UP; do sleep 10; done; curl -v --connect-timeout 100 -u admin:$CURRENT_ADMIN_PASSWORD -X POST "{{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/users/change_password?login=admin&previousPassword=$CURRENT_ADMIN_PASSWORD&password=$ADMIN_PASSWORD"']
+        env:
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sonarqube.fullname" . }}-admin-password
+              key: password
+        - name: CURRENT_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sonarqube.fullname" . }}-admin-password
+              key: currentPassword
         resources:
 {{ toYaml (default .Values.resources .Values.account.resources) | indent 10 }}
 {{- end }}

--- a/charts/sonarqube-dce/templates/secret.yaml
+++ b/charts/sonarqube-dce/templates/secret.yaml
@@ -77,5 +77,23 @@ metadata:
 type: Opaque
 data:
   SONAR_CLUSTER_SEARCH_PASSWORD: {{ .Values.searchNodes.searchAuthentication.userPassword | b64enc | quote }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
+---
+{{- if .Values.account }}
+{{- if .Values.account.adminPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sonarqube.fullname" . }}-admin-password
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+stringData:
+  password: {{ .Values.account.adminPassword | urlquery | quote }}
+  currentPassword: {{ default "admin" .Values.account.currentAdminPassword | urlquery | quote }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.5]
+* secure admin password in k8s secret
+
 ## [2.0.4]
 * no longer automount service account token
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 2.0.4
+version: 2.0.5
 appVersion: 9.3.0
 keywords:
   - coverage
@@ -32,6 +32,8 @@ annotations:
       description: "changed description of dependency postgresql chart"
     - kind: changed
       description: "no longer automount service account token"
+    - kind: changed
+      description: "secure admin password in k8s secret"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -47,7 +47,18 @@ spec:
         securityContext:
 {{ toYaml $securityContext | indent 12 }}
         {{- end }}
-        command: ["sh", "-c", 'until curl -v --connect-timeout 100 {{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/system/status | grep -w UP; do sleep 10; done; curl -v --connect-timeout 100 -u admin:{{ default "admin" .Values.account.currentAdminPassword }} -X POST "{{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/users/change_password?login=admin&previousPassword={{ .Values.account.currentAdminPassword | default "admin" | urlquery }}&password={{ .Values.account.adminPassword | default "admin" | urlquery }}"']
+        command: ["sh", "-c", 'until curl -v --connect-timeout 100 {{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/system/status | grep -w UP; do sleep 10; done; curl -v --connect-timeout 100 -u admin:$CURRENT_ADMIN_PASSWORD -X POST "{{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}{{ default "/" .Values.account.sonarWebContext }}api/users/change_password?login=admin&previousPassword=$CURRENT_ADMIN_PASSWORD&password=$ADMIN_PASSWORD"']
+        env:
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sonarqube.fullname" . }}-admin-password
+              key: password
+        - name: CURRENT_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sonarqube.fullname" . }}-admin-password
+              key: currentPassword
         resources:
 {{ toYaml (default .Values.resources .Values.account.resources) | indent 10 }}
 {{- end }}

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -26,3 +26,21 @@ metadata:
 type: Opaque
 data:
   SONAR_WEB_SYSTEMPASSCODE: {{ .Values.monitoringPasscode | b64enc | quote }}
+---
+{{- if .Values.account }}
+{{- if .Values.account.adminPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sonarqube.fullname" . }}-admin-password
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+stringData:
+  password: {{ .Values.account.adminPassword | urlquery | quote }}
+  currentPassword: {{ default "admin" .Values.account.currentAdminPassword | urlquery | quote }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

----
While the change admin password hook is very handy, we noticed it exposes the admin password in the deploy logs. For security reasons, we need this password to be stored as a k8s secret.

