### PR TITLE
added ability to set ingress class name if using networking.k8s.io/v1 API

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+##[1.1.0]
+* added ability to set ingress class name if using networking.k8s.io/v1 API
+
 ## [1.0.31]
 * Updated SonarQube LTS to 8.9.10
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.31
+version: 1.1.0
 appVersion: 8.9.10
 keywords:
   - coverage
@@ -18,8 +18,8 @@ maintainers:
     email: leo.geoffroy+helm@sonarsource.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Updated SonarQube to 8.9.10"
+    - kind: added
+      description: "Allow ingress class name to be set if using networking.k8s.io/v1 API"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube-lts/README.md
+++ b/charts/sonarqube-lts/README.md
@@ -144,6 +144,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ingress.hosts[0].path`                                  | Path within the URL structure                                                                                             | /                               |
 | `ingress.hosts[0].serviceName`                           | Optional field to override the default serviceName of a path                                                              | None                            |
 | `ingress.hosts[0].servicePort`                           | Optional field to override the default servicePort of a path                                                              | None                            |
+| `ingress.ingressClassName                                | Optional field to configure ingress class name                                                                            | None                            |
 | `ingress.tls`                                            | Ingress secrets for TLS certificates                                                                                      | `[]`                            |
 | `ingress.annotations` | Optional field to add extra annotations to the ingress | `None` |
 | `affinity`                                               | Node / Pod affinities                                                                                                     | `{}`                            |

--- a/charts/sonarqube-lts/templates/ingress.yaml
+++ b/charts/sonarqube-lts/templates/ingress.yaml
@@ -27,6 +27,9 @@ metadata:
 {{- end }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ printf "%s" .name }}

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -70,6 +70,8 @@ ingress:
       # For additional control over serviceName and servicePort
       # serviceName: someService
       # servicePort: somePort
+  # ingressClassName is only supported in clusters that use the networking.k8s.io/v1 API
+  ingressClassName:
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Ingresses as of `networking.k8s.io/v1` are supposed to use `ingressClassName` instead of the deprecated `kubernetes.io/ingress.class` annotation to control the ingress class of the ingress.  This chart supports creating ingresses in the networking.k8s.io/v1 API version but doesn't support the use of ingressClassName.  This pull requests adds the ability to conditionally set ingressClassName to allow users who use that exclusively to control ingress class use this chart.

Please ensure your pull request adheres to the following guidelines:
- [X] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [X] Bump the Version number of the respected chart