### PR TITLE
feat: added support for extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -2,7 +2,7 @@
 All changes to this chart will be documented in this file.
 
 ## [9.4.0]
-* Added support for `extraValues` and `extraVolumeMounts` in sonar pod.
+* Added support for `extraVolumes` and `extraVolumeMounts` in sonar pod.
 
 ## [9.3.0]
 * Refactor Deployment manifest to match the Statefulset manifest

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.4.0]
+* Added support for `extraValues` and `extraVolumeMounts` in sonar pod.
+
 ## [9.3.0]
 * Refactor Deployment manifest to match the Statefulset manifest
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -29,6 +29,8 @@ annotations:
     - name: Chart Source
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
+    - kind: added
+      description: "Support for extraVolumes and extraVolumeMounts in sonar pods"
     - kind: changed
       description: "Refactor Deployment manifest to match the Statefulset manifest"
     - kind: added

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 9.3.0
+version: 9.4.0
 appVersion: 9.9.0
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -309,6 +309,8 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `monitoringPasscodeSecretName` | Name of the secret where to load `monitoringPasscode` | `None` |
 | `monitoringPasscodeSecretKey` | Key of an existing secret containing `monitoringPasscode` | `None` |
 | `extraContainers` | Array of extra containers to run alongside the `sonarqube` container (aka. Sidecars) | `[]` |
+| `extraVolumes` | Array of extra volumes to add to the SonarQube deployment | `[]` |
+| `extraVolumeMounts` | Array of extra volume mounts to add to the SonarQube deployment | `[]` |
 
 ### Resources
 

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -329,6 +329,9 @@ spec:
 {{- if .Values.persistence.mounts }}
 {{ toYaml .Values.persistence.mounts | indent 12 }}
 {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
+{{- end }}
             {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/
               name: concat-dir
@@ -391,6 +394,9 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       volumes:
+{{- if .Values.extraVolumes }}
+{{- .Values.extraVolumes | toYaml | nindent 6 }}
+{{- end }}
 {{- if .Values.persistence.volumes }}
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}
 {{- end }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -372,6 +372,9 @@ spec:
 {{- if .Values.persistence.mounts }}
 {{ toYaml .Values.persistence.mounts | indent 12 }}
 {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
+{{- end }}
             {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/
               name: concat-dir
@@ -436,6 +439,9 @@ spec:
       volumes:
 {{- if .Values.persistence.volumes }}
 {{ tpl (toYaml .Values.persistence.volumes | indent 6) . }}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{- .Values.extraVolumes | toYaml | nindent 6 }}
 {{- end }}
       {{- if or .Values.sonarProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
       - name: config


### PR DESCRIPTION
This PR adds support for `extraVolumes` and `extraVolumeMounts`.

Useful for example when mounting secrets with a CSI provider (like vault) which is my specific use case for this.

---

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart