### PR TITLE
Automate the creation of custom resources post-install

### DIFF
--- a/charts/sonarqube-lts/.helmignore
+++ b/charts/sonarqube-lts/.helmignore
@@ -15,6 +15,8 @@
 *.bak
 *.tmp
 *~
+# Common folders
+tests/
 # Various IDEs
 .project
 .idea/

--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.31]
+* added `webApi.requests` (It will allow to generate resources on the platform after the installation through Web API)
+
 ## [1.0.30]
 * Add documentation for ingress tls
 

--- a/charts/sonarqube-lts/README.md
+++ b/charts/sonarqube-lts/README.md
@@ -262,6 +262,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `account.currentAdminPassword`                           | Current admin password                                                                                                    | `"admin"`                       |
 | `curlContainerImage`                                     | Curl container image                                                                                                      | `"curlimages/curl:latest"`      |
 | `adminJobAnnotations`                                    | Custom annotations for admin hook Job                                                                                     | `{}`                            |
+| `webApi.requests`                                        | It will allow to generate resources on the platform after the installation through `Web API`                                        | `[]`                            |
 | `terminationGracePeriodSeconds`                          | Configuration of `terminationGracePeriodSeconds`                                                                          | `60`                            |
 
 You can also configure values for the PostgreSQL database via the Postgresql [Chart](https://hub.helm.sh/charts/bitnami/postgresql)

--- a/charts/sonarqube-lts/templates/webapi-requests.yaml
+++ b/charts/sonarqube-lts/templates/webapi-requests.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.webApi }}
+{{- $fullName := include "sonarqube.fullname" . -}}
+{{- $internalPort := .Values.service.internalPort -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-web-api-hook
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: {{ $fullName }}-web-api-hook
+        image: {{ default "curlimages/curl:latest" .Values.webApi.curlContainerImage }}
+        command: [ 'sh', '-c']
+        {{- if .Values.webApi.requests }}
+        args:
+          - 'until curl -v --connect-timeout 100 {{ $fullName }}:{{ default 9000 $internalPort }}/api/system/status | grep -w UP; do sleep 10; done; '
+          {{- range $key, $val := .Values.webApi.requests }}
+          - 'curl -v --connect-timeout 100 -X POST "{{ $fullName }}:{{ default 9000 $internalPort }}/{{ $val }}"'
+          {{- end }}
+        {{- end }}
+{{- end }}

--- a/charts/sonarqube-lts/tests/webapi-requests_test.yaml
+++ b/charts/sonarqube-lts/tests/webapi-requests_test.yaml
@@ -1,6 +1,6 @@
 suite: webApi requests
 templates:
-  - post-install-hook.yaml
+  - webapi-requests.yaml
 tests:
   - it: job should not render by default
     asserts:

--- a/charts/sonarqube-lts/tests/webapi-requests_test.yaml
+++ b/charts/sonarqube-lts/tests/webapi-requests_test.yaml
@@ -1,0 +1,23 @@
+suite: webApi requests
+templates:
+  - post-install-hook.yaml
+tests:
+  - it: job should not render by default
+    asserts:
+      - isKind:
+          of: Job
+      - hasDocuments:
+          count: 1
+  - it: requests should be present
+    set:
+      webApi:
+        requests:
+          - web_api/api/qualitygates/create?name=QG_Q1
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - 'until curl -v --connect-timeout 100 RELEASE-NAME-sonarqube-lts:9000/api/system/status | grep -w UP; do sleep 10; done; '
+            - 'curl -v --connect-timeout 100 -X POST "RELEASE-NAME-sonarqube-lts:9000/web_api/api/qualitygates/create?name=QG_Q1"'

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -414,4 +414,16 @@ extraConfig:
 # curlContainerImage: curlimages/curl:latest
 # adminJobAnnotations: {}
 
+# webApi is used to load functionalities.
+# These requests is expected to contain values, such as:
+#
+# webApi:
+#   curlContainerImage: curlimages/curl:7.85.0
+#   requests:
+#     - web_api/api/qualitygates/create?name=QG_Q1
+#     - web_api/api/qualitygates/set_as_default?name=QG_Q1
+#     - web_api/api/qualitygates/create_condition?gateName=QG_Q1&metric=new_code_smells&op=LT&error=10
+webApi:
+  requests: []
+
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- For the initial configuration of my product, I needed a way to automate the creation of custom resources such as `Quality gates` and `Quality Profiles`. I thought that by adding the available helm hooks, we can create some resources after the installation.
 I have also generated unit tests for the template. Feel free to include them in an Action. I used the helm plugin `helm3-unittest` to run them: `helm unittest charts/sonarqube-lts`
- `webApi.requests` (It will allow to generate resources on the platform after the installation through Web API)
- `1.0.31`