### PR TITLE
Fix Openshift route name

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [3.0.5]
+* Fix issue with Openshift route name to use use fullname instead of name
+
 ## [3.0.4]
 * Fix issue with additional network policy
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 3.0.4
+version: 3.0.5
 appVersion: 9.4.0
 keywords:
   - coverage

--- a/charts/sonarqube/templates/route.yaml
+++ b/charts/sonarqube/templates/route.yaml
@@ -3,7 +3,7 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: {{ template "sonarqube.name" . }}
+  name: {{ template "sonarqube.fullname" . }}
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
Hi,

Name of the Openshift/OKD should use fullname instead of name like other resources.

- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

Thanks!