### PR TITLE
DOCKER-77 Add documentation for ingress tls in helm charts

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.1]
+* Add documentation for ingress tls
+
 ## [4.0.0]
 * Updated SonarQube to 9.6.0
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 4.0.0
+version: 4.0.1
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -311,7 +311,7 @@ ingress:
   #  traffic-type: external
   #  traffic-type: internal
   tls: []
-  # Secrets must be manually created in the namespace.
+  # Secrets must be manually created in the namespace. To generate a self-signed certificate (and private key) and then create the secret in the cluster please refer to official documentation available at https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets
   # - secretName: chart-example-tls
   #   hosts:
   #     - chart-example.local

--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.30]
+* Add documentation for ingress tls
+
 ## [1.0.29]
 * updated SonarQube LTS to 8.9.9
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.29
+version: 1.0.30
 appVersion: 8.9.9
 keywords:
   - coverage

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -81,7 +81,7 @@ ingress:
   #  traffic-type: external
   #  traffic-type: internal
   tls: []
-  # Secrets must be manually created in the namespace.
+  # Secrets must be manually created in the namespace. To generate a self-signed certificate (and private key) and then create the secret in the cluster please refer to official documentation available at https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets
   # - secretName: chart-example-tls
   #   hosts:
   #     - chart-example.local

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.0.1]
+* Add documentation for ingress tls
+
 ## [5.0.0]
 * Updated SonarQube to 9.6.0
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 5.0.0
+version: 5.0.1
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -103,7 +103,7 @@ ingress:
   #  traffic-type: external
   #  traffic-type: internal
   tls: []
-  # Secrets must be manually created in the namespace.
+  # Secrets must be manually created in the namespace. To generate a self-signed certificate (and private key) and then create the secret in the cluster please refer to official documentation available at https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets
   # - secretName: chart-example-tls
   #   hosts:
   #     - chart-example.local


### PR DESCRIPTION
I add a reference about generating self-signed certificates (and private keys) and registering the corresponding secret in the cluster.