### PR TITLE
DOCKER-64 bump apiVersion to v2 and refactor deprecated configs

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.3]
+* Bump apiVersion to v2
+
 ## [4.0.2]
 * Add documentation for ApplicationNodes.jwtSecret
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 4.0.2
+type: application
+version: 4.0.3
 appVersion: 9.6.0
 keywords:
   - coverage
@@ -32,3 +33,12 @@ annotations:
       image: sonarqube:9.6.0-datacenter-app
     - name: sonarqube-search
       image: sonarqube:9.6.0-datacenter-search
+dependencies:
+  - name: postgresql
+    version: 10.15.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: ingress-nginx
+    version: 4.0.13
+    repository: https://kubernetes.github.io/ingress-nginx
+    condition: nginx.enabled

--- a/charts/sonarqube-dce/requirements.yaml
+++ b/charts/sonarqube-dce/requirements.yaml
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  version: 10.15.0
-  repository: https://charts.bitnami.com/bitnami
-  condition: postgresql.enabled
-- name: ingress-nginx
-  version: 4.0.13
-  repository: https://kubernetes.github.io/ingress-nginx
-  condition: nginx.enabled

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.0.3]
+* Bump apiVersion to v2
+
 ## [5.0.2]
 * Set the number of allowed replicas to 0 and 1
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 5.0.2
+type: application
+version: 5.0.3
 appVersion: 9.6.0
 keywords:
   - coverage
@@ -30,3 +31,12 @@ annotations:
   artifacthub.io/images: |
     - name: sonarqube
       image: sonarqube:9.6.0-community
+dependencies:
+  - name: postgresql
+    version: 10.15.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: ingress-nginx
+    version: 4.0.13
+    repository: https://kubernetes.github.io/ingress-nginx
+    condition: nginx.enabled

--- a/charts/sonarqube/requirements.yaml
+++ b/charts/sonarqube/requirements.yaml
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  version: 10.15.0
-  repository: https://charts.bitnami.com/bitnami
-  condition: postgresql.enabled
-- name: ingress-nginx
-  version: 4.0.13
-  repository: https://kubernetes.github.io/ingress-nginx
-  condition: nginx.enabled


### PR DESCRIPTION
We have to update our `apiVersion` to `v2`, as this is the recommended API used by Helm 3 (which is the version that we support).

We checked the official [migration guidelines](https://helm.sh/docs/topics/v2_v3_migration/) and make our chart complaint  with the following changes in `apiVersion=v2`:
- "Dynamically linked chart dependencies moved to Chart.yaml (requirements.yaml removed and requirements --> dependencies)"
- "Charts have a type metadata field to define the chart to be of an application or library chart. It is application by default which means it is renderable and installable"
