### PR TITLE
Hotfix - sonarSecretProperties conditionals

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.31]
+* IngressClass key
+* secret.properties conditional
+
 ## [1.0.30]
 * Add documentation for ingress tls
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.30
+version: 1.0.31
 appVersion: 8.9.9
 keywords:
   - coverage

--- a/charts/sonarqube-lts/templates/ingress.yaml
+++ b/charts/sonarqube-lts/templates/ingress.yaml
@@ -27,6 +27,9 @@ metadata:
 {{- end }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ printf "%s" .name }}
@@ -38,7 +41,7 @@ spec:
             port:
               number: {{ default $servicePort .servicePort }}
         path: {{ .path}}
-        pathType: ImplementationSpecific
+        pathType: {{ default "ImplementationSpecific" .pathType }}
   {{- end }}
 {{ else }}
 spec:

--- a/charts/sonarqube-lts/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube-lts/templates/sonarqube-sts.yaml
@@ -106,7 +106,7 @@ spec:
           {{- end }}
       {{- end }}
 
-      {{- if and .Values.sonarProperties .Values.sonarSecretProperties }}
+      {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
@@ -339,7 +339,7 @@ spec:
 {{- if .Values.persistence.mounts }}
 {{ toYaml .Values.persistence.mounts | indent 12 }}
 {{- end }}
-            {{- if and .Values.sonarProperties .Values.sonarSecretProperties }}
+            {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/
               name: concat-dir
             {{- else if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -70,11 +70,17 @@ ingress:
       # For additional control over serviceName and servicePort
       # serviceName: someService
       # servicePort: somePort
+      # the pathType can be one of the following values: Exact|Prefix|ImplementationSpecific(default)
+      # pathType: ImplementationSpecific      
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   # This property allows for reports up to a certain size to be uploaded to SonarQube
   # nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+
+  # Set ingressClassName if kubernetes version is >= 1.18
+  # Reference: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  # ingressClassName: nginx  
 
 # Additional labels for Ingress manifest file
   # labels:


### PR DESCRIPTION
- [x] `ingressClass` key included in values.yaml for usage in Kubernetes cluster version >= 1.18
- [x] Conditionals at `charts/sonarqube-lts/templates/sonarqube-sts.yaml` updated from `and` to `or`, because only one key is necessary to "create" sonar.properties. In my use case, I used only the `sonarSecretProperties` for my all sonar configurations (like ldap, for example)