### PR TITLE
[NO MERGE] SQHELM-111 Clarify doc for custom cacert secret

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.2.1]
+* Clarify doc for custom cacert secret
+
 ## [8.2.0]
 * Add a configurable Prometheus PodMonitor resource
 * Refactor Prometheus exporter's documentation and bump to version 0.17.2

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.2.0
+version: 8.2.1
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -24,6 +24,8 @@ maintainers:
     email: jeremy.cotineau@sonarsource.com
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Clarify doc for custom cacert secret"
     - kind: added
       description: "Add a configurable Prometheus PodMonitor resource"
     - kind: changed

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -435,7 +435,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
    kind: Secret
    metadata:
      name: my-cacerts
-   data:
+   stringData:
      cert-1.crt: |
        xxxxxxxxxxxxxxxxxxxxxxx
    ```

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.3.1]
+* Clarify doc for custom cacert secret
+
 ## [9.3.0]
 * Refactor Deployment manifest to match the Statefulset manifest
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 9.3.0
+version: 9.3.1
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -29,6 +29,8 @@ annotations:
     - name: Chart Source
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Clarify doc for custom cacert secret"
     - kind: changed
       description: "Refactor Deployment manifest to match the Statefulset manifest"
     - kind: added

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -428,7 +428,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
    kind: Secret
    metadata:
      name: my-cacerts
-   data:
+   stringData:
      cert-1.crt: |
        xxxxxxxxxxxxxxxxxxxxxxx
    ```


### PR DESCRIPTION
In case of contributions received from forked repos, the vault step does not work due to a wrong Github token permission. The RE is working on that but, in the meanwhile, the best way to make the CI work again is to mimic the external contribution on a feature branch. This will retrigger the failed CI steps without facing the vault-related issues.