### PR TITLE
Comment out timeoutSeconds

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,7 +1,7 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
-## [9.4.3]
+## [8.2.4]
 * Improve values file comments
 
 ## [8.2.3]

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.4.3]
+* Improve values file comments
+
 ## [8.2.3]
 * Fixed unsupported wget parameter `--proxy off` with `--no-proxy`
 ## [8.2.2]

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -24,6 +24,8 @@ maintainers:
     email: jeremy.cotineau@sonarsource.com
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Improve values file comments"
     - kind: fixed
       description: "Fixed unsupported wget parameter --proxy off with --no-proxy"
     - kind: fixed

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -67,19 +67,19 @@ searchNodes:
     periodSeconds: 30
     failureThreshold: 6
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    timeoutSeconds: 1
+    #timeoutSeconds: 1
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 30
     failureThreshold: 6
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    timeoutSeconds: 1
+    #timeoutSeconds: 1
   startupProbe:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 24
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    timeoutSeconds: 1
+    #timeoutSeconds: 1
 
   ## We usually don't make specific resource recommendations, as they are heavily dependent on
   ## The usage of SonarQube and the surrounding infrastructure.
@@ -161,7 +161,7 @@ ApplicationNodes:
     periodSeconds: 30
     failureThreshold: 8
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    timeoutSeconds: 1
+    #timeoutSeconds: 1
     # If an ingress *path* other than the root (/) is defined, it should be reflected here
     # A trailing "/" must be included
     sonarWebContext: /
@@ -171,7 +171,7 @@ ApplicationNodes:
     periodSeconds: 30
     failureThreshold: 6
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    timeoutSeconds: 1
+    #timeoutSeconds: 1
     # If an ingress *path* other than the root (/) is defined, it should be reflected here
     # A trailing "/" must be included
     sonarWebContext: /
@@ -183,7 +183,7 @@ ApplicationNodes:
     periodSeconds: 10
     failureThreshold: 32
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    timeoutSeconds: 1
+    #timeoutSeconds: 1
     # If an ingress *path* other than the root (/) is defined, it should be reflected here
     # A trailing "/" must be included
     sonarWebContext: /

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -67,19 +67,19 @@ searchNodes:
     periodSeconds: 30
     failureThreshold: 6
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    #timeoutSeconds: 1
+    # timeoutSeconds: 1
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 30
     failureThreshold: 6
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    #timeoutSeconds: 1
+    # timeoutSeconds: 1
   startupProbe:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 24
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    #timeoutSeconds: 1
+    # timeoutSeconds: 1
 
   ## We usually don't make specific resource recommendations, as they are heavily dependent on
   ## The usage of SonarQube and the surrounding infrastructure.
@@ -161,7 +161,7 @@ ApplicationNodes:
     periodSeconds: 30
     failureThreshold: 8
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    #timeoutSeconds: 1
+    # timeoutSeconds: 1
     # If an ingress *path* other than the root (/) is defined, it should be reflected here
     # A trailing "/" must be included
     sonarWebContext: /
@@ -171,7 +171,7 @@ ApplicationNodes:
     periodSeconds: 30
     failureThreshold: 6
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    #timeoutSeconds: 1
+    # timeoutSeconds: 1
     # If an ingress *path* other than the root (/) is defined, it should be reflected here
     # A trailing "/" must be included
     sonarWebContext: /
@@ -183,7 +183,7 @@ ApplicationNodes:
     periodSeconds: 10
     failureThreshold: 32
     # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-    #timeoutSeconds: 1
+    # timeoutSeconds: 1
     # If an ingress *path* other than the root (/) is defined, it should be reflected here
     # A trailing "/" must be included
     sonarWebContext: /

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.4.3]
+* Improve values file comments
+
 ## [9.4.2]
 * Fixed unsupported wget parameter `--proxy off` with `--no-proxy`
 ## [9.4.1]

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -157,7 +157,7 @@ readinessProbe:
   periodSeconds: 30
   failureThreshold: 6
   # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-  timeoutSeconds: 1
+  #timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /
@@ -168,7 +168,7 @@ livenessProbe:
   periodSeconds: 30
   failureThreshold: 6
   # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-  timeoutSeconds: 1
+  #timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /
@@ -181,7 +181,7 @@ startupProbe:
   periodSeconds: 10
   failureThreshold: 24
   # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-  timeoutSeconds: 1
+  #timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -157,7 +157,7 @@ readinessProbe:
   periodSeconds: 30
   failureThreshold: 6
   # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-  #timeoutSeconds: 1
+  # timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /
@@ -168,7 +168,7 @@ livenessProbe:
   periodSeconds: 30
   failureThreshold: 6
   # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-  #timeoutSeconds: 1
+  # timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /
@@ -181,7 +181,7 @@ startupProbe:
   periodSeconds: 10
   failureThreshold: 24
   # Note that timeoutSeconds was not respected before Kubernetes 1.20 for exec probes
-  #timeoutSeconds: 1
+  # timeoutSeconds: 1
   # If an ingress *path* other than the root (/) is defined, it should be reflected here
   # A trailing "/" must be included
   sonarWebContext: /


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
- [x] Bump the Version number of the respected chart

No need to set it since the value given is the default as noted at https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes