### PR TITLE
SQHELM-110 Fix the SonarQube DCE chart volume mounts (init-fs container)

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.0.2]
+* Fix the volume mounts for the init-fs container
+
 ## [8.0.1]
 * Adds timeoutSeconds parameter to probes
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.0.1
+version: 8.0.2
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -24,6 +24,8 @@ maintainers:
     email: jeremy.cotineau@sonarsource.com
 annotations:
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Fix the volume mounts for the init-fs container"
     - kind: changed
       description: "Adds timeoutSeconds parameter to probes"
     - kind: changed

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -194,7 +194,6 @@ spec:
             - mountPath: {{ .Values.sonarqubeFolder }}/data
               name: "{{ template "sonarqube.fullname" . }}"
               subPath: data
-            {{- end }}
             - mountPath: {{ .Values.sonarqubeFolder }}/temp
               name: "{{ template "sonarqube.fullname" . }}"
               subPath: temp
@@ -203,6 +202,7 @@ spec:
               subPath: logs
             - mountPath: /tmp
               name: tmp-dir
+      {{- end }}
       containers:
       {{- if .Values.searchNodes.extraContainers }}
         {{- toYaml .Values.searchNodes.extraContainers | nindent 8 }}


### PR DESCRIPTION
Co-authored-by: @BitExodus

This PR is based on the contribution made by Enrique García the context of [this PR](https://github.com/SonarSource/helm-chart-sonarqube/pull/285).