### PR TITLE
Add PDB for sonarqube helm chart

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [10.1.1]
+* Add PodDisruptionBudget
+
 ## [10.1.0]
 * Update SonarQube to 10.1.0
 * Support Kubernetes v1.27 while dropping v1.23

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -175,3 +175,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "common.capabilities.policy.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sonarqube/templates/podDistributionBudget.yaml
+++ b/charts/sonarqube/templates/podDistributionBudget.yaml
@@ -1,0 +1,17 @@
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "sonarqube.fullname" . }}-search
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+{{- with .Values.searchNodes.podDistributionBudget }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "sonarqube.name" . }}
+      release: {{ .Release.Name }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -278,6 +278,10 @@ prometheusMonitoring:
     # Name of the label on target services that prometheus uses as job name
     # jobLabel: ""
 
+podDistributionBudget:
+  minAvailable: 0
+  # maxUnavailable: 1
+
 # List of plugins to install.
 # For example:
 # plugins:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`

Problem : Cluster autoscaler or Karpenter consider that the Sonarqube pod can be evicted (in case of an underutilized node for example), which can cause application downtime as this chart does not deploy an highly available sonarqube.

Solution : allow to setup a PodDisruptionBudget to block the eviction of the pod.