### PR TITLE
Specify service account name in change admin password hook

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.5]
+* Specify service account name in change admin password hook
+
 ## [1.0.4]
 * secure admin password in k8s secret
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.4
+version: 1.0.5
 appVersion: 9.3.0
 keywords:
   - coverage
@@ -30,6 +30,8 @@ annotations:
       description: "changed description of dependency postgresql chart"
     - kind: changed
       description: "secure admin password in k8s secret"
+    - kind: changed
+      description: "Specify service account name in change admin password hook"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -40,6 +40,7 @@ spec:
 {{ toYaml .Values.ApplicationNodes.image.pullSecrets | indent 8 }}
         {{- end }}
       {{- end }}
+      serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password
         image: {{ default "curlimages/curl:latest" .Values.curlContainerImage }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.6]
+* Specify service account name in change admin password hook
+
 ## [2.0.5]
 * secure admin password in k8s secret
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 2.0.5
+version: 2.0.6
 appVersion: 9.3.0
 keywords:
   - coverage
@@ -34,6 +34,8 @@ annotations:
       description: "no longer automount service account token"
     - kind: changed
       description: "secure admin password in k8s secret"
+    - kind: changed
+      description: "Specify service account name in change admin password hook"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -40,6 +40,7 @@ spec:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
         {{- end }}
       {{- end }}
+      serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password
         image: {{ default "curlimages/curl:latest" .Values.curlContainerImage }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

----
We noticed in our gatekeeper constraints that the admin password hook was using the default service account even though we specified a service account to be used. This change just uses that specified service account.