### PR TITLE
SQHELM-86 Update the supported kubernetes versions

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [6.0.2]
+* Update the list of supported kubernetes versions
+
 ## [6.0.1]
 * Set a new default (maximum) allowed size of the client request body on the ingress
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 6.0.1
+version: 6.0.2
 appVersion: 9.8.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -10,9 +10,10 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible Sonarqube Version: see chart.appVersion
+Compatible SonarQube Version: `9.8.0`
 
-Compatible Kubernetes Versions: From 1.19 to 1.25
+Supported Kubernetes Versions: From `1.23` to `1.26`
+
 ## Installing the chart
 
 > **_NOTE:_**  Please refer to [the official page](https://docs.sonarqube.org/latest/setup/sonarqube-cluster-on-kubernetes/) for further information on how to install and tune the helm chart specifications.
@@ -32,7 +33,7 @@ export JWT_SECRET=$(echo -n "your_secret" | openssl dgst -sha256 -hmac "your_key
 helm upgrade --install -n sonarqube-dce sonarqube sonarqube/sonarqube-dce --set ApplicationNodes.jwtSecret=$JWT_SECRET
 ```
 
-The above command deploys Sonarqube on the Kubernetes cluster in the default configuration in the sonarqube namespace. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The above command deploys SonarQube on the Kubernetes cluster in the default configuration in the sonarqube namespace. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 The default login is admin/admin.
 
@@ -110,7 +111,7 @@ spec:
 
 ## Configuration
 
-The following table lists the configurable parameters of the Sonarqube chart and their default values.
+The following table lists the configurable parameters of the SonarQube chart and their default values.
 
 ### Search Nodes Configuration
 
@@ -230,7 +231,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `hostAliases` | Aliases for IPs in /etc/hosts | `[]` |
 | `podLabels` | Map of labels to add to the pods | `{}` |
 | `env` | Environment variables to attach to the pods | `{}`|
-| `annotations` | Sonarqube Pod annotations | `{}` |
+| `annotations` | SonarQube Pod annotations | `{}` |
 
 
 ### NetworkPolicies
@@ -319,11 +320,11 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `persistence.mounts` | Specify extra mounts. Refer to ".spec.containers.volumeMounts" specification | `[]` |
 | `emptyDir` | Configuration of resources for `emptyDir` | `{}` |
 
-### Sonarqube Specific
+### SonarQube Specific
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `sonarqubeFolder` | Directory name of Sonarqube | `/opt/sonarqube` |
+| `sonarqubeFolder` | Directory name of SonarQube | `/opt/sonarqube` |
 | `monitoringPasscode` | Value for sonar.web.systemPasscode needed for LivenessProbes (encoded to Base64 format) | `define_it` |
 | `monitoringPasscodeSecretName` | Name of the secret where to load `monitoringPasscode` | `None` |
 | `monitoringPasscodeSecretKey` | Key of an existing secret containing `monitoringPasscode` | `None` |
@@ -429,7 +430,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
        xxxxxxxxxxxxxxxxxxxxxxx
    ```
 
-2. Upload your `cacerts.yaml` to a secret in the cluster you are installing Sonarqube to.
+2. Upload your `cacerts.yaml` to a secret in the cluster you are installing SonarQube to.
 
    ```shell
    kubectl apply -f cacerts.yaml
@@ -461,7 +462,7 @@ For environments where another tool, such as terraform or ansible, is used to pr
 
 In such environments, configuration may be read, via environment variables, from Secrets and ConfigMaps.
 
-1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by Sonarqube
+1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by SonarQube.
 
    ```yaml
    apiVersion: v1

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.0.2]
+* Update the list of supported kubernetes versions
+
 ## [7.0.1]
 * Set a new default (maximum) allowed size of the client request body on the ingress
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 7.0.1
+version: 7.0.2
 appVersion: 9.8.0
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -10,9 +10,10 @@ Please note that this chart only supports SonarQube Community, Developer, and En
 
 ## Compatibility
 
-Compatible Sonarqube Version: see chart.appVersion
+Compatible SonarQube Version: `9.8.0`
 
-Compatible Kubernetes Versions: From 1.19 to 1.25
+Supported Kubernetes Versions: From `1.23` to `1.26`
+
 ## Installing the chart
 
 To install the chart:
@@ -24,7 +25,7 @@ kubectl create namespace sonarqube
 helm upgrade --install -n sonarqube sonarqube sonarqube/sonarqube
 ```
 
-The above command deploys Sonarqube on the Kubernetes cluster in the default configuration in the sonarqube namespace. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The above command deploys SonarQube on the Kubernetes cluster in the default configuration in the sonarqube namespace. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 The default login is admin/admin.
 
@@ -110,7 +111,7 @@ spec:
 
 ## Configuration
 
-The following table lists the configurable parameters of the Sonarqube chart and their default values.
+The following table lists the configurable parameters of the SonarQube chart and their default values.
 
 ### Global
 
@@ -127,7 +128,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `hostAliases` | Aliases for IPs in /etc/hosts | `[]` |
 | `podLabels` | Map of labels to add to the pods | `{}` |
 | `env` | Environment variables to attach to the pods | `{}`|
-| `annotations` | Sonarqube Pod annotations | `{}` |
+| `annotations` | SonarQube Pod annotations | `{}` |
 | `edition` | SonarQube Edition to use (e.g. `community`, `developer` or `enterprise`) | `community` |
 
 ### NetworkPolicies
@@ -279,13 +280,13 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `plugins.noCheckCertificate` | Flag to not check server's certificate when downloading plugins | `false` |
 | `plugins.securityContext` | Security context for the container to download plugins | see `values.yaml` |
 
-### Sonarqube Specific
+### SonarQube Specific
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `jvmOpts` | Values to add to SONARQUBE_WEB_JVM_OPTS | `""` |
 | `jvmCeOpts` | Values to add to SONAR_CE_JAVAOPTS | `""` |
-| `sonarqubeFolder` | Directory name of Sonarqube | `/opt/sonarqube` |
+| `sonarqubeFolder` | Directory name of SonarQube | `/opt/sonarqube` |
 | `sonarProperties` | Custom `sonar.properties` key-value pairs (e.g., "sonarProperties.sonar.forceAuthentication=true") | `None` |
 | `sonarSecretProperties` | Additional `sonar.properties` key-value pairs to load from a secret | `None` |
 | `sonarSecretKey` | Name of existing secret used for settings encryption | `None` |
@@ -298,10 +299,10 @@ The following table lists the configurable parameters of the Sonarqube chart and
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `resources.requests.memory` | Sonarqube memory request | `2Gi` |
-| `resources.requests.cpu` | Sonarqube cpu request | `400m` |
-| `resources.limits.memory` | Sonarqube memory limit | `4Gi` |
-| `resources.limits.cpu` | Sonarqube cpu limit | `800m` |
+| `resources.requests.memory` | SonarQube memory request | `2Gi` |
+| `resources.requests.cpu` | SonarQube cpu request | `400m` |
+| `resources.limits.memory` | SonarQube memory limit | `4Gi` |
+| `resources.limits.cpu` | SonarQube cpu limit | `800m` |
 
 ### Persistence
 
@@ -417,7 +418,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
        xxxxxxxxxxxxxxxxxxxxxxx
    ```
 
-2. Upload your `cacerts.yaml` to a secret in the cluster you are installing Sonarqube to.
+2. Upload your `cacerts.yaml` to a secret in the cluster you are installing SonarQube to.
 
    ```shell
    kubectl apply -f cacerts.yaml
@@ -449,7 +450,7 @@ For environments where another tool, such as terraform or ansible, is used to pr
 
 In such environments, configuration may be read, via environment variables, from Secrets and ConfigMaps.
 
-1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by Sonarqube
+1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by SonarQube.
 
    ```yaml
    apiVersion: v1


### PR DESCRIPTION
We need to drop the support for EoL versions. This PR update the documentation, as direct consequence of the compatibility tests that we did before.