### PR TITLE
SQHELM-2 Update the postgresql chart's repository

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [5.2.1]
+* Update the postgresql chart's repository
+
 ## [5.2.0]
 * Refactor Pdb and Ingress to be compatible with static compatibitly test and 1.19 minimum requirement
 * Fix indent in Service.yaml annotations

--- a/charts/sonarqube-dce/Chart.lock
+++ b/charts/sonarqube-dce/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+  version: 10.15.0
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.0.13
+digest: sha256:eb84d38cb9cc5c49b8828240213ff53c25bb5b6f5101f88671a40e08dd0ba049
+generated: "2022-12-20T14:38:00.244884+01:00"

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 5.2.0
+version: 5.2.1
 appVersion: 9.7.1
 keywords:
   - coverage
@@ -58,7 +58,7 @@ annotations:
 dependencies:
   - name: postgresql
     version: 10.15.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     condition: postgresql.enabled
   - name: ingress-nginx
     version: 4.0.13

--- a/charts/sonarqube-dce/requirements.lock
+++ b/charts/sonarqube-dce/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.15.0
-- name: ingress-nginx
-  repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.0.13
-digest: sha256:5612be33416d0996cc9f48746c6a61f92d406c43df48dffafc073188b6d7754f
-generated: "2022-01-06T14:07:07.633138512+01:00"

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [6.2.1]
+* Update the postgresql chart's repository
+
 ## [6.2.0]
 * Refactor Ingress to be compatible with static compatibitly test and 1.19 minimum requirement
 

--- a/charts/sonarqube/Chart.lock
+++ b/charts/sonarqube/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+  version: 10.15.0
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.0.13
+digest: sha256:eb84d38cb9cc5c49b8828240213ff53c25bb5b6f5101f88671a40e08dd0ba049
+generated: "2022-12-20T14:37:33.067762+01:00"

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 6.2.0
+version: 6.2.1
 appVersion: 9.7.1
 keywords:
   - coverage
@@ -58,7 +58,7 @@ annotations:
 dependencies:
   - name: postgresql
     version: 10.15.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
     condition: postgresql.enabled
   - name: ingress-nginx
     version: 4.0.13

--- a/charts/sonarqube/requirements.lock
+++ b/charts/sonarqube/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.15.0
-- name: ingress-nginx
-  repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.0.13
-digest: sha256:5612be33416d0996cc9f48746c6a61f92d406c43df48dffafc073188b6d7754f
-generated: "2022-01-06T14:17:34.853574059+01:00"


### PR DESCRIPTION
The required version of the PostgreSQL chart is no longer available. This prevents users from installing our charts. We need to fix the repository used to fetch it (the bitnami chart got moved to another repository).