### PR TITLE
Run the initSysctl initcontainer as root

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [10.4.0]
 * Update Chart's version to 10.4.0
 * Improve the description of deprecated `ApplicationNodes.jvmOpts` and `ApplicationNodes.jvmCeOpts` values
+* Run the initSysctl init-container as root to prevent 'permission denied' issues
 
 ## [10.3.0]
 * Upgrade SonarQube to 10.3.0
@@ -239,7 +240,7 @@ All changes to this chart will be documented in this file.
 * added link to community support forum
 
 ## [0.1.6]
-* fixed wrong scc user reference if name was explicitly set 
+* fixed wrong scc user reference if name was explicitly set
 
 ## [0.1.5]
 * fixed serviceaccount logic

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -31,6 +31,8 @@ annotations:
       description: "Update Chart's version to 10.4.0"
     - kind: fixed
       description: "Improve the description of deprecated 'ApplicationNodes.jvmOpts' and 'ApplicationNodes.jvmCeOpts' values"
+    - kind: fixed
+      description: "Run the initSysctl init-container as root to prevent 'permission denied' issues"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -461,6 +461,8 @@ initSysctl:
   securityContext:
     # Compatible with podSecurity standard privileged
     privileged: true
+    # if run without root permissions, error "sysctl: permission denied on key xxx, ignoring"
+    runAsUser: 0
   # resources: {}
 
 initFs:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [10.4.0]
 * Update Chart's version to 10.4.0
 * Improve the description of deprecated `jvmOpts` and `jvmCeOpts` values
+* Run the initSysctl init-container as root to prevent 'permission denied' issues
 
 ## [10.3.0]
 * Upgrade SonarQube to 10.3.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -36,6 +36,8 @@ annotations:
       description: "Update Chart's version to 10.4.0"
     - kind: fixed
       description: "Improve the description of deprecated 'jvmOpts' and 'jvmCeOpts' values"
+    - kind: fixed
+      description: "Run the initSysctl init-container as root to prevent 'permission denied' issues"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -243,6 +243,8 @@ initSysctl:
   securityContext:
     # Compatible with podSecurity standard privileged
     privileged: true
+    # if run without root permissions, error "sysctl: permission denied on key xxx, ignoring"
+    runAsUser: 0
   # resources: {}
 
 # This should not be required anymore, used to chown/chmod folder created by faulty CSI driver that are not applying properly POSIX fsgroup.


### PR DESCRIPTION
Kubernetes version: v1.26.6
When not using the root user, the initSysctl throws an error: 
```sysctl: permission denied on key "vm.max_map_count", ignoring```

After this, elasticSearch refuses to start:
```bootstrap check failure [1] of [1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]```

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`