### PR TITLE
Docs: add ingress annotations in README

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.0.1]
+* Add documentation for ingress annotations
+
 ## [3.0.0]
 * updated SonarQube to 9.5.0
 
@@ -132,4 +135,3 @@ All changes to this chart will be documented in this file.
 ## [0.0.1]
 * separated search and app configuration
 * added new search service
-

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 3.0.0
+version: 3.0.1
 appVersion: 9.5.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -276,6 +276,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ingress.hosts[0].servicePort` | Optional field to override the default servicePort of a path | `None` |
 | `ingress.tls` | Ingress secrets for TLS certificates | `[]` |
 | `ingress.ingressClassName` | Optional field to configure ingress class name | `None` |
+| `ingress.annotations` | Optional field to add extra annotations to the ingress | `None` |
 
 ### InitContainers
 

--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.28]
+* Add documentation for ingress annotations
+
 ## [1.0.27]
 * Fix repository issues with bitnami/postgres
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.27
+version: 1.0.28
 appVersion: 8.9.8
 keywords:
   - coverage

--- a/charts/sonarqube-lts/README.md
+++ b/charts/sonarqube-lts/README.md
@@ -145,6 +145,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ingress.hosts[0].serviceName`                           | Optional field to override the default serviceName of a path                                                              | None                            |
 | `ingress.hosts[0].servicePort`                           | Optional field to override the default servicePort of a path                                                              | None                            |
 | `ingress.tls`                                            | Ingress secrets for TLS certificates                                                                                      | `[]`                            |
+| `ingress.annotations` | Optional field to add extra annotations to the ingress | `None` |
 | `affinity`                                               | Node / Pod affinities                                                                                                     | `{}`                            |
 | `tolerations`                                            | List of node taints to tolerate                                                                                           | `[]`                            |
 | `nodeSelector`                                           | Node labels for pod assignment                                                                                            | `{}`                            |

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.1]
+* Add documentation for ingress annotations
+
 ## [4.0.0]
 * updated SonarQube to 9.5.0
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 4.0.0
+version: 4.0.1
 appVersion: 9.5.0
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -195,6 +195,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ingress.hosts[0].servicePort` | Optional field to override the default servicePort of a path | `None` |
 | `ingress.tls` | Ingress secrets for TLS certificates | `[]` |
 | `ingress.ingressClassName` | Optional field to configure ingress class name | `None` |
+| `ingress.annotations` | Optional field to add extra annotations to the ingress | `None` |
 
 ### Route
 


### PR DESCRIPTION
This PR simply adds to the documentation that it's possible to provide extra annotations for the ingress resource.
`charts/sonarqube/templates/ingress.yaml` already reads the `ingress.annotations` field, it's just that the README didn't mention it.
The annotations can be important for use cases that include the AWS Application Load Balancer Controller.

Example use case:
```yaml
---
ingress:
  annotations:
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
```

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart
