### PR TITLE
(Draft) SQHELM-116 install_plugins.sh: fix plugins deletion

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.2.2]
+* Fix install_plugins.sh not deleting previously installed plugins
+
 ## [8.2.1]
 * Clarify doc for custom cacert secret
 

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.2.1
+version: 8.2.2
 appVersion: 9.9.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/templates/install-plugins.yaml
+++ b/charts/sonarqube-dce/templates/install-plugins.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   install_plugins.sh: |-
     {{- if .Values.ApplicationNodes.plugins.install }}
-      [ -e {{ .Values.sonarqubeFolder }}/extensions/plugins/* ] && rm {{ .Values.sonarqubeFolder }}/extensions/plugins/*
+      rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
       cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.ApplicationNodes.plugins.install }}
       curl {{ if $.Values.ApplicationNodes.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.ApplicationNodes.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.4.1]
+* Fix install_plugins.sh not deleting previously installed plugins
+
 ## [9.4.0]
 * Added support for `extraVolumes` and `extraVolumeMounts` in sonar pod.
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 9.4.0
+version: 9.4.1
 appVersion: 9.9.0
 keywords:
   - coverage

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   install_plugins.sh: |-
     {{- if .Values.plugins.install }}
-      [ -e {{ .Values.sonarqubeFolder }}/extensions/plugins/* ] && rm {{ .Values.sonarqubeFolder }}/extensions/plugins/*
+      rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
       cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.plugins.install }}
       curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}


### PR DESCRIPTION
**PR Draft needed to overcome the external PR issue**

The install_plugins.sh script starts by deleting previously installed plugins, but fails in case there are several already installed. As a result, updating a plugin leads to SonarQube not starting (because having two versions of the same plugin is a fatal error).

Fix this by using `rm -f *` instead of broken `[ -e * ] && rm *`.

Please ensure your pull request adheres to the following guidelines:
- [ ] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [ ] Bump the Version number of the respected chart