### PR TITLE
Fix liveness probe.

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [10.1.0]
 * Fix wrong condition between initFs and concat-properties
 * Update Chart's version to 10.1.0
+* Fix liveness probe for SonarQube Application to detect when a failure occurs.
 
 ## [10.0.0]
 * Update SonarQube to 10.0.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -29,6 +29,8 @@ annotations:
       description: "Fix wrong condition between initFs and concat-properties"
     - kind: changed
       description: "Update Chart's version to 10.1.0"
+    - kind: changed
+      description: "Fix liveness probe for SonarQube Application to detect when a failure occurs."
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -283,7 +283,7 @@ spec:
               - -c
               - |
                 host="$(hostname -i || echo '127.0.0.1')"
-                wget --no-proxy --quiet -O /dev/null --timeout={{ .Values.livenessProbe.timeoutSeconds }} --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" "http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness"
+                wget --no-proxy --quiet -O /dev/null --timeout={{ .Values.ApplicationNodes.livenessProbe.timeoutSeconds }} --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" "http://${host}:{{ .Values.service.internalPort }}{{ .Values.ApplicationNodes.livenessProbe.sonarWebContext }}api/system/liveness"
             initialDelaySeconds: {{ .Values.ApplicationNodes.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.ApplicationNodes.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.ApplicationNodes.livenessProbe.failureThreshold }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -283,8 +283,7 @@ spec:
               - -c
               - |
                 host="$(hostname -i || echo '127.0.0.1')"
-                reply=$(wget --no-proxy -qO- --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" http://${host}:{{ .Values.service.internalPort }}{{ .Values.ApplicationNodes.livenessProbe.sonarWebContext }}api/system/liveness 2>&1)
-                if [ -z "$reply" ]; then exit 0; else exit 1; fi
+                wget --no-proxy --quiet -O /dev/null --timeout={{ .Values.livenessProbe.timeoutSeconds }} --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" "http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness"
             initialDelaySeconds: {{ .Values.ApplicationNodes.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.ApplicationNodes.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.ApplicationNodes.livenessProbe.failureThreshold }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [10.1.0]
 * Update Chart's version to 10.1.0
+* Fix liveness probe to detect when a failure occurs.
 
 ## [10.0.0]
 * Update SonarQube to 10.0.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -32,6 +32,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: "Update Chart's version to 10.1.0"
+    - kind: changed
+      description: "Fix liveness probe to detect when a failure occurs."
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -288,8 +288,7 @@ spec:
               - -c
               - |
                 host="$(hostname -i || echo '127.0.0.1')"
-                reply=$(wget --no-proxy -qO- --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness 2>&1)
-                if [ -z "$reply" ]; then exit 0; else exit 1; fi
+                wget --no-proxy --quiet -O /dev/null --timeout={{ .Values.livenessProbe.timeoutSeconds }} --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" "http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness"
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -331,8 +331,7 @@ spec:
               - -c
               - |
                 host="$(hostname -i || echo '127.0.0.1')"
-                reply=$(wget --no-proxy -qO- --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness 2>&1)
-                if [ -z "$reply" ]; then exit 0; else exit 1; fi
+                wget --no-proxy --quiet -O /dev/null --timeout={{ .Values.livenessProbe.timeoutSeconds }} --header="X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" "http://${host}:{{ .Values.service.internalPort }}{{ .Values.livenessProbe.sonarWebContext }}api/system/liveness"
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}


### PR DESCRIPTION
The liveness probe would not detect system failures when there was no content response. 500 errors for example would not be detected. This fixes the issue by using the wget return code when the command fails.

Example of working liveness probe:

```
 kubectl describe pod sonarqube-test-sonarqube-0 | tail
  Normal   Started    12m                     kubelet            Started container init-sysctl
  Normal   Started    12m                     kubelet            Started container concat-properties
  Normal   Created    12m                     kubelet            Created container concat-properties
  Normal   Pulled     12m                     kubelet            Container image "busybox:1.32" already present on machine
  Warning  Unhealthy  7m28s (x6 over 9m58s)   kubelet            Liveness probe failed:
  Normal   Killing    7m28s                   kubelet            Container sonarqube failed liveness probe, will be restarted
  Normal   Started    6m49s (x3 over 12m)     kubelet            Started container sonarqube
  Normal   Pulled     6m6s (x4 over 12m)      kubelet            Container image "sonarqube:10.0.0-enterprise" already present on machine
  Normal   Created    6m6s (x4 over 12m)      kubelet            Created container sonarqube
  Warning  BackOff    2m31s (x19 over 6m22s)  kubelet            Back-off restarting failed container
```

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`


