### PR TITLE
BUILD-2953  Adapt helm-chart-sonarqube (replace set-output deprecated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: jfrog rt build-promote --status released "${{ github.event.repository.name }}" "${{ github.event.inputs.buildNumber }}" sonarsource-helm-releases
       - name: Create local repository directory
         id: local_repo
-        run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
+        run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> "$GITHUB_OUTPUT"
       - uses: SonarSource/gh-action_release/download-build@v5
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}


### PR DESCRIPTION
# BUILD-2953  Adapt helm-chart-sonarqube (replace set-output deprecated)

## Changes

* Replace deprecated `set-output` with the [recommendations of GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
   That way it can work after 31st of May