### PR TITLE
Update default memory resources to provide for the Enterprise Edition

### DIFF
--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -332,16 +332,19 @@ monitoringPasscode: "define_it"
 # Set annotations for pods
 annotations: {}
 
-## We usually don't make specific ressource recommandations, as they are heavily dependend on
-## The usage of SonarQube and the surrounding infrastructure.
-## Adjust these values to your needs, but make sure that the memory limit is never under 4 GB
+## We usually don't make specific resource recommendations, as they are heavily dependent on
+## the usage of SonarQube and the surrounding infrastructure.
+## Adjust these values to your needs.
+## If you did not change the individual JVM heap size settings (environment variables),
+## then the memory limit should never be under 4 GB for the Community and Developer Editions,
+## 6 GB for the Enterprise Edition.
 resources:
   limits:
     cpu: 800m
-    memory: 4Gi
+    memory: 6Gi
   requests:
     cpu: 400m
-    memory: 2Gi
+    memory: 3Gi
 
 persistence:
   enabled: false


### PR DESCRIPTION
The same Helm Chart is used to deploy all single pod SonarQube editions, and while Community and Developer run well on a 4 GB RAM pod, it's not the case for the Enterprise Edition which requires 6 GB.

Please ensure your pull request adheres to the following guidelines:
- [ ] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`