### PR TITLE
Update PostgreSQL chart to fix CVE-2024-7348

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [7.0.7]
+* `bitnami/postgresql` from 10.15.0 to 15.5.x to fix [CVE-2024-7348: PostgreSQL relation replacement during pg_dump executes arbitrary SQL](https://www.postgresql.org/support/security/CVE-2024-7348/)
+
 ## [7.0.6]
 * Update SonarQube to 9.9.6
 

--- a/charts/sonarqube-dce/Chart.lock
+++ b/charts/sonarqube-dce/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
-  version: 10.15.0
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 15.5.36
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.0.13
-digest: sha256:eb84d38cb9cc5c49b8828240213ff53c25bb5b6f5101f88671a40e08dd0ba049
-generated: "2022-12-20T14:38:00.244884+01:00"
+digest: sha256:268cd64bc1d4dbc8ce2eca25ead1eea4e4b09a06d4944e2913eab52bc1d288a8
+generated: "2024-09-27T14:27:03.3839277+07:00"

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -41,8 +41,8 @@ annotations:
       image: sonarqube:9.9.6-datacenter-search
 dependencies:
   - name: postgresql
-    version: 10.15.0
-    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+    version: 15.5.x
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: ingress-nginx
     version: 4.0.13

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -88,7 +88,7 @@ Determine the k8s secretKey contrining the JDBC password
   {{- if and .Values.postgresql.existingSecret .Values.postgresql.existingSecretPasswordKey -}}
   {{- .Values.postgresql.existingSecretPasswordKey -}}
   {{- else -}}
-  {{- "postgres-password" -}}
+  {{- "password" -}}
   {{- end -}}
 {{- else if .Values.jdbcOverwrite.enable -}}
   {{- if and .Values.jdbcOverwrite.jdbcSecretName .Values.jdbcOverwrite.jdbcSecretPasswordKey -}}

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -85,8 +85,8 @@ Determine the k8s secretKey contrining the JDBC password
 */}}
 {{- define "jdbc.secretPasswordKey" -}}
 {{- if .Values.postgresql.enabled -}}
-  {{- if and .Values.postgresql.existingSecret .Values.postgresql.existingSecretPasswordKey -}}
-  {{- .Values.postgresql.existingSecretPasswordKey -}}
+  {{- if and .Values.postgresql.auth.existingSecret .Values.postgresql.auth.secretKeys.userPasswordKey -}}
+  {{- .Values.postgresql.auth.secretKeys.userPasswordKey -}}
   {{- else -}}
   {{- "password" -}}
   {{- end -}}

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -88,7 +88,7 @@ Determine the k8s secretKey contrining the JDBC password
   {{- if and .Values.postgresql.existingSecret .Values.postgresql.existingSecretPasswordKey -}}
   {{- .Values.postgresql.existingSecretPasswordKey -}}
   {{- else -}}
-  {{- "postgresql-password" -}}
+  {{- "postgres-password" -}}
   {{- end -}}
 {{- else if .Values.jdbcOverwrite.enable -}}
   {{- if and .Values.jdbcOverwrite.jdbcSecretName .Values.jdbcOverwrite.jdbcSecretPasswordKey -}}

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -71,12 +71,12 @@ Determine the k8s secret containing the JDBC credentials
 Determine JDBC username
 */}}
 {{- define "jdbc.username" -}}
-{{- if and .Values.postgresql.enabled .Values.postgresql.postgresqlUsername -}}
-  {{- .Values.postgresql.postgresqlUsername | quote -}}
+{{- if and .Values.postgresql.enabled .Values.postgresql.auth.username -}}
+  {{- .Values.postgresql.auth.username | quote -}}
 {{- else if and .Values.jdbcOverwrite.enable .Values.jdbcOverwrite.jdbcUsername -}}
   {{- .Values.jdbcOverwrite.jdbcUsername | quote -}}
 {{- else -}}
-  {{- .Values.postgresql.postgresqlUsername -}}
+  {{- .Values.postgresql.auth.username -}}
 {{- end -}}
 {{- end -}}
 
@@ -108,7 +108,7 @@ Determine JDBC password if internal secret is used
 {{- if .Values.jdbcOverwrite.enable -}}
   {{- .Values.jdbcOverwrite.jdbcPassword | b64enc | quote -}}
 {{- else -}}
-  {{- .Values.postgresql.postgresqlPassword | b64enc | quote -}}
+  {{- .Values.postgresql.auth.password | b64enc | quote -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/sonarqube-dce/templates/jdbc-config.yaml
+++ b/charts/sonarqube-dce/templates/jdbc-config.yaml
@@ -11,6 +11,6 @@ data:
   SONAR_JDBC_USERNAME: {{ template "jdbc.username" . }}
 {{- if .Values.jdbcOverwrite.enable }}
   SONAR_JDBC_URL: {{ .Values.jdbcOverwrite.jdbcUrl | trim | quote }}
-{{- else if and .Values.postgresql.service.port .Values.postgresql.postgresqlDatabase }}
-  SONAR_JDBC_URL: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresqlDatabase -}}"
+{{- else if and .Values.postgresql.service.port .Values.postgresql.auth.database }}
+  SONAR_JDBC_URL: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.auth.database -}}"
 {{- end }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -460,9 +460,10 @@ postgresql:
   #
   # The bitnami chart enforces the key to be "postgresql-password". This value is only here for historic purposes
   # existingSecretPasswordKey: "postgresql-password"
-  postgresqlUsername: "sonarUser"
-  postgresqlPassword: "sonarPass"
-  postgresqlDatabase: "sonarDB"
+  auth:
+    username: "sonarUser"
+    password: "sonarPass"
+    database: "sonarDB"
   # Specify the TCP port that PostgreSQL should use
   service:
     port: 5432

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [8.0.7]
+* `bitnami/postgresql` from 10.15.0 to 15.5.x to fix [CVE-2024-7348: PostgreSQL relation replacement during pg_dump executes arbitrary SQL](https://www.postgresql.org/support/security/CVE-2024-7348/)
+
 ## [8.0.6]
 * Update SonarQube to 9.9.6
 

--- a/charts/sonarqube/Chart.lock
+++ b/charts/sonarqube/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
-  version: 10.15.0
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 15.5.32
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.0.13
-digest: sha256:eb84d38cb9cc5c49b8828240213ff53c25bb5b6f5101f88671a40e08dd0ba049
-generated: "2022-12-20T14:37:33.067762+01:00"
+digest: sha256:43b463db9a48566549714b283af318c9359f8298d7fb5e42ea1a6d7b23e38b96
+generated: "2024-09-23T16:20:17.8506403+07:00"

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube offers Code Quality and Code Security analysis for up to 27 languages. Find Bugs, Vulnerabilities, Security Hotspots and Code Smells throughout your workflow.
 type: application
-version: 8.0.6
+version: 8.0.7
 appVersion: 9.9.6
 keywords:
   - coverage
@@ -32,15 +32,15 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update SonarQube to 9.9.6"
-  artifacthub.io/containsSecurityUpdates: "false"
+      description: "Update bitnami/postgresql dependency chart from 10.15.0 to 15.5.x"
+  artifacthub.io/containsSecurityUpdates: "yes"
   artifacthub.io/images: |
     - name: sonarqube
       image: sonarqube:9.9.6-community
 dependencies:
   - name: postgresql
-    version: 10.15.0
-    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+    version: 15.5.x
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: ingress-nginx
     version: 4.0.13

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -76,10 +76,10 @@ Determine the k8s secretKey contrining the JDBC password
 */}}
 {{- define "jdbc.secretPasswordKey" -}}
 {{- if .Values.postgresql.enabled -}}
-  {{- if and .Values.postgresql.existingSecret .Values.postgresql.existingSecretPasswordKey -}}
-  {{- .Values.postgresql.existingSecretPasswordKey -}}
+  {{- if and .Values.postgresql.auth.existingSecret .Values.postgresql.auth.secretKeys.userPasswordKey -}}
+  {{- .Values.postgresql.auth.secretKeys.userPasswordKey -}}
   {{- else -}}
-  {{- "postgres-password" -}}
+  {{- "password" -}}
   {{- end -}}
 {{- else if .Values.jdbcOverwrite.enable -}}
   {{- if and .Values.jdbcOverwrite.jdbcSecretName .Values.jdbcOverwrite.jdbcSecretPasswordKey -}}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Determine the k8s secretKey contrining the JDBC password
   {{- if and .Values.postgresql.existingSecret .Values.postgresql.existingSecretPasswordKey -}}
   {{- .Values.postgresql.existingSecretPasswordKey -}}
   {{- else -}}
-  {{- "postgresql-password" -}}
+  {{- "postgres-password" -}}
   {{- end -}}
 {{- else if .Values.jdbcOverwrite.enable -}}
   {{- if and .Values.jdbcOverwrite.jdbcSecretName .Values.jdbcOverwrite.jdbcSecretPasswordKey -}}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -99,7 +99,7 @@ Determine JDBC password if internal secret is used
 {{- if .Values.jdbcOverwrite.enable -}}
   {{- .Values.jdbcOverwrite.jdbcPassword | b64enc | quote -}}
 {{- else -}}
-  {{- .Values.postgresql.postgresqlPassword | b64enc | quote -}}
+  {{- .Values.postgresql.auth.postgresPassword | b64enc | quote -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/sonarqube/templates/sonarqube-sts.yaml
+++ b/charts/sonarqube/templates/sonarqube-sts.yaml
@@ -343,7 +343,7 @@ spec:
                 # A Sonarqube container is considered ready if the status is UP, DB_MIGRATION_NEEDED or DB_MIGRATION_RUNNING
                 # status about migration are added to prevent the node to be kill while sonarqube is upgrading the database.
                 host="$(hostname -i || echo '127.0.0.1')"
-                if wget --proxy off -qO- http://${host}:{{ .Values.service.internalPort }}{{ .Values.readinessProbe.sonarWebContext }}api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'; then
+                if wget --no-proxy -qO- http://${host}:{{ .Values.service.internalPort }}{{ .Values.readinessProbe.sonarWebContext }}api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'; then
                 	exit 0
                 fi
                 exit 1

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -389,22 +389,6 @@ jdbcOverwrite:
 postgresql:
   # Enable to deploy the bitnami PostgreSQL chart
   enabled: true
-  ## postgresql Chart global settings
-  # global:
-  #   imageRegistry: ''
-  #   imagePullSecrets: ''
-  ## bitnami/postgres image tag
-  # image:
-  #   tag: 11.7.0-debian-10-r9
-  # existingSecret Name of existing secret to use for PostgreSQL passwords
-  # The secret has to contain the keys postgresql-password which is the password for postgresqlUsername when it is
-  # different of postgres, postgresql-postgres-password which will override postgresqlPassword,
-  # postgresql-replication-password which will override replication.password and postgresql-ldap-password which will be
-  # used to authenticate on LDAP. The value is evaluated as a template.
-  # existingSecret: ""
-  #
-  # The bitnami chart enforces the key to be "postgresql-password". This value is only here for historic purposes
-  # existingSecretPasswordKey: "postgresql-password"
   auth:
     username: "sonarUser"
     password: "sonarPass"

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -405,9 +405,10 @@ postgresql:
   #
   # The bitnami chart enforces the key to be "postgresql-password". This value is only here for historic purposes
   # existingSecretPasswordKey: "postgresql-password"
-  postgresqlUsername: "sonarUser"
-  postgresqlPassword: "sonarPass"
-  postgresqlDatabase: "sonarDB"
+  auth:
+    username: "sonarUser"
+    password: "sonarPass"
+    database: "sonarDB"
   # Specify the TCP port that PostgreSQL should use
   service:
     port: 5432

--- a/tests/unit-compatibility-test/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/sonarqube/secret-values.yaml
@@ -19,3 +19,5 @@ sonarWebContext: /
 
 postgresql:
   enabled: false
+  auth:
+    postgresPassword: "secret"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
  This change is created for fixing [CVE-2024-7348: PostgreSQL relation replacement during pg_dump executes arbitrary SQL](https://www.postgresql.org/support/security/CVE-2024-7348/) by change `bitnami/postgresql` helm chart to latest version to have patched PostgreSQL version `16.4.0`.
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`