### PR TITLE
Support hostAliases for deploymentType statefulset in lts chart

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.31]
+* added hostAliases to deploymentType statefulset
+
 ## [1.0.30]
 * Add documentation for ingress tls
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.30
+version: 1.0.31
 appVersion: 8.9.9
 keywords:
   - coverage

--- a/charts/sonarqube-lts/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube-lts/templates/sonarqube-sts.yaml
@@ -395,6 +395,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases | indent 8 }}
+    {{- end }}
     {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}


### PR DESCRIPTION
This PR allows for specifying hostAliases for statefulsets in the lts chart. This setting is already available for deployments. This PR is basically the same as #41, just this time for the lts chart.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart