### PR TITLE
Refactor Deployment manifest to match the Statefulset manifest

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.0.3]
+* Refactor Deployment manifest to match the Statefulset manifest
+
 ## [7.0.2]
 * Update the list of supported kubernetes versions
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 7.0.2
+version: 7.0.3
 appVersion: 9.8.0
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
         checksum/plugins: {{ include (print $.Template.BasePath "/install-plugins.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- if .Values.prometheusExporter.enabled }}
+        checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-config.yaml") . | sha256sum }}
+        checksum/prometheus-ce-config: {{ include (print $.Template.BasePath "/prometheus-ce-config.yaml") . | sha256sum }}
+{{- end }}
 {{- if .Values.annotations}}
       {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value | quote }}
@@ -46,7 +50,6 @@ spec:
     {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}
     {{- end }}
-      serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
       {{- if or .Values.image.pullSecrets .Values.image.pullSecret }}
@@ -61,6 +64,18 @@ spec:
       initContainers:
       {{- if .Values.extraInitContainers }}
 {{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}
+      {{- if .Values.postgresql.enabled }}
+        - name: "wait-for-db"
+          image: {{ default "busybox:1.32" .Values.initContainers.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy  }}
+          {{- if $securityContext := .Values.initContainers.securityContext }}
+          securityContext:
+{{ toYaml $securityContext | indent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.initContainers.resources | indent 12 }}
+          command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
       {{- end }}
       {{- if .Values.caCerts.enabled }}
         - name: ca-certs
@@ -106,45 +121,12 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- if .Values.plugins.install }}
-        - name: install-plugins
-          image: {{ default "curlimages/curl:7.76.1" .Values.plugins.image }}
-          imagePullPolicy: {{ .Values.image.pullPolicy  }}
-          command: ["sh",
-            "-e",
-            "/tmp/scripts/install_plugins.sh"]
-          volumeMounts:
-            - mountPath: {{ .Values.sonarqubeFolder }}/extensions/plugins
-              name: sonarqube
-              subPath: extensions/plugins
-            - name: install-plugins
-              mountPath: /tmp/scripts/
-            {{- if .Values.plugins.netrcCreds }}
-            - name: plugins-netrc-file
-              mountPath: /root
-            {{- end }}
-          {{- if $securityContext := .Values.initContainers.securityContext }}
-          securityContext:
-{{ toYaml $securityContext | indent 12 }}
-          {{- end }}
-          resources:
-{{ toYaml (default .Values.initContainers.resources .Values.plugins.resource) | indent 12 }}
-          env:
-            - name: http_proxy
-              value: {{ default "" .Values.plugins.httpProxy }}
-            - name: https_proxy
-              value: {{ default "" .Values.plugins.httpsProxy }}
-            - name: no_proxy
-              value: {{ default "" .Values.plugins.noProxy }}
-          {{- with .Values.env }}
-            {{- . | toYaml | trim | nindent 12 }}
-          {{- end }}
-      {{- end }}
+
       {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
-          command: 
+          command:
           - sh
           - -c
           - |
@@ -182,36 +164,67 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- if .Values.postgresql.enabled }}
-        - name: "wait-for-db"
-          image: {{ default "busybox:1.32" .Values.initContainers.image }}
+
+      {{- if .Values.prometheusExporter.enabled }}
+        - name: inject-prometheus-exporter
+          image: {{ default "curlimages/curl:7.76.1" .Values.prometheusExporter.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
-          {{- if $securityContext := .Values.initContainers.securityContext }}
+          {{- if $securityContext := (default .Values.initContainers.securityContext .Values.prometheusExporter.securityContext) }}
           securityContext:
 {{ toYaml $securityContext | indent 12 }}
           {{- end }}
           resources:
-{{ toYaml .Values.initContainers.resources | indent 12 }}
-          command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]
+{{ toYaml (default .Values.initContainers.resources .Values.prometheusExporter.resources) | indent 12 }}
+          command: ["/bin/sh","-c"]
+          args: ["curl -s '{{ template "prometheusExporter.downloadURL" . }}' {{ if $.Values.prometheusExporter.noCheckCertificate }}--insecure{{ end }} --output /data/jmx_prometheus_javaagent.jar -v"]
+          volumeMounts:
+            - mountPath: /data
+              name: sonarqube
+              subPath: data
+          env:
+            - name: http_proxy
+              value: {{ default "" .Values.prometheusExporter.httpProxy }}
+            - name: https_proxy
+              value: {{ default "" .Values.prometheusExporter.httpsProxy }}
+            - name: no_proxy
+              value: {{ default "" .Values.prometheusExporter.noProxy }}
+          {{- with .Values.env }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
       {{- end }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
-      {{- end }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- if .Values.plugins.install }}
+        - name: install-plugins
+          image: {{ default "curlimages/curl:7.76.1" .Values.plugins.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy  }}
+          command: ["sh",
+            "-e",
+            "/tmp/scripts/install_plugins.sh"]
+          volumeMounts:
+            - mountPath: {{ .Values.sonarqubeFolder }}/extensions/plugins
+              name: sonarqube
+              subPath: extensions/plugins
+            - name: install-plugins
+              mountPath: /tmp/scripts/
+            {{- if .Values.plugins.netrcCreds }}
+            - name: plugins-netrc-file
+              mountPath: /root
     {{- end }}
-    {{- if .Values.hostAliases }}
-      hostAliases:
-{{ toYaml .Values.hostAliases | indent 8 }}
+          {{- if $securityContext := (default .Values.initContainers.securityContext .Values.plugins.securityContext) }}
+          securityContext:
+{{ toYaml $securityContext | indent 12 }}
     {{- end }}
-    {{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+          resources:
+{{ toYaml (default .Values.initContainers.resources .Values.plugins.resource) | indent 12 }}
+          env:
+            - name: http_proxy
+              value: {{ default "" .Values.plugins.httpProxy }}
+            - name: https_proxy
+              value: {{ default "" .Values.plugins.httpsProxy }}
+            - name: no_proxy
+              value: {{ default "" .Values.plugins.noProxy }}
+          {{- with .Values.env }}
+            {{- . | toYaml | trim | nindent 12 }}
     {{- end }}
-    {{- if .Values.affinity }}
-      affinity:
-{{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
       containers:
       {{- if .Values.extraContainers }}
@@ -224,6 +237,16 @@ spec:
             - name: http
               containerPort: {{ .Values.service.internalPort }}
               protocol: TCP
+            {{- if .Values.prometheusExporter.enabled }}
+            - name: monitoring-web
+              containerPort: {{ .Values.prometheusExporter.webBeanPort }}
+              protocol: TCP
+            - name: monitoring-ce
+              containerPort: {{ .Values.prometheusExporter.ceBeanPort }}
+              protocol: TCP
+            {{- end }}
+          resources:
+{{ toYaml (default .Values.resources .Values.resource) | indent 12 }}
           env:
             - name: SONAR_WEB_JAVAOPTS
               value: {{ template "sonarqube.jvmOpts" . }}
@@ -271,12 +294,30 @@ spec:
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
-            httpGet:
-              path: {{ .Values.readinessProbe.sonarWebContext }}api/system/status
-              port: http
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                #!/bin/bash
+                # A Sonarqube container is considered ready if the status is UP, DB_MIGRATION_NEEDED or DB_MIGRATION_RUNNING
+                # status about migration are added to prevent the node to be kill while sonarqube is upgrading the database.
+                host="$(hostname -i || echo '127.0.0.1')"
+                if wget --proxy off -qO- http://${host}:{{ .Values.service.internalPort }}{{ .Values.readinessProbe.sonarWebContext }}api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'; then
+                	exit 0
+                fi
+                exit 1
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          startupProbe:
+            httpGet:
+              scheme: HTTP
+              path: {{ .Values.readinessProbe.sonarWebContext }}api/system/status
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
 {{- toYaml .Values.containerSecurityContext | nindent 12 }}
@@ -293,7 +334,7 @@ spec:
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
               name: secret
             {{- end }}
-            {{- if .Values.caCerts }}
+            {{- if .Values.caCerts.enabled }}
             - mountPath: {{ .Values.sonarqubeFolder }}/certs
               name: sonarqube
               subPath: certs
@@ -318,8 +359,31 @@ spec:
               subPath: logs
             - mountPath: /tmp
               name: tmp-dir
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- if .Values.prometheusExporter.enabled }}
+            - mountPath: {{ .Values.sonarqubeFolder }}/conf/prometheus-config.yaml
+              subPath: prometheus-config.yaml
+              name: prometheus-config
+            - mountPath: {{ .Values.sonarqubeFolder }}/conf/prometheus-ce-config.yaml
+              subPath: prometheus-ce-config.yaml
+              name: prometheus-ce-config
+            {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       volumes:
 {{- if .Values.persistence.volumes }}
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}
@@ -348,7 +412,7 @@ spec:
           - key: sonar-secret.txt
             path: sonar-secret.txt
       {{- end }}
-      {{- if .Values.caCerts }}
+      {{- if .Values.caCerts.enabled }}
       - name: ca-certs
         secret:
           secretName: {{ .Values.caCerts.secret }}
@@ -373,6 +437,20 @@ spec:
           items:
             - key: install_plugins.sh
               path: install_plugins.sh
+      {{- if .Values.prometheusExporter.enabled }}
+      - name: prometheus-config
+        configMap:
+          name: {{ template "sonarqube.fullname" . }}-prometheus-config
+          items:
+            - key: prometheus-config.yaml
+              path: prometheus-config.yaml
+      - name: prometheus-ce-config
+        configMap:
+          name: {{ template "sonarqube.fullname" . }}-prometheus-ce-config
+          items:
+            - key: prometheus-ce-config.yaml
+              path: prometheus-ce-config.yaml
+      {{- end }}
       - name: sonarqube
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:


### PR DESCRIPTION
We are currently using the Chart as Statefulset, but since we have no persistence, we're moving it to Deployment. 

Unfortunately, the Deployment is not working when Prometheus is enabled. The pod fails (CrashLoopBackOff) because the JMX exporter is missing.

```
[truncated]
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube 2022.11.29 17:45:57 INFO  app[][o.s.a.SchedulerImpl] Process[es] is up
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube 2022.11.29 17:45:57 INFO  app[][o.s.a.ProcessLauncherImpl] Launch process[WEB_SERVER] from [/opt/sonarqube]: /usr/lib/jvm/java-11-openjdk/bin/java -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/opt/sonarqube/temp -XX:-OmitStackTraceInFastThrow --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED -Dcom.redhat.fips=false -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8000:/opt/sonarqube/conf/prometheus-config.yaml -Dhttp.nonProxyHosts=localhost|127.*|[::1] -cp ./lib/sonar-application-9.7.1.62043.jar:/opt/sonarqube/lib/jdbc/postgresql/postgresql-42.4.1.jar org.sonar.server.app.WebServer /opt/sonarqube/temp/sq-process13968265659864058523properties
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube Error opening zip file or JAR manifest missing : /opt/sonarqube/data/jmx_prometheus_javaagent.jar
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube Error occurred during initialization of VM
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube agent library failed to init: instrument
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube 2022.11.29 17:45:57 WARN  app[][o.s.a.p.AbstractManagedProcess] Process exited with exit value [Web Server]: 1
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube 2022.11.29 17:45:57 INFO  app[][o.s.a.SchedulerImpl] Process[Web Server] is stopped
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube 2022.11.29 17:45:57 WARN  app[][o.s.a.p.AbstractManagedProcess] Process exited with exit value [ElasticSearch]: 143
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube 2022.11.29 17:45:57 INFO  app[][o.s.a.SchedulerImpl] Process[ElasticSearch] is stopped
sonarqube-sonarqube-5454cd7496-hfp9c sonarqube 2022.11.29 17:45:57 INFO  app[][o.s.a.SchedulerImpl] SonarQube is stopped
```

The Deployment manifest is missing some declarations from the Stefulset manifest, for example :

- Prometheus JMX exporter
- Wait-for-db init container  
 
Almost all changes come from a difference between the Stafulset and Deployment manifest.

It works well from my side, and Prometheus can now fetch the 3 metrics endpoints with a classic PodMonitor definition.

Any clue why the deployment manifest is way behind the Statefulset one? 

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart