### PR TITLE
Add helper to flatten hashmap for sonarProperties

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.3.2]
+* Add helper function to flatten dictionary keys and values to render properties correctly in properties file.
+
 ## [8.3.1]
 * Make `jvmOpts` and `jvmCeOpts` not override env vars and sonar properties
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.3.1
+version: 8.3.2
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -49,6 +49,8 @@ annotations:
       description: "Update SonarQube logo"
     - kind: changed
       description: "Bootstrap chart version 8.x.x dedicated to the future SonarQube 10.0"
+    - kind: changed
+      description: "Added helper function recurseFlattenMap to fix rendering of properties."
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -267,3 +267,16 @@ Return the appropriate apiVersion for poddisruptionbudget.
 {{- print "policy/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "recurseFlattenMap" -}}
+{{- $map := first . -}}
+{{- $label := last . -}}
+{{- range $key, $val := $map -}}
+  {{- $sublabel := list $label $key | join "." -}}
+  {{- if kindOf $val | eq "map" -}}
+    {{- list $val $sublabel | include "recurseFlattenMap" -}}
+  {{- else -}}
+{{ $sublabel }}={{ $val }}
+  {{ end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sonarqube-dce/templates/config.yaml
+++ b/charts/sonarqube-dce/templates/config.yaml
@@ -28,8 +28,8 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   sonar.properties: |
-  {{- range $key, $val := .Values.searchNodes.sonarProperties }}
-    {{ $key }}={{ $val }}
+  {{- if .Values.sonarProperties }}
+    {{ list .Values.sonarProperties.sonar "sonar" | include "recurseFlattenMap" | indent 4 }}
   {{- end }}
   {{- if .Values.sonarSecretKey }}
     sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.5.2]
+* Add helper function to flatten dictionary keys and values to render properties correctly in properties file.
+
 ## [9.5.1]
 * Make `jvmOpts` and `jvmCeOpts` not override env vars and sonar properties
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 9.5.1
+version: 9.5.2
 appVersion: 9.9.0
 keywords:
   - coverage
@@ -56,6 +56,8 @@ annotations:
       description: "Update SonarQube logo"
     - kind: changed
       description: "Bootstrap chart version 9.x.x dedicated to the future SonarQube 10.0"
+    - kind: changed
+      description: "Added helper function recurseFlattenMap to fix rendering of properties.""
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -175,3 +175,16 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "recurseFlattenMap" -}}
+{{- $map := first . -}}
+{{- $label := last . -}}
+{{- range $key, $val := $map -}}
+  {{- $sublabel := list $label $key | join "." -}}
+  {{- if kindOf $val | eq "map" -}}
+    {{- list $val $sublabel | include "recurseFlattenMap" -}}
+  {{- else -}}
+{{ $sublabel }}={{ $val }}
+  {{ end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sonarqube/templates/config.yaml
+++ b/charts/sonarqube/templates/config.yaml
@@ -9,9 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   sonar.properties: |
-  {{- range $key, $val := .Values.sonarProperties }}
-    {{ $key }}={{ $val }}
-  {{- end }}
+  {{- if .Values.sonarProperties }}
+    {{ list .Values.sonarProperties.sonar "sonar" | include "recurseFlattenMap" | indent 4 }}
+  {{- end}}
   {{- if not .Values.elasticsearch.bootstrapChecks }}
     sonar.es.bootstrap.checks.disable=true
   {{- end }}


### PR DESCRIPTION
This adds a helper to flatten sonarProperties dictionary so that the key is formatted properly. Without this helper the values for nested keys get improperly strigified as things like this:

```
sonar=map[governance:map[report:map[project:map[branch:map[frequency:Daily]]
```

This joins the strings with dots as expected and sets the values correctly.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart