### PR TITLE
Add support for labels and route annotations like ingress

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.3]
+* Add support for Openshift Route labels and annotations
+
 ## [4.0.2]
 * Fix issue with Openshift route name to use use fullname instead of name
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 4.0.2
+version: 4.0.3
 appVersion: 9.5.0
 
 keywords:

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -204,6 +204,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `route.enabled` | Flag to enable OpenShift Route | `false` |
 | `route.host` | Host of the route | `""` |
 | `route.tls.termination` | TLS termination type. Currently supported values are `edge` and `passthrough` | `edge` |
+| `route.annotations` | Optional field to add extra annotations to the route | `None` |
+| `route.labels` | Route additional labels | `{}` |
 
 ### Probes
 

--- a/charts/sonarqube/templates/route.yaml
+++ b/charts/sonarqube/templates/route.yaml
@@ -9,6 +9,15 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.route.labels }}
+{{ .Values.route.labels | toYaml | trimSuffix "\n"| indent 4 -}}
+{{- end}}
+{{- if .Values.route.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.route.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}
 spec:
 {{- if .Values.route.host }}
   host: {{ .Values.route.host }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -116,6 +116,15 @@ route:
   tls:
     termination: edge
 
+  annotations: {}
+  # See Openshift/OKD route annotation
+  # https://docs.openshift.com/container-platform/4.10/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration
+  # haproxy.router.openshift.io/timeout: 1m
+
+  # Additional labels for Route manifest file
+  # labels:
+  #  external: 'true'
+
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}


### PR DESCRIPTION
Hi (again),

Labels and annotations are supported for Ingress resource but sadly not for the Openshift/OKD Route.

This PR add support for adding extra labels and annotations like the Ingress resource.

Annotations are required to configure Route behavior like timeout : https://docs.openshift.com/container-platform/4.10/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

Regards,