### PR TITLE
SQHELM-111 Clarify doc for custom cacert secret

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.2.1]
+* Clarify doc for custom cacert secret
+
 ## [8.2.0]
 * Add a configurable Prometheus PodMonitor resource
 * Refactor Prometheus exporter's documentation and bump to version 0.17.2

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.2.0
+version: 8.2.1
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -24,6 +24,8 @@ maintainers:
     email: jeremy.cotineau@sonarsource.com
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Clarify doc for custom cacert secret"
     - kind: added
       description: "Add a configurable Prometheus PodMonitor resource"
     - kind: changed

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -435,7 +435,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
    kind: Secret
    metadata:
      name: my-cacerts
-   data:
+   stringData:
      cert-1.crt: |
        xxxxxxxxxxxxxxxxxxxxxxx
    ```

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.3.1]
+* Clarify doc for custom cacert secret
+
 ## [9.3.0]
 * Refactor Deployment manifest to match the Statefulset manifest
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 9.3.0
+version: 9.3.1
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -29,6 +29,8 @@ annotations:
     - name: Chart Source
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Clarify doc for custom cacert secret"
     - kind: changed
       description: "Refactor Deployment manifest to match the Statefulset manifest"
     - kind: added

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -428,7 +428,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
    kind: Secret
    metadata:
      name: my-cacerts
-   data:
+   stringData:
      cert-1.crt: |
        xxxxxxxxxxxxxxxxxxxxxxx
    ```


### PR DESCRIPTION
The current READMEs for all charts show a multiline string example for the `cacert` secret, but specify `data` rather than `stringData`. To make things a little more clear the example should be `stringData`.

Signed-off-by: Micah Nagel <micah.nagel@defenseunicorns.com>

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make

As docs changes, I'm not sure if these require a chart bump/changelog entry?