### PR TITLE
fix label issue with digest images

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [10.3.0]
 * Update Chart's version to 10.3.0
 * Update default images to the latest versions
+* Fix crash when adding a digests to the image tag
 
 ## [10.2.0]
 * Update SonarQube to 10.2.0

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: {{ template "sonarqube.fullname" . }}
-    app.kubernetes.io/version: {{ tpl .Values.image.tag . | quote }}
+    app.kubernetes.io/version: {{ tpl .Values.image.tag . | regexReplaceAll "\\W+" .Release.Name "_" | trunc 63 | trimSuffix "-" | quote }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: {{ template "sonarqube.fullname" . }}
-    app.kubernetes.io/version: {{ tpl .Values.image.tag . | regexReplaceAll "\\W+" .Release.Name "_" | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version:  {{ regexReplaceAll "\\W+" (tpl .Values.image.tag .) "_" | trunc 63 | trimSuffix "-" | quote }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:


### PR DESCRIPTION
When tring to set a digest to the image tag the helm chart fails with the following error:

`Upgrade "sonarqube" failed: cannot patch "sonarqube-sonarqube" with kind Deployment: Deployment.apps "sonarqube-sonarqube" is invalid: [metadata.labels: Invalid value: "lts-community@sha256:3596d14feb065a31ce84cef60cc3ecfb7b47233ef860fd85c0d4e465f676c9f7": must be no more than 63 characters, metadata.labels: Invalid value: "lts-community@sha256:3596d14feb065a31ce84cef60cc3ecfb7b47233ef860fd85c0d4e465f676c9f7": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]`

This change escapes all non word characters (especially @ in this case) and truncates the label to 63 characters.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`