### PR TITLE
chore(templates): update default curlversion

### DIFF
--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -167,7 +167,7 @@ spec:
 
       {{- if .Values.prometheusExporter.enabled }}
         - name: inject-prometheus-exporter
-          image: {{ default "curlimages/curl:7.76.1" .Values.prometheusExporter.image }}
+          image: {{ default "curlimages/curl:8.1.2" .Values.prometheusExporter.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
           {{- if $securityContext := (default .Values.initContainers.securityContext .Values.prometheusExporter.securityContext) }}
           securityContext:
@@ -194,7 +194,7 @@ spec:
       {{- end }}
       {{- if .Values.plugins.install }}
         - name: install-plugins
-          image: {{ default "curlimages/curl:7.76.1" .Values.plugins.image }}
+          image: {{ default "curlimages/curl:8.1.2" .Values.plugins.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
           command: ["sh",
             "-e",


### PR DESCRIPTION
- fixing 4 critical CVE's
- update curl v8.1.1

Please ensure your pull request adheres to the following guidelines:
- [ ] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`

curl v7.76.1 has the following critical CVE's

- https://avd.aquasec.com/nvd/cve-2021-36159
- https://avd.aquasec.com/nvd/cve-2022-37434
- https://avd.aquasec.com/nvd/cve-2021-3711
- https://avd.aquasec.com/nvd/cve-2021-3711