### PR TITLE
SONAR-19951 Bug/podmonitor endpoint portname missmatch

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [10.1.1]
+* Changed prometheus podmonitor's podMetricsEndpoints port name (http -> monitoring-web)
+* Update Chart's version to 10.1.1
+
 ## [10.1.0]
 * Changed default test process to wget, using sonarqube image as default
 * Update Chart's version to 10.1.0

--- a/charts/sonarqube/templates/prometheus-podmonitor.yaml
+++ b/charts/sonarqube/templates/prometheus-podmonitor.yaml
@@ -17,7 +17,7 @@ spec:
     matchLabels:
       app: {{ template "sonarqube.name" . }}
   podMetricsEndpoints:
-  - port: http
+  - port: monitoring-web
     path: /api/monitoring/metrics
     scheme: http
     {{- if .Values.prometheusMonitoring.podMonitor.interval }}


### PR DESCRIPTION
podMetricsEndpoints.port name changed in prometheus-podmonitor.yaml / because portnam
e:http is not working / monitoring-web is right.

Please ensure your pull request adheres to the following guidelines:
- [✓] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [✓] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`