### PR TITLE
fix: PodMonitor doesn't honor sonarWebContext and fails to monitor SonarQube

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -13,6 +13,7 @@ All changes to this chart will be documented in this file.
 * Make `ephemeral-storage` resource's limits and requests configurable for the SonarQube App and Search containers
 * Set memory and cpu limits for the test container
 * Fix `searchAuthentication` probes failure by enforcing basic auth on wget
+* Take `sonarWebContext` into account for the `PodMonitor` path
 
 ## [10.4.0]
 * Upgrade SonarQube to 10.4.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -49,6 +49,8 @@ annotations:
       description: "Set memory and cpu limits for the test container"
     - kind: fixed
       description: "Fix `searchAuthentication` probes failure by enforcing basic auth on wget"
+    - kind: fixed
+      description: "Take `sonarWebContext` into account for the `PodMonitor` path"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/prometheus-podmonitor.yaml
+++ b/charts/sonarqube-dce/templates/prometheus-podmonitor.yaml
@@ -18,7 +18,7 @@ spec:
       app: {{ template "sonarqube.name" . }}
   podMetricsEndpoints:
   - port: http
-    path: /api/monitoring/metrics
+    path: {{ include "sonarqube.webcontext" . }}api/monitoring/metrics
     scheme: http
     {{- if .Values.ApplicationNodes.prometheusMonitoring.podMonitor.interval }}
     interval: {{ .Values.ApplicationNodes.prometheusMonitoring.podMonitor.interval }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file.
 * Update default `resources` values matching better default Xmx and Xms of the SonarQube processes.
 * Make `ephemeral-storage` resource's limits and requests configurable for the SonarQube container
 * Set memory and cpu limits for the test container
+* Take `sonarWebContext` into account for the `PodMonitor` path
 
 ## [10.4.0]
 * Upgrade SonarQube to 10.4.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -44,6 +44,8 @@ annotations:
       description: "Make 'ephemeral-storage' resource's limits and requests configurable for the SonarQube container"
     - kind: changed
       description: "Set memory and cpu limits for the test container"
+    - kind: fixed
+      description: "Take `sonarWebContext` into account for the `PodMonitor` path"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/prometheus-podmonitor.yaml
+++ b/charts/sonarqube/templates/prometheus-podmonitor.yaml
@@ -18,7 +18,7 @@ spec:
       app: {{ template "sonarqube.name" . }}
   podMetricsEndpoints:
   - port: http
-    path: /api/monitoring/metrics
+    path: {{ include "sonarqube.webcontext" . }}api/monitoring/metrics
     scheme: http
     {{- if .Values.prometheusMonitoring.podMonitor.interval }}
     interval: {{ .Values.prometheusMonitoring.podMonitor.interval }}


### PR DESCRIPTION
Hello,

Currently if you set the `sonarWebContext` and enable the `PodMonitor` via `prometheusMonitoring.podMonitor.enabled`, then it will fail to monitor, this is because while it is hard coded to poll `/api/monitoring/metrics`, SonarQube is listening at (as an example) `/sonarqube/api/monitoring/metrics`.

**Testing:**
To be done still.

Please ensure your pull request adheres to the following guidelines:
- [X] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`