### PR TITLE
Add a possibility to adjust the Helm hook phase for admin job

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [10.3.0]
+* Update SonarQube to 10.3.0
+* Add a possibility to adjust the Helm hook phase for admin job
+
 ## [10.2.0]
 * Update Chart's version to 10.2.0
 

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [10.3.0]
 * Update SonarQube to 10.3.0
 * Add a possibility to adjust the Helm hook phase for admin job
+* Add change awareness to "change admin password hook"
 
 ## [10.2.0]
 * Update Chart's version to 10.2.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 10.2.0
+version: 10.3.0
 appVersion: 10.1.0
 keywords:
   - coverage
@@ -26,7 +26,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 10.2.0"
+      description: "Update Chart's version to 10.3.0"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -446,8 +446,10 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `account.sonarWebContext` | SonarQube web context for Admin hook | `nil` |
 | `curlContainerImage` | Curl container image | `curlimages/curl:latest` |
 | `adminJobAnnotations` | Custom annotations for admin hook Job | `{}` |
+| `adminJobHelmHook` | Custom Helm hook phase for admin hook Job | `post-install` |
 | `terminationGracePeriodSeconds` | Configuration of `terminationGracePeriodSeconds` | `60` |
 
+To set the appropriate Helm hook phase this overview helps [Helm - The Available Hooks](https://helm.sh/docs/topics/charts_hooks/#the-available-hooks)
 
 You can also configure values for the PostgreSQL database via the Postgresql [Chart](https://hub.helm.sh/charts/bitnami/postgresql)
 

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -29,6 +29,10 @@ spec:
       {{- range $key, $value := .Values.service.labels }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+      {{- if .Values.account.adminPassword }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-admin.yaml") . | sha256sum }}
+      {{- end }}
     spec:
       restartPolicy: OnFailure
       {{- if or .Values.ApplicationNodes.image.pullSecrets .Values.ApplicationNodes.image.pullSecret }}

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -13,7 +13,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": {{ default "post-install" .Values.adminJobHelmHook }}
     "helm.sh/hook-delete-policy": hook-succeeded
   {{- range $key, $value := .Values.adminJobAnnotations }}
     {{ $key }}: {{ $value | quote }}

--- a/charts/sonarqube-dce/templates/secret-admin.yaml
+++ b/charts/sonarqube-dce/templates/secret-admin.yaml
@@ -96,3 +96,21 @@ data:
   SONAR_CLUSTER_SEARCH_PASSWORD: {{ .Values.searchNodes.searchAuthentication.userPassword | b64enc | quote }}
 {{- end }}
 {{- end }}
+---
+{{- if .Values.account }}
+{{- if .Values.account.adminPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sonarqube.fullname" . }}-admin-password
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+stringData:
+  password: {{ .Values.account.adminPassword | urlquery | quote }}
+  currentPassword: {{ default "admin" .Values.account.currentAdminPassword | urlquery | quote }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -600,6 +600,7 @@ extraConfig:
 #       memory: 128Mi
 # curlContainerImage: curlimages/curl:latest
 # adminJobAnnotations: {}
+# adminJobHelmHook: post-install
 # sonarWebContext: /
 
 terminationGracePeriodSeconds: 60

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [10.3.0]
+* Update SonarQube to 10.3.0
+* Add a possibility to adjust the Helm hook phase for admin job
+
 ## [10.2.0]
 * Update Chart's version to 10.2.0
 

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [10.3.0]
 * Update SonarQube to 10.3.0
 * Add a possibility to adjust the Helm hook phase for admin job
+* Add change awareness to "change admin password hook"
 
 ## [10.2.0]
 * Update Chart's version to 10.2.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 10.2.0
+version: 10.3.0
 appVersion: 10.1.0
 keywords:
   - coverage
@@ -31,7 +31,7 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 10.2.0"
+      description: "Update Chart's version to 10.3.0"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -442,7 +442,10 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `account.securityContext` | SecurityContext for change-password-hook | `{}` |
 | `curlContainerImage` | Curl container image | `curlimages/curl:latest` |
 | `adminJobAnnotations` | Custom annotations for admin hook Job | `{}` |
+| `adminJobHelmHook` | Custom Helm hook phase for admin hook Job | `post-install` |
 | `terminationGracePeriodSeconds` | Configuration of `terminationGracePeriodSeconds` | `60` |
+
+To set the appropriate Helm hook phase this overview helps [Helm - The Available Hooks](https://helm.sh/docs/topics/charts_hooks/#the-available-hooks)
 
 You can also configure values for the PostgreSQL database via the Postgresql [Chart](https://hub.helm.sh/charts/bitnami/postgresql)
 

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -29,6 +29,10 @@ spec:
       {{- range $key, $value := .Values.service.labels }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+      {{- if .Values.account.adminPassword }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-admin.yaml") . | sha256sum }}
+      {{- end }}
     spec:
       restartPolicy: OnFailure
       {{- if or .Values.image.pullSecrets .Values.image.pullSecret }}

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -13,7 +13,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": {{ default "post-install" .Values.adminJobHelmHook }}
     "helm.sh/hook-delete-policy": hook-succeeded
   {{- range $key, $value := .Values.adminJobAnnotations }}
     {{ $key }}: {{ $value | quote }}

--- a/charts/sonarqube/templates/secret-admin.yaml
+++ b/charts/sonarqube/templates/secret-admin.yaml
@@ -1,0 +1,18 @@
+---
+{{- if .Values.account }}
+{{- if .Values.account.adminPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sonarqube.fullname" . }}-admin-password
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+stringData:
+  password: {{ .Values.account.adminPassword | urlquery | quote }}
+  currentPassword: {{ default "admin" .Values.account.currentAdminPassword | urlquery | quote }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -44,21 +44,3 @@ type: Opaque
 data:
   SONAR_WEB_SYSTEMPASSCODE: {{ .Values.monitoringPasscode | b64enc | quote }}
 {{- end }}
----
-{{- if .Values.account }}
-{{- if .Values.account.adminPassword }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "sonarqube.fullname" . }}-admin-password
-  labels:
-    app: {{ template "sonarqube.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-type: Opaque
-stringData:
-  password: {{ .Values.account.adminPassword | urlquery | quote }}
-  currentPassword: {{ default "admin" .Values.account.currentAdminPassword | urlquery | quote }}
-{{- end }}
-{{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -534,6 +534,7 @@ extraConfig:
 #       memory: 128Mi
 # curlContainerImage: curlimages/curl:latest
 # adminJobAnnotations: {}
+# adminJobHelmHook: post-install
 # sonarWebContext: /
 
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
The exact value of this annotation is configured using the Helm values file (Values). The default value is "post-install", but it can be overridden via .Values.adminJobHelmHook.

We need this because we roll out the helmet map in a CI/CD pipeline and always use Helm upgrade here. If we want to change the admin password now, we can't implement that with the "post install". The Helm release would then have to be deleted and reinstalled. But if we change the hook to "post-upgrade", the job will be created even though the version was already installed.

If the password was set in the past, this is not a problem for the job, as it simply would not be authorized (HTTP 401) to change the password. However, the curl command will still exit with "exit 0". 

However, if you want to change the password, you must always adjust "currentAdminPassword" and "adminPassword" so that the job is actually authorized to change the password.