### PR TITLE
[NO JIRA] Remove strict check on version bumps

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -58,8 +58,8 @@ chart_testing_task:
   wait_for_kind_script:
     - secs=3600; endTime=$(( $(date +%s) + secs )); while [[ -n "$(kubectl cluster-info --context kind-kind 2>&1 > /dev/null)" ]] || [ $(date +%s) -gt $endTime ]; do sleep 5; done
   script:
-    - ct lint --config test.yaml --target-branch release/lts/9.9
-    - ct install --config test.yaml
+    - ct lint --config test.yaml --all
+    - ct install --config test.yaml --all
   artifacthub_lint_script:
     - ah lint
 


### PR DESCRIPTION
We adopt a new release policy where every change does not require a bump on the chart's version. This PR removes an old check and align the LTS policy with what we follow on the main development stream.