### PR TITLE
SONAR-21969 remove outdated readme doc about persistency

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -13,6 +13,7 @@ All changes to this chart will be documented in this file.
 * Make `ephemeral-storage` resource's limits and requests configurable for the SonarQube App and Search containers
 * Set memory and cpu limits for the test container
 * Fix `searchAuthentication` probes failure by enforcing basic auth on wget
+* Remove outdated doc about persistency
 
 ## [10.4.0]
 * Upgrade SonarQube to 10.4.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -49,6 +49,8 @@ annotations:
       description: "Set memory and cpu limits for the test container"
     - kind: fixed
       description: "Fix `searchAuthentication` probes failure by enforcing basic auth on wget"
+    - kind: removed
+      description: "Remove outdated doc about persistency"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -407,20 +407,6 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `initFs.image`                      | InitFS container image                                    | `ApplicationNodes.image`                                               |
 | `initFs.securityContext.privileged` | InitFS container needs to run privileged                  | `true`                                                                 |
 
-### Persistence
-
-| Parameter                   | Description                                                                  | Default         |
-| --------------------------- | ---------------------------------------------------------------------------- | --------------- |
-| `persistence.enabled`       | Flag for enabling persistent storage                                         | `false`         |
-| `persistence.annotations`   | Kubernetes pvc annotations                                                   | `{}`            |
-| `persistence.existingClaim` | Do not create a new PVC but use this one                                     | `None`          |
-| `persistence.storageClass`  | Storage class to be used                                                     | `""`            |
-| `persistence.accessMode`    | Volumes access mode to be set                                                | `ReadWriteOnce` |
-| `persistence.size`          | Size of the volume                                                           | `5Gi`           |
-| `persistence.volumes`       | Specify extra volumes. Refer to ".spec.volumes" specification                | `[]`            |
-| `persistence.mounts`        | Specify extra mounts. Refer to ".spec.containers.volumeMounts" specification | `[]`            |
-| `emptyDir`                  | Configuration of resources for `emptyDir`                                    | `{}`            |
-
 ### SonarQube Specific
 
 | Parameter                      | Description                                                                             | Default          |


### PR DESCRIPTION
This part of the doc is actually a leftover from the fork between standard and dce. 

The correct section is already described under SearchNodes.persistency