### PR TITLE
feat(networkpolicies): use the prometheusNamespace value

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.3.0]
+* Use the networkPolicy.prometheusNamespace value for the network policy namespace selector
+* Uncomment default value in values.yaml for backwards compatibility
+
 ## [5.2.0]
 * Add support for monitoringPasscode passed as a secret and removal of livenessprobe httpheader defined in clear text
 
@@ -130,7 +134,7 @@ All changes to this chart will be documented in this file.
 * Use liveness endpoint instead of helth endpoint for liveness probe
 
 ## [1.1.9]
-* fixed wrong scc user reference if name was explicitly set 
+* fixed wrong scc user reference if name was explicitly set
 
 ## [1.1.8]
 * fixed serviceaccount logic

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 5.2.0
+version: 5.3.0
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              networking/namespace: monitoring
+              networking/namespace: {{ .Values.networkPolicy.prometheusNamespace }}
       ports:
         - port: {{ .Values.prometheusExporter.ceBeanPort }}
           protocol: TCP

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -65,7 +65,7 @@ networkPolicy:
   enabled: false
 
   # If you plan on using the jmx exporter, you need to define where the traffic is coming from
-  # prometheusNamespace: "monitoring"
+  prometheusNamespace: "monitoring"
 
   # If you are using a external database and enable network Policies to be created
   # you will need to explicitly allow egress traffic to your database


### PR DESCRIPTION
For the prometheusExporter namespace selector, use the `networkPolicy.prometheusNamespace` value instead of using a fixed value.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart