### PR TITLE
DOCKER 79 Add documentation in the DCE chart on how to generate the jwt secret

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.2]
+* Add documentation for ApplicationNodes.jwtSecret
+
 ## [4.0.1]
 * Add documentation for ingress tls
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 4.0.1
+version: 4.0.2
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -16,7 +16,12 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Installing the chart
 
-Please ensure that the value for `ApplicationNodes.jwtSecret` is set with something like `echo -n "your_secret" | openssl dgst -sha256 -hmac "your_key" -binary | base64` and persist this in your `values.yaml`.
+> **_NOTE:_**  Please refer to [the official page](https://docs.sonarqube.org/latest/setup/sonarqube-cluster-on-kubernetes/) for further information on how to install and tune the helm chart specifications.
+
+Prior to installing the chart, please ensure that the `ApplicationNodes.jwtSecret` value is set properly with a HS256 key encoded with base64. In the following, an example on how to generate this key on a Unix system:
+```bash
+echo -n "your_secret" | openssl dgst -sha256 -hmac "your_key" -binary | base64
+```
 
 To install the chart:
 
@@ -209,7 +214,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ApplicationNodes.plugins.securityContext` | Security context for the container to download plugins | see `values.yaml |
 | `ApplicationNodes.jvmOpts` | Values to add to SONARQUBE_WEB_JVM_OPTS | `""` |
 | `ApplicationNodes.jvmCeOpts` | Values to add to SONAR_CE_JAVAOPTS | `""` |
-| `ApplicationNodes.jwtSecret` | A HS256 key encoded with base64 | `""` |
+| `ApplicationNodes.jwtSecret` | A HS256 key encoded with base64 (*This value must be set before installing the chart, see [the documentation](https://docs.sonarqube.org/latest/setup/sonarqube-cluster-on-kubernetes/)*) | `""` |
 | `ApplicationNodes.existingJwtSecret` | secret that contains the `jwtSecret` | `nil` |
 | `ApplicationNodes.resources.requests.memory` | memory request for app Nodes | `2Gi` |
 | `ApplicationNodes.resources.requests.cpu` | cpu request for app Nodes | `400m` |

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -242,7 +242,7 @@ ApplicationNodes:
   ## Values to add to SONAR_CE_JAVAOPTS
   jvmCeOpts: ""
 
-  # SONAR_AUTH_JWTBASE64HS256SECRET
+  # Set this value with a HS256 key encoded with base64. You can generate a key using the following command on a Unix system: echo -n "your_secret" | openssl dgst -sha256 -hmac "your_key" -binary | base64
   jwtSecret: ""
   # can use existing secret with SONAR_AUTH_JWTBASE64HS256SECRET as key
   # existingJwtSecret: ""


### PR DESCRIPTION
Our values.yml and readme.md lack consistent documentation about the jwt secret. We revise the existing guidelines and specify more where needed.