### PR TITLE
DOCKER-80 add the possibility to use an existing secret for change admin password hook

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.5]
+* Add the possibility of using a secret for customizing the admin password
+
 ## [4.0.4]
 * Remove unreachable condition and fix the right values for sonarProperties and sonarSecretProperties
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 4.0.4
+version: 4.0.5
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -396,6 +396,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `logging.jsonOutput` | Enable/Disable logging in JSON format | `false` |
 | `account.adminPassword` | Custom new admin password | `admin` |
 | `account.currentAdminPassword` | Current admin password | `admin` |
+| `account.adminPasswordSecretName` | Secret containing `password` (custom password) and `currentPassword` (current password) keys for admin | `None` |
 | `account.resources.requests.memory` | Memory request for Admin hook | `128Mi` |
 | `account.resources.requests.cpu` | CPU request for Admin hook | `100m` |
 | `account.resources.limits.memory` | Memory limit for Admin hook | `128Mi` |

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -1,5 +1,5 @@
 {{- if .Values.account }}
-{{- if .Values.account.adminPassword }}
+{{- if or .Values.account.adminPassword .Values.account.adminPasswordSecretName}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -57,12 +57,20 @@ spec:
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.account.adminPassword }}
               name: {{ template "sonarqube.fullname" . }}-admin-password
+              {{- else }}
+              name: {{ .Values.account.adminPasswordSecretName }}
+              {{- end }}
               key: password
         - name: CURRENT_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.account.adminPassword }}
               name: {{ template "sonarqube.fullname" . }}-admin-password
+              {{- else }}
+              name: {{ .Values.account.adminPasswordSecretName }}
+              {{- end }}
               key: currentPassword
         resources:
 {{ toYaml (default .Values.resources .Values.account.resources) | indent 10 }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -549,8 +549,12 @@ extraConfig:
   configmaps: []
 
 # account:
+# The values can be set to define the current and the (new) custom admin passwords at the startup (the username will remain "admin")
 #   adminPassword: admin
 #   currentAdminPassword: admin
+# The above values can be also provided by a secret that contains "password" and "currentPassword" as keys. You can generate such a secret in your cluster
+# using "kubectl create secret generic admin-password-secret-name --from-literal=password=admin --from-literal=currentPassword=admin"
+#   adminPasswordSecretName: ""
 #   resources:
 #     limits:
 #       cpu: 100m

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.0.5]
+* Add the possibility of using a secret for customizing the admin password
+
 ## [5.0.4]
 * Add documentation for sonarProperties and sonarSecretProperties
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 5.0.4
+version: 5.0.5
 appVersion: 9.6.0
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -384,6 +384,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | --------- | ----------- | ------- |
 | `account.adminPassword` | Custom admin password | `admin` |
 | `account.currentAdminPassword` | Current admin password | `admin` |
+| `account.adminPasswordSecretName` | Secret containing `password` (custom password) and `currentPassword` (current password) keys for admin | `None` |
 | `account.resources.requests.memory` | Memory request for Admin hook | `128Mi` |
 | `account.resources.requests.cpu` | CPU request for Admin hook | `100m` |
 | `account.resources.limits.memory` | Memory limit for Admin hook | `128Mi` |

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -1,5 +1,5 @@
 {{- if .Values.account }}
-{{- if .Values.account.adminPassword }}
+{{- if or .Values.account.adminPassword .Values.account.adminPasswordSecretName}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -61,12 +61,20 @@ spec:
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.account.adminPassword }}
               name: {{ template "sonarqube.fullname" . }}-admin-password
+              {{- else }}
+              name: {{ .Values.account.adminPasswordSecretName }}
+              {{- end }}
               key: password
         - name: CURRENT_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.account.adminPassword }}
               name: {{ template "sonarqube.fullname" . }}-admin-password
+              {{- else }}
+              name: {{ .Values.account.adminPasswordSecretName }}
+              {{- end }}
               key: currentPassword
         resources:
 {{ toYaml (default .Values.resources .Values.account.resources) | indent 10 }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -498,8 +498,12 @@ extraConfig:
   configmaps: []
 
 # account:
+# The values can be set to define the current and the (new) custom admin passwords at the startup (the username will remain "admin")
 #   adminPassword: admin
 #   currentAdminPassword: admin
+# The above values can be also provided by a secret that contains "password" and "currentPassword" as keys. You can generate such a secret in your cluster
+# using "kubectl create secret generic admin-password-secret-name --from-literal=password=admin --from-literal=currentPassword=admin"
+#   adminPasswordSecretName: ""
 #   securityContext: {}
 #   resources:
 #     limits:


### PR DESCRIPTION
Currently, users cannot define their own secret in the cluster for setting the current and custom passwords at the startup. This PR aims at providing our standard and dce chart users with this possibility.