### PR TITLE
NO-JIRA make automountServiceAccountToken in _pod.tpl configurable

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [10.7.1]
+* Update _pod.tpl to make automountServiceAccountToken configurable
+
 ## [10.7.0]
 * Update Chart's version to 10.7.0
 * Support Kubernetes v1.30

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -33,7 +33,7 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update _pod.tpl to make automountServiceAccountToken configuratable"
+      description: "Update _pod.tpl to make automountServiceAccountToken configurable"
     - kind: changed
       description: "Update Chart's version to 10.7.0"
     - kind: changed

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -33,6 +33,8 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
+      description: "Update _pod.tpl to make automountServiceAccountToken configuratable"
+    - kind: changed
       description: "Update Chart's version to 10.7.0"
     - kind: changed
       description: "Support Kubernetes v1.30"

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -19,7 +19,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  automountServiceAccountToken: false
+  automountServiceAccountToken: {{ .Values.podSpec.automountServiceAccountToken }}
   {{- with .Values.schedulerName }}
   schedulerName: {{ . }}
   {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -21,6 +21,10 @@ deploymentStrategy: {}
 ##
 # schedulerName:
 
+# 
+podSpec:
+  automountServiceAccountToken: false
+
 ## Is this deployment for OpenShift? If so, we help with SCCs
 OpenShift:
   enabled: false


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`

Our setup of SonarQube is using CloudSQL and the authentication is going via CloudSQL Proxy which needs automountServiceAccountToken to be set to true in order ot be able to authenticate via IAM Service Account. 