### PR TITLE
Restore passing .Values.env from secret

### DIFF
--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -230,10 +230,7 @@ spec:
           resources:
 {{ toYaml (default .Values.ApplicationNodes.resources .Values.resource) | indent 12 }}
           env:
-          {{- range (include "sonarqube.combined_app_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_app_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
             - name: SONAR_HELM_CHART_VERSION
               value: {{ .Chart.Version | replace "+" "_" }}
             - name: SONAR_LOG_JSONOUTPUT

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -98,10 +98,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
       {{- if or .Values.initSysctl.enabled .Values.elasticsearch.configureNode }}
         - name: init-sysctl
@@ -120,10 +117,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
 
       {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
@@ -164,10 +158,7 @@ spec:
           resources:
 {{ toYaml .Values.initContainers.resources | indent 12 }}
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}  
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
 
       {{- if .Values.prometheusExporter.enabled }}
@@ -193,10 +184,7 @@ spec:
               value: {{ default "" .Values.prometheusExporter.httpsProxy }}
             - name: no_proxy
               value: {{ default "" .Values.prometheusExporter.noProxy }}
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
       {{- if .Values.plugins.install }}
         - name: install-plugins
@@ -228,10 +216,7 @@ spec:
               value: {{ default "" .Values.plugins.httpsProxy }}
             - name: no_proxy
               value: {{ default "" .Values.plugins.noProxy }}
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
     {{- end }}
       containers:
       {{- if .Values.extraContainers }}
@@ -255,10 +240,7 @@ spec:
           resources:
 {{ toYaml (default .Values.resources .Values.resource) | indent 12 }}
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
             - name: SONAR_HELM_CHART_VERSION
               value: {{ .Chart.Version | replace "+" "_" }}
             - name: SONAR_JDBC_PASSWORD

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -97,10 +97,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
       {{- if or .Values.initSysctl.enabled .Values.elasticsearch.configureNode }}
         - name: init-sysctl
@@ -119,10 +116,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
 
       {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
@@ -163,10 +157,7 @@ spec:
           resources:
 {{ toYaml .Values.initContainers.resources | indent 12 }}
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
 
       {{- if .Values.prometheusExporter.enabled }}
@@ -192,10 +183,7 @@ spec:
               value: {{ default "" .Values.prometheusExporter.httpsProxy }}
             - name: no_proxy
               value: {{ default "" .Values.prometheusExporter.noProxy }}
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
       {{- if and .Values.persistence.enabled .Values.initFs.enabled }}
         - name: init-fs
@@ -272,10 +260,7 @@ spec:
               value: {{ default "" .Values.plugins.httpsProxy }}
             - name: no_proxy
               value: {{ default "" .Values.plugins.noProxy }}
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
       {{- end }}
       containers:
       {{- if .Values.extraContainers }}
@@ -299,10 +284,7 @@ spec:
           resources:
 {{ toYaml (default .Values.resources .Values.resource) | indent 12 }}
           env:
-          {{- range (include "sonarqube.combined_env" . | fromJsonArray)  }}
-            - name: {{ .name }}
-              value: {{ .value | quote}}
-          {{- end }}
+          {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 12 }}
             - name: SONAR_HELM_CHART_VERSION
               value: {{ .Chart.Version | replace "+" "_" }}
             - name: SONAR_JDBC_PASSWORD


### PR DESCRIPTION
This PR https://github.com/SonarSource/helm-chart-sonarqube/pull/464 introduced some regression due to the filtering and effective env vars.

The PR assume that all `.Values.env` are using value but ignore environment mounted from secret.

See https://community.sonarsource.com/t/upgrade-from-10-4-1-to-10-5-0-broke-ldap-authentication/113722

I know the chart provide a `extraConfig.secrets` but this also assume there is a 1-1 mapping with secret key and env var. This is not convenient at all when providing several LDAP server and oblige to update the secret when adding/removing server configuration. This also oblige to duplicate value on the secret.

I've tested both deployment/statefulset with values

```
env:
  - name: SONAR_WEB_CONTEXT
    value: /path
  - name: FOOBAR
    valueFrom:
      secretKeyRef:
        name: "sonarqube-ldap"
        key: BARFOO
  - name: SONAR_CE_JAVAOPTS
    value: -Xmx1024m
  - name: SONAR_WEB_JAVAOPTS
    value: -Xmx512m
```

And ensured it create following env vars for both sonarqube and sonarqube-dce

```
...
env:
  - name: FOOBAR
    valueFrom:
      secretKeyRef:
        key: BARFOO
        name: sonarqube-ldap
  - name: SONAR_WEB_CONTEXT
    value: /path/
  - name: SONAR_WEB_JAVAOPTS
    value: -Xmx512m
  - name: SONAR_CE_JAVAOPTS
    value: -Xmx1024m
  - name: SONAR_HELM_CHART_VERSION
    value: 10.6.0
....
```


Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`

I didn't update the changelog because I don't know if you are planning a 5.0.1 release or not