### PR TITLE
Remove the right-dash curly brace to prevent chomping whitespace

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [4.3.1]
+* Fix the right-dash curly brace issue with the additional network policy parameter
+
 ## [4.3.0]
 * Allow `tests.image` to be configured and update README accordingly.
 * Allow `tests.initContainers.image` to be configured and update README accordingly.

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 4.3.0
+version: 4.3.1
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube-dce/templates/networkpolicy.yaml
+++ b/charts/sonarqube-dce/templates/networkpolicy.yaml
@@ -169,7 +169,7 @@ spec:
           protocol: UDP
 {{- end }}
 
-{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.additionalNetworkPolicys -}}
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.additionalNetworkPolicys }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.4.1]
+* Fix the right-dash curly brace issue with the additional network policy parameter
+
 ## [5.4.0]
 * Allow `tests.image` to be configured and update README accordingly.
 * Allow `tests.initContainers.image` to be configured and update README accordingly.

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 5.4.0
+version: 5.4.1
 appVersion: 9.6.1
 keywords:
   - coverage

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -96,7 +96,7 @@ spec:
           protocol: UDP
 {{- end }}
 
-{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.additionalNetworkPolicys -}}
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.additionalNetworkPolicys }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

When using NetworkPolicies with `.Values.networkPolicy.additionalNetworkPolicys` the templating result is broken because of the right-dash curly brace of the previous `if` statement that removes the next newline.

```yaml
---
# Source: sonarqube/templates/networkpolicy.yaml
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: test-sonarqube-database
  labels:
    app: sonarqube
    chart: sonarqube-5.4.0
    release: test
    heritage: Helm
spec:
  podSelector:
    matchLabels:
      app.kubernetes.io/name: postgresql
  policyTypes:
    - Ingress
    - Egress
  ingress:
    - from:
        - podSelector:
            matchLabels:
              app: sonarqube
      ports:
        - port: 5432
  egress:
    - to:
        - namespaceSelector: {}
          podSelector:
            matchLabels:
              k8s-app: kube-dns
      ports:
        - port: 53
          protocol: UDP---
kind: NetworkPolicy
apiVersion: networking.k8s.io/v1
metadata:
  name: test-sonarqube-additional-network-policy
  labels:
    app: sonarqube
    chart: sonarqube-5.4.0
    release: test
    heritage: Helm
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          name: ingress-nginx
    ports:
    - port: 9000
      protocol: TCP
  podSelector:
    matchLabels:
      app: sonarqube
  policyTypes:
  - Ingress
```

I've tried to deploy the Chart through FluxCD Helm-Controller and getting the error below : 

```
Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
line 52: mapping key "apiVersion" already defined at line 2
line 51: mapping key "kind" already defined at line 3
line 53: mapping key "metadata" already defined at line 4
line 60: mapping key "spec" already defined at line 13
```

