### PR TITLE
SONAR-18987 run test always, regardless of chart changes

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -65,8 +65,8 @@ chart_testing_task:
   wait_for_kind_script:
     - secs=3600; endTime=$(( $(date +%s) + secs )); while [[ -n "$(kubectl cluster-info --context kind-kind 2>&1 > /dev/null)" ]] || [ $(date +%s) -gt $endTime ]; do sleep 5; done
   script:
-    - ct lint --check-version-increment=false --config test.yaml
-    - ct install --config test.yaml
+    - ct lint --config test.yaml --all
+    - ct install --config test.yaml --all
   artifacthub_lint_script:
     - ah lint
 


### PR DESCRIPTION
`--all` will lint and test all charts, disabling changed charts detection and version increment checking.

Those checks are mostly causing merge conflict for user.

This change will allow us to release more easily on release-branches with the new release model.