### PR TITLE
DOCKER-78 fix wrong conditions for sonarProperties and sonarSecretProperties and documentation update

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.4]
+* Remove unreachable condition and fix the right values for sonarProperties and sonarSecretProperties
+
 ## [4.0.3]
 * Bump apiVersion to v2
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 4.0.3
+version: 4.0.4
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -166,8 +166,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ApplicationNodes.image.pullSecret` | (DEPRECATED) app imagePullSecret to use for private repository | `nil` |
 | `ApplicationNodes.image.pullSecrets` | app imagePullSecrets to use for private repository | `nil` |
 | `ApplicationNodes.env` | Environment variables to attach to the app pods | `nil` |
-| `ApplicationNodes.sonarProperties` | Custom `sonar.properties` file for App Nodes | `None` |
-| `ApplicationNodes.sonarSecretProperties` | Additional `sonar.properties` file for App Nodes to load from a secret | `None` |
+| `ApplicationNodes.sonarProperties` | Custom `sonar.properties` key-value pairs for App Nodes (e.g., "ApplicationNodes.sonarProperties.sonar.forceAuthentication=true") | `None` |
+| `ApplicationNodes.sonarSecretProperties` | Additional `sonar.properties` key-value pairs for App Nodes to load from a secret | `None` |
 | `ApplicationNodes.sonarSecretKey` | Name of existing secret used for settings encryption | `None` |
 | `ApplicationNodes.replicaCount` | Replica count of the app Nodes | `2` |
 | `ApplicationNodes.podDistributionBudget` | PodDisctributionBudget for the App Nodes | `minAvailable: "50%"` |

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -315,14 +315,10 @@ spec:
 {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+            {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
               subPath: sonar.properties
               name: concat-dir
-            {{- else if .Values.sonarProperties }}
-            - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
-              subPath: sonar.properties
-              name: config
             {{- end }}
             {{- if .Values.sonarSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.0.4]
+* Add documentation for sonarProperties and sonarSecretProperties
+
 ## [5.0.3]
 * Bump apiVersion to v2
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 5.0.3
+version: 5.0.4
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -287,8 +287,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `jvmOpts` | Values to add to SONARQUBE_WEB_JVM_OPTS | `""` |
 | `jvmCeOpts` | Values to add to SONAR_CE_JAVAOPTS | `""` |
 | `sonarqubeFolder` | Directory name of Sonarqube | `/opt/sonarqube` |
-| `sonarProperties` | Custom `sonar.properties` file | `None` |
-| `sonarSecretProperties` | Additional `sonar.properties` file to load from a secret | `None` |
+| `sonarProperties` | Custom `sonar.properties` key-value pairs (e.g., "sonarProperties.sonar.forceAuthentication=true") | `None` |
+| `sonarSecretProperties` | Additional `sonar.properties` key-value pairs to load from a secret | `None` |
 | `sonarSecretKey` | Name of existing secret used for settings encryption | `None` |
 | `monitoringPasscode` | Value for sonar.web.systemPasscode. needed for LivenessProbes | `define_it` |
 | `extraContainers` | Array of extra containers to run alongside the `sonarqube` container (aka. Sidecars) | `[]` |


### PR DESCRIPTION
Based on my current understanding, we have 4 ways to specify these properties:

- Rely on the default `sonar.properties` already available inside the containers
- Mount your own `sonar.properties`
- Mount your own `secret.properties` (from a secret spec)
- A combination of 3 and 2 

In the DCE chart, I think that we cover correctly only case 1. We could probably refactor the code in this way to achieve the other cases.