### PR TITLE
Fix sonarProperties mount condition for DCE

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.0.8]
+* Fixed DCE chart to properly mount sonarProperties into the app pod
+
 ## [4.0.7]
 * Updated SonarQube to 9.6.1 for the DCE-chart application nodes
 
@@ -114,7 +117,7 @@ All changes to this chart will be documented in this file.
 * added link to community support forum
 
 ## [0.1.6]
-* fixed wrong scc user reference if name was explicitly set 
+* fixed wrong scc user reference if name was explicitly set
 
 ## [0.1.5]
 * fixed serviceaccount logic

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 4.0.7
+version: 4.0.8
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -95,7 +95,7 @@ spec:
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.ApplicationNodes.image.pullPolicy  }}
-          command: 
+          command:
           - sh
           - -c
           - |
@@ -257,7 +257,7 @@ spec:
             - name: SONAR_CLUSTER_SEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ template "search.userPassword" . }}" 
+                  name: "{{ template "search.userPassword" . }}"
                   key: SONAR_CLUSTER_SEARCH_PASSWORD
             {{ end }}
             {{- with .Values.ApplicationNodes.env }}
@@ -315,11 +315,11 @@ spec:
 {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if or .Values.sonarProperties .Values.sonarSecretProperties }}
+            {{- if or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.sonarSecretProperties }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
               subPath: sonar.properties
               name: concat-dir
-            {{- else if .Values.sonarProperties }}
+            {{- else if .Values.ApplicationNodes.sonarProperties }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
               subPath: sonar.properties
               name: config


### PR DESCRIPTION
The DCE app pod is not getting it's sonarProperties volume mounted because it's (I'm guessing) using a deprecated .Values.sonarProperties key, rather then the nested one at .Values.ApplicationNodes.sonarProperties.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

Example with installing object script (v4.0.7 helm chart version):

```
ApplicationNodes:
  plugins:
    install:
      - "https://objectscriptquality.com/sites/default/files/public/contents/plugin/release/sonar-objectscript-plugin-3.3.2.jar"

  sonarProperties:
    objectScriptQuality.license.serverUrl: https://www.objectscriptquality.com/api/v1/license
    objectScriptQuality.license.cache: /tmp/

# without this key defined only the `concat-properties` init container gets to mount the .Values.ApplicationNodes.sonarProperties
sonarProperties:
  dummy_key_needed_to_mount_sonar_properties_into_app_pod: true
```
