### PR TITLE
Update helm chart repo path in sources for each Chart

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to this chart will be documented in this file.
 * Support Kubernetes v1.30
 * Upgrade ingress-nginx dependency to 4.10.1
 * Deprecate `jdbcOverwrite.enable` in favor of `jdbcOverwrite.enabled` 
+* Update helm chart repo path in sources for each Chart
 
 ## [10.6.0]
 * Upgrade SonarQube to 10.6.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 home: https://www.sonarqube.org/
 icon: https://raw.githubusercontent.com/SonarSource/sonarqube-static-resources/master/helm/SonarQubeLogo.svg
 sources:
-  - https://github.com/SonarSource/helm-chart-sonarqube
+  - https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube-dce
   - https://github.com/SonarSource/docker-sonarqube
   - https://github.com/SonarSource/sonarqube
 kubeVersion: '>= 1.24.0-0'
@@ -35,6 +35,8 @@ annotations:
       description: "Upgrade ingress-nginx dependency to 4.10.1"
     - kind: changed
       description: "Deprecate `jdbcOverwrite.enable` in favor of `jdbcOverwrite.enabled`"
+    - kind: changed
+      description: "Update helm chart repo path in sources"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file.
 * Deprecate `jdbcOverwrite.enable` in favor of `jdbcOverwrite.enabled`
 * Fix regression on env valuesFrom in the new STS template
 * Fix a typo in the new common STS template
+* Update helm chart repo path in sources for each Chart
 
 ## [10.6.0]
 * Update SonarQube to 10.6.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 home: https://www.sonarqube.org/
 icon: https://raw.githubusercontent.com/SonarSource/sonarqube-static-resources/master/helm/SonarQubeLogo.svg
 sources:
-  - https://github.com/SonarSource/helm-chart-sonarqube
+  - https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   - https://github.com/SonarSource/docker-sonarqube
   - https://github.com/SonarSource/sonarqube
 kubeVersion: '>= 1.24.0-0'
@@ -44,6 +44,8 @@ annotations:
       description: "Fix regression on env valuesFrom in the new STS template"
     - kind: fixed
       description: "Fix a typo in the new common STS template"
+    - kind: changed
+      description: "Update helm chart repo path in sources"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube


### PR DESCRIPTION
This PR is an update of this previous one  https://github.com/SonarSource/helm-chart-sonarqube/pull/308 (merged here https://github.com/SonarSource/helm-chart-sonarqube/pull/315) because the compare links in PR don't work as this repository is not for one Chart only but for two different Charts.