### PR TITLE
feat(sonarqube/sonarqube-lts): allow setting priorityClassName for StatefulSets

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.32]
+* Allow setting priorityClassName for StatefulSet too
+
 ## [1.0.31]
 * Updated SonarQube LTS to 8.9.10
 

--- a/charts/sonarqube-lts/Chart.yaml
+++ b/charts/sonarqube-lts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube-lts
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
-version: 1.0.31
+version: 1.0.32
 appVersion: 8.9.10
 keywords:
   - coverage

--- a/charts/sonarqube-lts/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube-lts/templates/sonarqube-sts.yaml
@@ -391,6 +391,9 @@ spec:
               subPath: prometheus-ce-config.yaml
               name: prometheus-ce-config
             {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [6.2.1]
+* Allow setting priorityClassName for StatefulSet too
+
 ## [6.2.0]
 * Refactor Ingress to be compatible with static compatibitly test and 1.19 minimum requirement
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 6.2.0
+version: 6.2.1
 appVersion: 9.7.1
 keywords:
   - coverage

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -121,7 +121,7 @@ spec:
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
-          command: 
+          command:
           - sh
           - -c
           - |
@@ -407,6 +407,9 @@ spec:
               subPath: prometheus-ce-config.yaml
               name: prometheus-ce-config
             {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}


### PR DESCRIPTION
Hello 👋 

StatefulSets are using the same pod spec as deployments, and are supporting setting priorityClassNames too. This PR will allow user to use already existing value `priorityClassName` to change priority for sts pods too.

Thanks!