### PR TITLE
fix: postgresql chart's repository link (LTS)

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.0.6]
+* Fix the postgresql chart's repository link
+
 ## [7.0.5]
 * Update SonarQube to 9.9.5
 

--- a/charts/sonarqube-dce/Chart.lock
+++ b/charts/sonarqube-dce/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 10.15.0
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.0.13
-digest: sha256:eb84d38cb9cc5c49b8828240213ff53c25bb5b6f5101f88671a40e08dd0ba049
-generated: "2022-12-20T14:38:00.244884+01:00"
+digest: sha256:ffbc50d9979559779f64801bb6e4d2e8e6371fd3cca4d8c20a97af2bf2233629
+generated: "2024-05-21T17:45:55.855164+02:00"

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -40,7 +40,7 @@ annotations:
 dependencies:
   - name: postgresql
     version: 10.15.0
-    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: ingress-nginx
     version: 4.0.13

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.0.6]
+* Fix the postgresql chart's repository link
+
 ## [8.0.5]
 * Update SonarQube to 9.9.5
 

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [8.0.6]
 * Fix the postgresql chart's repository link
+* Fix `startupProbe.sonarWebContext` use
 
 ## [8.0.5]
 * Update SonarQube to 9.9.5

--- a/charts/sonarqube/Chart.lock
+++ b/charts/sonarqube/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 10.15.0
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.0.13
-digest: sha256:eb84d38cb9cc5c49b8828240213ff53c25bb5b6f5101f88671a40e08dd0ba049
-generated: "2022-12-20T14:37:33.067762+01:00"
+digest: sha256:ffbc50d9979559779f64801bb6e4d2e8e6371fd3cca4d8c20a97af2bf2233629
+generated: "2024-05-21T17:45:05.532691+02:00"

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.0.5
+version: 8.0.6
 appVersion: 9.9.5
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -38,7 +38,7 @@ annotations:
 dependencies:
   - name: postgresql
     version: 10.15.0
-    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: ingress-nginx
     version: 4.0.13

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -353,7 +353,7 @@ spec:
           startupProbe:
             httpGet:
               scheme: HTTP
-              path: {{ .Values.readinessProbe.sonarWebContext }}api/system/status
+              path: {{ .Values.startupProbe.sonarWebContext }}api/system/status
               port: http
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}


### PR DESCRIPTION
Change postgres chart's repository link to 
```
https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
```
as `https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami` is no longer available

> [!NOTE]
> Based on [SONAR-22190 Fix the postgresql chart's repository link](https://github.com/SonarSource/helm-chart-sonarqube/commit/7bf56c6691d5377d50fd219f29971ce8fb690b0a) on `master`