### PR TITLE
add support ingressClassName

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.27]
+* Adding support for the ingressClassName attribute
+
 ## [1.0.26]
 * updated SonarQube LTS to 8.9.8
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.26
+version: 1.0.27
 appVersion: 8.9.8
 keywords:
   - coverage

--- a/charts/sonarqube-lts/templates/ingress.yaml
+++ b/charts/sonarqube-lts/templates/ingress.yaml
@@ -27,6 +27,7 @@ metadata:
 {{- end }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ printf "%s" .name }}

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -63,6 +63,8 @@ service:
 ingress:
   enabled: false
   # Used to create an Ingress record.
+  ingressClassName: nginx
+  # Name of the ingress class that loads this endpoint
   hosts:
     - name: sonarqube.your-org.com
       # Different clouds or configurations might need /* as the default path


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [X] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [X] Bump the Version number of the respected chart



Hello, I'm adding support for the ingressClassName attribute.

This configuration is available for current versions of Ingress.

<https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/basic-configuration/#new-features-available-in-kubernetes-118-and-above>

Thank you for your attention