### PR TITLE
DRAFT: DOCKER-71-fix-wrong-condition-for-sonarSecretKey-in-helm-chart

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.3.1]
+* Refactor templating of ConfigMap for sonar.properties
+
 ## [4.3.0]
 * Allow `tests.image` to be configured and update README accordingly.
 * Allow `tests.initContainers.image` to be configured and update README accordingly.

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 4.3.0
+version: 4.3.1
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube-dce/templates/config.yaml
+++ b/charts/sonarqube-dce/templates/config.yaml
@@ -9,18 +9,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- if and .Values.sonarSecretKey (not .Values.ApplicationNodes.sonarProperties) }}
-  sonar.properties: sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
-  {{- end }}
-  {{- if or .Values.ApplicationNodes.sonarProperties }}
+{{- if or .Values.sonarSecretKey .Values.ApplicationNodes.sonarProperties }}
   sonar.properties:
-  {{ range $key, $val := .Values.ApplicationNodes.sonarProperties }}
+  {{- range $key, $val := .Values.ApplicationNodes.sonarProperties }}
     {{ $key }}={{ $val }}
-  {{ end }}
   {{- end }}
-    {{- if and .Values.sonarSecretKey .Values.ApplicationNodes.sonarProperties }}
-      sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
-    {{- end }}
+  {{- if .Values.sonarSecretKey }}
+    sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
+  {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -32,15 +29,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- if and .Values.sonarSecretKey (not .Values.searchNodes.sonarProperties) }}
-  sonar.properties: sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
-  {{- end }}
-  {{- if or .Values.searchNodes.sonarProperties }}
+{{- if or .Values.sonarSecretKey .Values.searchNodes.sonarProperties }}
   sonar.properties:
-  {{ range $key, $val := .Values.searchNodes.sonarProperties }}
+  {{- range $key, $val := .Values.searchNodes.sonarProperties }}
     {{ $key }}={{ $val }}
-  {{ end }}
   {{- end }}
-    {{- if and .Values.sonarSecretKey .Values.searchNodes.sonarProperties }}
-      sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
-    {{- end }}
+  {{- if and .Values.sonarSecretKey }}
+    sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
+  {{- end }}
+{{- end }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -91,7 +91,7 @@ spec:
           {{- end }}
       {{- end }}
       {{- end }}
-      {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties }}
+      {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey }}
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.ApplicationNodes.image.pullPolicy  }}
@@ -110,7 +110,7 @@ spec:
               awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
             fi
           volumeMounts:
-          {{- if .Values.ApplicationNodes.sonarProperties }}
+          {{- if or .Values.ApplicationNodes.sonarProperties .Values.sonarSecretKey}}
             - mountPath: /tmp/props/sonar.properties
               name: config
               subPath: sonar.properties
@@ -321,7 +321,7 @@ spec:
 {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties }}
+            {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey}}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
               subPath: sonar.properties
               name: concat-dir
@@ -380,7 +380,7 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       volumes:
-      {{- if .Values.ApplicationNodes.sonarProperties }}
+      {{- if or .Values.ApplicationNodes.sonarProperties .Values.sonarSecretKey }}
       - name: config
         configMap:
           name: {{ template "sonarqube.fullname" . }}-app-config
@@ -447,7 +447,7 @@ spec:
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
       - name : tmp-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
-        {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties }}
+        {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey }}
       - name : concat-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 -}}
         {{- end }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -126,7 +126,7 @@ spec:
           {{- end }}
       {{- end }}
       {{- if and .Values.searchNodes.persistence.enabled .Values.initFs.enabled }}
-      {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties }}
+      {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey }}
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.searchNodes.image.pullPolicy  }}
@@ -145,7 +145,7 @@ spec:
               awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
             fi
           volumeMounts:
-          {{- if .Values.searchNodes.sonarProperties }}
+          {{- if or .Values.searchNodes.sonarProperties .Values.sonarSecretKey }}
             - mountPath: /tmp/props/sonar.properties
               name: config
               subPath: sonar.properties
@@ -351,6 +351,11 @@ spec:
 {{- if .Values.searchNodes.persistence.mounts }}
 {{ toYaml .Values.searchNodes.persistence.mounts | indent 12 }}
 {{- end }}
+            {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey }}
+            - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
+            subPath: sonar.properties
+            name: concat-dir
+            {{- end }}
             {{- if .Values.sonarSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
               name: secret
@@ -403,7 +408,7 @@ spec:
           - key: sonar-secret.txt
             path: sonar-secret.txt
       {{- end }}
-      {{- if .Values.searchNodes.sonarProperties }}
+      {{- if or .Values.searchNodes.sonarProperties .Values.sonarSecretKey }}
       - name: config
         configMap:
           name: {{ template "sonarqube.fullname" . }}-search-config
@@ -449,7 +454,7 @@ spec:
       {{- end }}
       - name : tmp-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
-        {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties }}
+        {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey }}
       - name : concat-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 -}}
         {{- end }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.4.1]
+* Refactor templating of ConfigMap for sonar.properties
+
 ## [5.4.0]
 * Allow `tests.image` to be configured and update README accordingly.
 * Allow `tests.initContainers.image` to be configured and update README accordingly.

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 5.4.0
+version: 5.4.1
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube/templates/config.yaml
+++ b/charts/sonarqube/templates/config.yaml
@@ -8,18 +8,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- if and .Values.sonarSecretKey (not .Values.sonarProperties) (not .Values.elasticsearch.bootstrapChecks) }}
-  sonar.properties: sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
-  {{- end }}
-  {{- if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
+{{- if or .Values.sonarProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks ) }}
   sonar.properties:
-  {{ range $key, $val := .Values.sonarProperties }}
+  {{- range $key, $val := .Values.sonarProperties }}
     {{ $key }}={{ $val }}
-  {{ end }}
+  {{- end }}
   {{- if not .Values.elasticsearch.bootstrapChecks }}
     sonar.es.bootstrap.checks.disable=true
   {{- end }}
+  {{- if .Values.sonarSecretKey }}
+    sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
   {{- end }}
-    {{- if and .Values.sonarSecretKey .Values.sonarProperties }}
-      sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
-    {{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+      {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
@@ -162,7 +162,7 @@ spec:
               awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
             fi
           volumeMounts:
-          {{- if .Values.sonarProperties }}
+          {{- if or .Values.sonarProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
             - mountPath: /tmp/props/sonar.properties
               name: config
               subPath: sonar.properties
@@ -288,12 +288,9 @@ spec:
 {{- if .Values.persistence.mounts }}
 {{ toYaml .Values.persistence.mounts | indent 12 }}
 {{- end }}
-            {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+            {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/
               name: concat-dir
-            {{- else if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
-            - mountPath: {{ .Values.sonarqubeFolder }}/conf/
-              name: config
             {{- end }}
             {{- if .Values.sonarSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
@@ -337,7 +334,7 @@ spec:
 {{- if .Values.persistence.volumes }}
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}
 {{- end }}
-      {{- if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
+      {{- if or .Values.sonarProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
       - name: config
         configMap:
           name: {{ template "sonarqube.fullname" . }}-config
@@ -395,7 +392,7 @@ spec:
         {{- end  }}
       - name : tmp-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
-        {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+        {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
       - name : concat-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 -}}
         {{- end }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -117,7 +117,7 @@ spec:
           {{- end }}
       {{- end }}
 
-      {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+      {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
@@ -136,7 +136,7 @@ spec:
               awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
             fi
           volumeMounts:
-          {{- if .Values.sonarProperties }}
+          {{- if or .Values.sonarProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
             - mountPath: /tmp/props/sonar.properties
               name: config
               subPath: sonar.properties
@@ -376,13 +376,9 @@ spec:
 {{- if .Values.persistence.mounts }}
 {{ toYaml .Values.persistence.mounts | indent 12 }}
 {{- end }}
-            {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+            {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/
               name: concat-dir
-            {{- else if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
-            - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
-              subPath: sonar.properties
-              name: config
             {{- end }}
             {{- if .Values.sonarSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
@@ -449,7 +445,7 @@ spec:
 {{- if .Values.persistence.volumes }}
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}
 {{- end }}
-      {{- if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
+      {{- if or .Values.sonarProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
       - name: config
         configMap:
           name: {{ template "sonarqube.fullname" . }}-config
@@ -527,7 +523,7 @@ spec:
         {{- end  }}
       - name : tmp-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
-        {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+        {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
       - name : concat-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 -}}
         {{- end }}


### PR DESCRIPTION
- fix condition in helm templating for sonar.properties ConfigMap
- fix condition in helm templating for volumeMounts of this sonar.properties data

tests:
- templating locally with various .values file
- ct tests

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart