### PR TITLE
Adds timeoutSeconds parameter to probes

### DIFF
--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -270,6 +270,7 @@ spec:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.sonarWebContext }}api/system/status
@@ -277,6 +278,7 @@ spec:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
 {{- toYaml .Values.containerSecurityContext | nindent 12 }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -333,6 +333,7 @@ spec:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             exec:
               command:
@@ -350,6 +351,7 @@ spec:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           startupProbe:
             httpGet:
               scheme: HTTP
@@ -358,6 +360,7 @@ spec:
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
 {{- toYaml .Values.containerSecurityContext | nindent 12 }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -158,7 +158,7 @@ readinessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
   failureThreshold: 6
-  # Note that timeoutSeconds was not respected before Kuberenetes 1.20 for exec probes
+  # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
   timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
@@ -169,7 +169,7 @@ livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
   failureThreshold: 6
-  # Note that timeoutSeconds was not respected before Kuberenetes 1.20 for exec probes
+  # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
   timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
@@ -182,7 +182,7 @@ startupProbe:
   initialDelaySeconds: 30
   periodSeconds: 10
   failureThreshold: 24
-  # Note that timeoutSeconds was not respected before Kuberenetes 1.20 for exec probes
+  # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
   timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -158,6 +158,8 @@ readinessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
   failureThreshold: 6
+  # Note that timeoutSeconds was not respected before Kuberenetes 1.20 for exec probes
+  timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /
@@ -167,6 +169,8 @@ livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
   failureThreshold: 6
+  # Note that timeoutSeconds was not respected before Kuberenetes 1.20 for exec probes
+  timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /
@@ -178,6 +182,8 @@ startupProbe:
   initialDelaySeconds: 30
   periodSeconds: 10
   failureThreshold: 24
+  # Note that timeoutSeconds was not respected before Kuberenetes 1.20 for exec probes
+  timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

Certain conditions in kubernetes hosts could provoke aumented response times for certain probes (exec) which would lead to undesired and unnecessary termination of containers:
[root@worker02~]# time docker exec k8s_sonarqube_sonarqube-0_cicd_13d8c79d-ea4a-4ba6-bac2-776c3c9ddaf8_20 date
Thu Dec 15 16:25:27 UTC 2022

real    0m0.068s
user    0m0.020s
sys     0m0.017s

[root@worker02~]# time docker exec k8s_sonarqube_sonarqube-0_cicd_13d8c79d-ea4a-4ba6-bac2-776c3c9ddaf8_20 date
Thu Dec 15 16:25:29 UTC 2022

real    0m1.194s
user    0m0.016s
sys     0m0.017s

Currently, is only possible to configure certain probe parameters but using the default "1 second" for timeoutSeconds is not flexible enough to overcome these situations.

This PR aims to improve the situation.

While the change is relevant, is not enough to create a revision of the chart, thus, this PR to master does not include an entry for CHANGELOG.md nor a change in the chart version.
