### PR TITLE
SQHELM-109 allow setting priorityClassName for StatefulSets

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.1.0]
+* Allow setting priorityClassName for StatefulSets
+
 ## [8.0.2]
 * Fix the volume mounts for the init-fs container
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.0.2
+version: 8.1.0
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -24,10 +24,10 @@ maintainers:
     email: jeremy.cotineau@sonarsource.com
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fix the volume mounts for the init-fs container"
     - kind: changed
       description: "Adds timeoutSeconds parameter to probes"
+    - kind: fixed
+      description: "Fix the volume mounts for the init-fs container"
     - kind: changed
       description: "Update SonarQube logo"
     - kind: changed

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -248,6 +248,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | --------- | ----------- | ------- |
 | `affinity` | Node / Pod affinities | `{}` |
 | `tolerations` | List of node taints to tolerate | `[]` |
+| `priorityClassName` | Schedule pods on priority (e.g. `high-priority`) | `None` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `hostAliases` | Aliases for IPs in /etc/hosts | `[]` |
 | `podLabels` | Map of labels to add to the pods | `{}` |

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -359,6 +359,9 @@ spec:
               subPath: prometheus-ce-config.yaml
               name: prometheus-ce-config
             {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -386,6 +386,9 @@ spec:
               subPath: logs
             - mountPath: /tmp
               name: tmp-dir
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -352,6 +352,9 @@ tolerations: []
 nodeSelector: {}
 #  sonarqube: "true"
 
+# Uncomment this to scheduler pods on priority
+# priorityClassName: "high-priority"
+
 # hostAliases allows the modification of the hosts file inside a container
 hostAliases: []
 # - ip: "192.168.1.10"

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.1.0]
+* Allow setting priorityClassName for StatefulSets
+
 ## [9.0.1]
 * Adds timeoutSeconds parameter to probes
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 9.0.1
+version: 9.1.0
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -29,6 +29,8 @@ annotations:
     - name: Chart Source
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Allow setting priorityClassName for StatefulSets"
     - kind: changed
       description: "Adds timeoutSeconds parameter to probes"
     - kind: changed

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -121,7 +121,7 @@ spec:
         - name: concat-properties
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
-          command: 
+          command:
           - sh
           - -c
           - |
@@ -410,6 +410,9 @@ spec:
               subPath: prometheus-ce-config.yaml
               name: prometheus-ce-config
             {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}


### PR DESCRIPTION
* allow setting priorityClassName for StatefulSets

Co-authored-by: Artem Kajalainen <artem.kajalainen@virta.global>

This PR is based on the contribution made by Artem Kajalainenin the context of this [PR](https://github.com/SonarSource/helm-chart-sonarqube/pull/279)