### PR TITLE
[skip ci] handover

### DIFF
--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -15,8 +15,8 @@ sources:
   - https://github.com/SonarSource/sonarqube
 kubeVersion: '>= 1.19.0-0'
 maintainers:
-  - name: tobias-trabelsi-sonarsource
-    email: tobias.trabelsi+helm@sonarsource.com
+  - name: leo-geoffroy-sonarsource
+    email: leo.geoffroy+helm@sonarsource.com
 annotations:
   artifacthub.io/links: |
     - name: support

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -14,8 +14,8 @@ sources:
   - https://github.com/SonarSource/docker-sonarqube
 kubeVersion: ">= 1.19.0-0"
 maintainers:
-  - name: tobias-trabelsi-sonarsource
-    email: tobias.trabelsi+helm@sonarsource.com
+  - name: leo-geoffroy-sonarsource
+    email: leo.geoffroy+helm@sonarsource.com
 annotations:
   artifacthub.io/changes: |
     - kind: changed

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -15,8 +15,8 @@ sources:
   - https://github.com/SonarSource/sonarqube
 kubeVersion: '>= 1.19.0-0'
 maintainers:
-  - name: tobias-trabelsi-sonarsource
-    email: tobias.trabelsi+helm@sonarsource.com
+  - name: leo-geoffroy-sonarsource
+    email: leo.geoffroy+helm@sonarsource.com
 annotations:
   artifacthub.io/links: |
     - name: support


### PR DESCRIPTION
the "skip ci" needs to be squashed away during merge, but i think bumping the chart version number is not necessary here 