### PR TITLE
DOCKER-81 Add support for monitoringPasscode passed as a secret and removal of in-clear-text livenessprobe httpheader

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.2.0]
+* Add support for monitoringPasscode passed as a secret and removal of livenessprobe httpheader defined in clear text
+
 ## [4.1.0]
 * Add the possibility of using a secret for customizing the admin password
 * Remove unreachable condition and fix the right values for sonarProperties and sonarSecretProperties

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 4.1.0
+version: 4.2.0
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -325,7 +325,9 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `sonarqubeFolder` | Directory name of Sonarqube | `/opt/sonarqube` |
-| `monitoringPasscode` | Value for sonar.web.systemPasscode. needed for LivenessProbes | `define_it` |
+| `monitoringPasscode` | Value for sonar.web.systemPasscode needed for LivenessProbes (encoded to Base64 format) | `define_it` |
+| `monitoringPasscodeSecretName` | Name of the secret where to load `monitoringPasscode` | `None` |
+| `monitoringPasscodeSecretKey` | Key of an existing secret containing `monitoringPasscode` | `None` |
 | `extraContainers` | Array of extra containers to run alongside the `sonarqube` container (aka. Sidecars) | `[]` |
 
 ### JDBC Overwrite

--- a/charts/sonarqube-dce/templates/secret.yaml
+++ b/charts/sonarqube-dce/templates/secret.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.monitoringPasscode}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,7 +12,7 @@ metadata:
 type: Opaque
 data:
   SONAR_WEB_SYSTEMPASSCODE: {{ .Values.monitoringPasscode | b64enc | quote }}
-
+{{- end }}
 ---
 {{- if not (or .Values.postgresql.enabled .Values.postgresql.existingSecret .Values.jdbcOverwrite.jdbcSecretName)}}
 apiVersion: v1

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -251,8 +251,13 @@ spec:
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
+                {{- if and .Values.monitoringPasscodeSecretName .Values.monitoringPasscodeSecretKey }}
+                  name: {{ .Values.monitoringPasscodeSecretName }}
+                  key: {{ .Values.monitoringPasscodeSecretKey }}
+                {{- else }}
                   name: {{ template "sonarqube.fullname" . }}-monitoring-passcode
                   key: SONAR_WEB_SYSTEMPASSCODE
+                {{- end }}
             {{ if .Values.searchNodes.searchAuthentication.enabled }}
             - name: SONAR_CLUSTER_SEARCH_PASSWORD
               valueFrom:
@@ -275,13 +280,14 @@ spec:
                 name: {{ . }}
 {{- end }}
           livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: {{ .Values.ApplicationNodes.livenessProbe.sonarWebContext }}api/system/liveness
-              port: http
-              httpHeaders:
-                - name: X-Sonar-Passcode
-                  value: {{ .Values.monitoringPasscode }}
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                host="$(hostname -i || echo '127.0.0.1')"
+                reply=$(wget -qO- --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" http://${host}:{{ .Values.service.internalPort }}{{ .Values.ApplicationNodes.livenessProbe.sonarWebContext }}api/system/liveness 2>&1)
+                if [ -z "$reply" ]; then exit 0; else exit 1; fi
             initialDelaySeconds: {{ .Values.ApplicationNodes.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.ApplicationNodes.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.ApplicationNodes.livenessProbe.failureThreshold }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -397,6 +397,9 @@ initFs:
 # a monitoring passcode needs to be defined in order to get reasonable probe results
 # not setting the monitoring passcode will result in a deployment that will never be ready
 monitoringPasscode: "define_it"
+# Alternatively, you can define the passcode loading it from an existing secret specifying the right key
+# monitoringPasscodeSecretName: "pass-secret-name"
+# monitoringPasscodeSecretKey: "pass-key"
 
 ## Environment variables to attach to the pods
 ##

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.2.0]
+* Add support for monitoringPasscode passed as a secret and removal of livenessprobe httpheader defined in clear text
+
 ## [5.1.0]
 * Bump apiVersion to v2
 * Set the number of allowed replicas to 0 and 1

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 5.1.0
+version: 5.2.0
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -290,7 +290,9 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `sonarProperties` | Custom `sonar.properties` key-value pairs (e.g., "sonarProperties.sonar.forceAuthentication=true") | `None` |
 | `sonarSecretProperties` | Additional `sonar.properties` key-value pairs to load from a secret | `None` |
 | `sonarSecretKey` | Name of existing secret used for settings encryption | `None` |
-| `monitoringPasscode` | Value for sonar.web.systemPasscode. needed for LivenessProbes | `define_it` |
+| `monitoringPasscode` | Value for sonar.web.systemPasscode needed for LivenessProbes (encoded to Base64 format) | `define_it` |
+| `monitoringPasscodeSecretName` | Name of the secret where to load `monitoringPasscode` | `None` |
+| `monitoringPasscodeSecretKey` | Key of an existing secret containing `monitoringPasscode` | `None` |
 | `extraContainers` | Array of extra containers to run alongside the `sonarqube` container (aka. Sidecars) | `[]` |
 
 ### Resources

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -240,8 +240,13 @@ spec:
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
+                {{- if and .Values.monitoringPasscodeSecretName .Values.monitoringPasscodeSecretKey }}
+                  name: {{ .Values.monitoringPasscodeSecretName }}
+                  key: {{ .Values.monitoringPasscodeSecretKey }}
+                {{- else }}
                   name: {{ template "sonarqube.fullname" . }}-monitoring-passcode
                   key: SONAR_WEB_SYSTEMPASSCODE
+                {{- end }}
             {{- with .Values.env }}
             {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
@@ -257,13 +262,14 @@ spec:
                 name: {{ . }}
 {{- end }}
           livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: {{ .Values.livenessProbe.sonarWebContext }}api/system/liveness
-              port: http
-              httpHeaders:
-                - name: X-Sonar-Passcode
-                  value: {{ .Values.monitoringPasscode }}
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                host="$(hostname -i || echo '127.0.0.1')"
+                reply=$(wget -qO- --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness 2>&1)
+                if [ -z "$reply" ]; then exit 0; else exit 1; fi
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -14,6 +14,7 @@ data:
   {{ template "jdbc.secretPasswordKey" . }}: {{ template "jdbc.internalSecretPasswd" . }}
 {{- end }}
 ---
+{{- if .Values.monitoringPasscode}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,6 +27,7 @@ metadata:
 type: Opaque
 data:
   SONAR_WEB_SYSTEMPASSCODE: {{ .Values.monitoringPasscode | b64enc | quote }}
+{{- end }}
 ---
 {{- if .Values.account }}
 {{- if .Values.account.adminPassword }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -310,8 +310,13 @@ spec:
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
+                {{- if and .Values.monitoringPasscodeSecretName .Values.monitoringPasscodeSecretKey }}
+                  name: {{ .Values.monitoringPasscodeSecretName }}
+                  key: {{ .Values.monitoringPasscodeSecretKey }}
+                {{- else }}
                   name: {{ template "sonarqube.fullname" . }}-monitoring-passcode
                   key: SONAR_WEB_SYSTEMPASSCODE
+                {{- end }}
             {{- with .Values.env }}
             {{- . | toYaml | trim | nindent 12 }}
             {{- end }}
@@ -327,13 +332,14 @@ spec:
                 name: {{ . }}
 {{- end }}
           livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: {{ .Values.livenessProbe.sonarWebContext }}api/system/liveness
-              port: http
-              httpHeaders:
-                - name: X-Sonar-Passcode
-                  value: {{ .Values.monitoringPasscode }}
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                host="$(hostname -i || echo '127.0.0.1')"
+                reply=$(wget -qO- --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness 2>&1)
+                if [ -z "$reply" ]; then exit 0; else exit 1; fi
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -297,6 +297,9 @@ jvmCeOpts: ""
 ## a monitoring passcode needs to be defined in order to get reasonable probe results
 # not setting the monitoring passcode will result in a deployment that will never be ready
 monitoringPasscode: "define_it"
+# Alternatively, you can define the passcode loading it from an existing secret specifying the right key
+# monitoringPasscodeSecretName: "pass-secret-name"
+# monitoringPasscodeSecretKey: "pass-key"
 
 ## Environment variables to attach to the pods
 ##


### PR DESCRIPTION
Currently, we cannot load the monitoringPasscode from an existing secret and we define it among liveness HTTP headers in clear text (DOCKER-65).

In this PR, we add the possibility to get this value from a secret and define a new liveness probe that masks the HTTP header.