### PR TITLE
DOCKER-63 Set the number of allowed replicas in sonarqube and sonarqube-lts charts

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.0.2]
+* Set the number of allowed replicas to 0 and 1
+
 ## [5.0.1]
 * Add documentation for ingress tls
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 5.0.1
+version: 5.0.2
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -118,7 +118,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `deploymentType` | Deployment Type (supported values are `StatefulSet` or `Deployment`) | `StatefulSet` |
-| `replicaCount`   | Number of replicas deployed  | `1` |
+| `replicaCount`   | Number of replicas deployed (supported values are 0 and 1)  | `1` |
 | `deploymentStrategy` | Deployment strategy | `{}` |
 | `priorityClassName` | Schedule pods on priority (e.g. `high-priority`) | `None` |
 | `schedulerName` | Kubernetes scheduler name | `None` |

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: {{ template "sonarqube.fullname" . }}
     app.kubernetes.io/version: {{ tpl .Values.image.tag . | quote }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   serviceName: {{ template "sonarqube.fullname" . }}
   selector:
     matchLabels:

--- a/charts/sonarqube/values.schema.json
+++ b/charts/sonarqube/values.schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "required": [
+        "replicaCount"
+    ],
+    "properties": {
+        "replicaCount": {
+            "type": "integer",
+            "enum": [0, 1]
+        }
+    }
+ }

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -2,13 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# If the deployment Type is set to Deployment sonarqube is deployed as a replica set.
 deploymentType: "StatefulSet"
 
-# If the deployment Type is set to Deployment sonarqube is deployed as a replica set
-# There should not be more than 1 sonarqube instance connected to the same database
+# There should not be more than 1 sonarqube instance connected to the same database. Please set this value to 1 or 0 (in case you need to scale down programmatically).
 replicaCount: 1
 
- # This will use the default deployment strategy unless it is overriden
+# This will use the default deployment strategy unless it is overriden
 deploymentStrategy: {}
 # Uncomment this to scheduler pods on priority
 # priorityClassName: "high-priority"


### PR DESCRIPTION
We only support 1 replica for deployment and statefulset types in sonarqube and sonarqube-lts charts. Therefore, we set 0 and 1 as allowed values for `replicas`, having 1 as the default value.