### PR TITLE
Specify location of .netrc file if netrcCreds are provided for plugin installation.

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.7]
+* Specify location of .netrc file when downloading plugins that require auth
+
 ## [1.0.6]
 * Fixed properties scope for app deployment and search sts
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.6
+version: 1.0.7
 appVersion: 9.3.0
 keywords:
   - coverage
@@ -34,6 +34,8 @@ annotations:
       description: "Specify service account name in change admin password hook"
     - kind: fixed
       description: "Fixed properties scope for app deployment and search sts"
+    - kind: fixed
+      description: "Specify location of .netrc file when downloading plugins that require auth"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app

--- a/charts/sonarqube-dce/templates/install-plugins.yaml
+++ b/charts/sonarqube-dce/templates/install-plugins.yaml
@@ -13,7 +13,7 @@ data:
       [ -e {{ .Values.sonarqubeFolder }}/extensions/downloads/* ] && rm {{ .Values.sonarqubeFolder }}/extensions/downloads/*
       cd {{ .Values.sonarqubeFolder }}/extensions/downloads
       {{- range $index, $val := .Values.ApplicationNodes.plugins.install }}
-      curl {{ if $.Values.ApplicationNodes.plugins.noCheckCertificate }}--insecure{{ end }} -fsSLO {{ $val | quote }}
+      curl {{ if $.Values.ApplicationNodes.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.ApplicationNodes.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
       {{- end }}
     {{- end }}
     {{- if .Values.ApplicationNodes.plugins.lib }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.7]
+* Specify location of .netrc file when downloading plugins that require auth
+
 ## [2.0.6]
 * Specify service account name in change admin password hook
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 2.0.6
+version: 2.0.7
 appVersion: 9.3.0
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -36,6 +36,8 @@ annotations:
       description: "secure admin password in k8s secret"
     - kind: changed
       description: "Specify service account name in change admin password hook"
+    - kind: fixed
+      description: "Specify location of .netrc file when downloading plugins that require auth"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -13,7 +13,7 @@ data:
       [ -e {{ .Values.sonarqubeFolder }}/extensions/downloads/* ] && rm {{ .Values.sonarqubeFolder }}/extensions/downloads/*
       cd {{ .Values.sonarqubeFolder }}/extensions/downloads
       {{- range $index, $val := .Values.plugins.install }}
-      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} -fsSLO {{ $val | quote }}
+      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
       {{- end }}
     {{- end }}
     {{- if .Values.plugins.lib }}


### PR DESCRIPTION
**Description**
There is currently an issue where if a user needs to provide credentials to a server in order to retrieve a plugin for installation, the .netrc file that is created by the chart (using the secret specified at `.Values.plugins.netrcCreds`) is not used. This causes issues in scenarios where users want to install internal plugins that have been published to private artifact registries that don't allow anonymous access.

Normally we would just need to specify the `'-n'` flag to curl to tell it to use the .netrc file in the users home directory, but as we have mounted the .netrc secret at the root directory (see [here](https://github.com/SonarSource/helm-chart-sonarqube/blob/master/charts/sonarqube/templates/deployment.yaml#L127)), we have to specify the `'--netrc-file'` flag to tell it to retrieve the file from the /root directory.

**Changes**

- Added conditional rendering of the `--netrc-file` flag (driven by the value provided in `.Values.plugins.netrcCreds`), and have defaulted the value of it to /root/.netrc. I've not made the location for this configurable, as the mount location for the secret mentioned above is also not configurable, so its not really expected to change.