### PR TITLE
optional ingress parameter for sonarqube-lts chart - ingressClassName

### DIFF
--- a/charts/sonarqube-lts/CHANGELOG.md
+++ b/charts/sonarqube-lts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [1.0.32]
+* Add optional ingress parameter `ingressClassName`
+
 ## [1.0.31]
 * Updated SonarQube LTS to 8.9.10
 

--- a/charts/sonarqube-lts/README.md
+++ b/charts/sonarqube-lts/README.md
@@ -144,6 +144,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ingress.hosts[0].path`                                  | Path within the URL structure                                                                                             | /                               |
 | `ingress.hosts[0].serviceName`                           | Optional field to override the default serviceName of a path                                                              | None                            |
 | `ingress.hosts[0].servicePort`                           | Optional field to override the default servicePort of a path                                                              | None                            |
+| `ingress.ingressClassName`                               |  Optional field to configure ingress class  name                                                                                                 | None                            |
 | `ingress.tls`                                            | Ingress secrets for TLS certificates                                                                                      | `[]`                            |
 | `ingress.annotations` | Optional field to add extra annotations to the ingress | `None` |
 | `affinity`                                               | Node / Pod affinities                                                                                                     | `{}`                            |

--- a/charts/sonarqube-lts/templates/ingress.yaml
+++ b/charts/sonarqube-lts/templates/ingress.yaml
@@ -27,6 +27,9 @@ metadata:
 {{- end }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ printf "%s" .name }}

--- a/charts/sonarqube-lts/values.yaml
+++ b/charts/sonarqube-lts/values.yaml
@@ -76,6 +76,9 @@ ingress:
   # This property allows for reports up to a certain size to be uploaded to SonarQube
   # nginx.ingress.kubernetes.io/proxy-body-size: "8m"
 
+  # Set the ingressClassName on the ingress record
+  # ingressClassName: nginx
+
 # Additional labels for Ingress manifest file
   # labels:
   #  traffic-type: external


### PR DESCRIPTION
Why:
While the Sonarqube chart allows one to set ingressClassName the same does not apply to the Sonarqube-LTS chart. Internally, we use the LTS version and would need to set this parameter.

How:
Simply added this mentioned extra parameter to the Sonarqube-LTS chart dollowing the way it's done one the default Sonarqube chart.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart