### PR TITLE
Add Chart repository as source

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -12,6 +12,7 @@ keywords:
 home: https://www.sonarqube.org/
 icon: https://raw.githubusercontent.com/SonarSource/sonarqube-static-resources/master/helm/SonarQubeLogo.svg
 sources:
+  - https://github.com/SonarSource/helm-chart-sonarqube
   - https://github.com/SonarSource/docker-sonarqube
   - https://github.com/SonarSource/sonarqube
 kubeVersion: '>= 1.19.0-0'


### PR DESCRIPTION
We use a custom chart with sonarqube as a dependency, and we use renovate to auto update the dependency version when you publish a new chart. Renovate will use the source to add a release note with a compare link between old and new versions to the MR, and we'd prefer to have the helm chart comparison instead of docker-sonarqube (it's been done for several GitLab charts, example : https://gitlab.com/gitlab-org/charts/gitlab-runner/-/merge_requests/379)

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [ ] Bump the Version number of the respected chart