### PR TITLE
Fix sonarqube dce search mounts

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [6.0.1]
+* Fix a bug in the generation of the Data Center Edition chart search StatefulSet.
+
 ## [6.0.0]
 * Update SonarQube to 9.8.0
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 6.0.0
+version: 6.0.1
 appVersion: 9.8.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -194,7 +194,6 @@ spec:
             - mountPath: {{ .Values.sonarqubeFolder }}/data
               name: "{{ template "sonarqube.fullname" . }}"
               subPath: data
-            {{- end }}
             - mountPath: {{ .Values.sonarqubeFolder }}/temp
               name: "{{ template "sonarqube.fullname" . }}"
               subPath: temp
@@ -203,6 +202,7 @@ spec:
               subPath: logs
             - mountPath: /tmp
               name: tmp-dir
+      {{- end }}
       containers:
       {{- if .Values.searchNodes.extraContainers }}
         {{- toYaml .Values.searchNodes.extraContainers | nindent 8 }}


### PR DESCRIPTION
Why

The generated yaml files had 3 elements declaring mount paths for the data, temp and logs folders when the init-fs init container was disabled, producing an invalid yaml with bad indentation and invalid for kubectl.

What

Move the "end" block to include the generation of the mount paths for data, temp and logs. The "if" block with the condition that checks if the init-fs container was closed too early in the previous version.