### PR TITLE
Add SONAR_WEB_CONTEXT example in comments

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2.0.2]
+* Add documentation to setup web context via environment variable
+
 ## [2.0.1]
 * Fix for issue (#215)[https://github.com/SonarSource/helm-chart-sonarqube/issues/215], adding tolerations and affinity to change password hooks
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 2.0.1
+version: 2.0.2
 appVersion: 9.4.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -14,6 +14,9 @@ searchNodes:
   ## Environment variables to attach to the search pods
   ##
   # env:
+  #   # If you use a different ingress path from /, you have to add it here as the value of SONAR_WEB_CONTEXT
+  #   - name: SONAR_WEB_CONTEXT
+  #     value: /sonarqube
   #   - name: VARIABLE
   #     value: my-value
 

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.0.2]
+* Add documentation to setup web context via environment variable
+
 ## [3.0.1]
 * Fix for issue (#215)[https://github.com/SonarSource/helm-chart-sonarqube/issues/215], adding tolerations and affinity to change password hooks
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 3.0.1
+version: 3.0.2
 appVersion: 9.4.0
 keywords:
   - coverage

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -292,6 +292,9 @@ monitoringPasscode: "define_it"
 ## Environment variables to attach to the pods
 ##
 # env:
+#   # If you use a different ingress path from /, you have to add it here as the value of SONAR_WEB_CONTEXT
+#   - name: SONAR_WEB_CONTEXT
+#     value: /sonarqube
 #   - name: VARIABLE
 #     value: my-value
 


### PR DESCRIPTION
Without setting SONAR_WEB_CONTEXT, using a non-default path doesn't work.

This fixes https://github.com/SonarSource/helm-chart-sonarqube/issues/205

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [ ] Bump the Version number of the respected chart

This is not a change in the chart itself, but in the example config.