### PR TITLE
Fix: sysctl permission error

### DIFF
--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -245,6 +245,7 @@ initSysctl:
     privileged: true
     # if run without root permissions, error "sysctl: permission denied on key xxx, ignoring"
     runAsUser: 0
+    runAsGroup: 0
   # resources: {}
 
 # This should not be required anymore, used to chown/chmod folder created by faulty CSI driver that are not applying properly POSIX fsgroup.


### PR DESCRIPTION
`runAsGroup: 0` is also required to prevent "sysctl: permission denied on key xxx, ignoring" error

Please ensure your pull request adheres to the following guidelines:
- [ ] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`