### PR TITLE
DOCKER-92 fix the wrong image's tag in application nodes

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.2.1]
+* Fix wrong image's tag in application nodes
+
 ## [4.2.0]
 * Add support for monitoringPasscode passed as a secret and removal of livenessprobe httpheader defined in clear text
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 4.2.0
+version: 4.2.1
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -113,7 +113,7 @@ searchNodes:
 ApplicationNodes:
   image:
     repository: sonarqube
-    tag: 9.6.0-datacenter-app
+    tag: 9.6.1-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:


### PR DESCRIPTION
We set the application nodes to use an incorrect image (`9.6.0-datacenter-app` instead of `9.6.1-datacenter-app`).