### PR TITLE
Update helm chart repo path in sources for each Chart

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -20,6 +20,7 @@ All changes to this chart will be documented in this file.
 * Document the upgrade process when autoscaling is enabled
 * Fix openshift change-admin-password-hook Job SecurityContext failure
 * Support SONAR_OPENSHIFT telemetry env_var
+* Update helm chart repo path in sources for each Chart
 
 ## [10.6.0]
 * Upgrade SonarQube to 10.6.0

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -20,7 +20,7 @@ All changes to this chart will be documented in this file.
 * Document the upgrade process when autoscaling is enabled
 * Fix openshift change-admin-password-hook Job SecurityContext failure
 * Support SONAR_OPENSHIFT telemetry env_var
-* Update helm chart repo path in sources for each Chart
+* Update helm chart repo path in sources
 
 ## [10.6.0]
 * Upgrade SonarQube to 10.6.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 home: https://www.sonarqube.org/
 icon: https://raw.githubusercontent.com/SonarSource/sonarqube-static-resources/master/helm/SonarQubeLogo.svg
 sources:
-  - https://github.com/SonarSource/helm-chart-sonarqube
+  - https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube-dce
   - https://github.com/SonarSource/docker-sonarqube
   - https://github.com/SonarSource/sonarqube
 kubeVersion: '>= 1.24.0-0'
@@ -65,6 +65,8 @@ annotations:
       description: "Fix openshift change-admin-password-hook Job SecurityContext failure"
     - kind: added
       description: "Support SONAR_OPENSHIFT telemetry env_var"
+    - kind: changed
+      description: "Update helm chart repo path in sources"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -21,6 +21,7 @@ All changes to this chart will be documented in this file.
 * Changed default value for caCerts.image
 * Fix openshift change-admin-password-hook Job SecurityContext failure
 * Support SONAR_OPENSHIFT telemetry env_var
+* Update helm chart repo path in sources for each Chart
 
 ## [10.6.0]
 * Update SonarQube to 10.6.0

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -21,7 +21,7 @@ All changes to this chart will be documented in this file.
 * Changed default value for caCerts.image
 * Fix openshift change-admin-password-hook Job SecurityContext failure
 * Support SONAR_OPENSHIFT telemetry env_var
-* Update helm chart repo path in sources for each Chart
+* Update helm chart repo path in sources
 
 ## [10.6.0]
 * Update SonarQube to 10.6.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 home: https://www.sonarqube.org/
 icon: https://raw.githubusercontent.com/SonarSource/sonarqube-static-resources/master/helm/SonarQubeLogo.svg
 sources:
-  - https://github.com/SonarSource/helm-chart-sonarqube
+  - https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   - https://github.com/SonarSource/docker-sonarqube
   - https://github.com/SonarSource/sonarqube
 kubeVersion: '>= 1.24.0-0'
@@ -70,6 +70,8 @@ annotations:
       description: "Fix openshift change-admin-password-hook Job SecurityContext failure"
     - kind: added
       description: "Support SONAR_OPENSHIFT telemetry env_var"
+    - kind: changed
+      description: "Update helm chart repo path in sources"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube


### PR DESCRIPTION
This PR is a reopening of reopening of https://github.com/SonarSource/helm-chart-sonarqube/pull/524. It is an update of this previous one https://github.com/SonarSource/helm-chart-sonarqube/pull/308 (merged here https://github.com/SonarSource/helm-chart-sonarqube/pull/315) because the compare links in PR don't work as this repository is not for one Chart only but for two different Charts.

