### PR TITLE
NO-JIRA support using gateway in different namespace in HTTPRoute

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Update Chart's version to 10.8.0
 * Support the installation of the Oracle JDBC Driver
 * Support Kubernetes v1.31
+* Support Gateway on different namespace in HTTPRoute
 
 ## [10.7.0]
 * Update Chart's version to 10.7.0

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -443,13 +443,14 @@ The following table lists the configurable parameters of the SonarQube chart and
 
 ### HttpRoute
 
-| Parameter             | Description                                                                                                   | Default |
-| --------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
-| `httproute.enabled`   | Flag to enable GatewayAPI HttpRoute                                                                           | `False` |
-| `httproute.gateway`   | Name of the gateway located in the same namespace                                                             | `None`  |
-| `httproute.hostnames` | List of hostnames to match the HttpRoute against                                                              | `None`  |
-| `httproute.labels`    | (Optional) List of extra labels to add to the HttpRoute                                                       | `None`  |
-| `httproute.rules`     | (Optional) Extra Rules block of the HttpRoute. A default one is created with SonarWebContext and service port | `None`  |
+| Parameter                    | Description                                                                                                   | Default |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
+| `httproute.enabled`          | Flag to enable GatewayAPI HttpRoute                                                                           | `False` |
+| `httproute.gateway`          | Name of the gateway                                                                                           | `None`  |
+| `httproute.gatewayNamespace` | (Optional) Name of the gateway namespace when located in a different namespace                                | `None`  |
+| `httproute.hostnames`        | List of hostnames to match the HttpRoute against                                                              | `None`  |
+| `httproute.labels`           | (Optional) List of extra labels to add to the HttpRoute                                                       | `None`  |
+| `httproute.rules`            | (Optional) Extra Rules block of the HttpRoute. A default one is created with SonarWebContext and service port | `None`  |
 
 ### Elasticsearch
 

--- a/charts/sonarqube-dce/templates/http-route.yml
+++ b/charts/sonarqube-dce/templates/http-route.yml
@@ -14,6 +14,9 @@ metadata:
 spec:
   parentRefs:
   - name: {{ .Values.httproute.gateway }}
+    {{- if .Values.httproute.gatewayNamespace }}
+    namespace: {{ .Values.httproute.gatewayNamespace }}
+    {{- end }}
   hostnames:
     {{- with .Values.httproute.hostnames }}
     {{ toYaml . }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -460,6 +460,7 @@ ingress-nginx:
 httproute:
   enabled: false
   # gateway: my-gateway
+  # gatewayNamespace: my-gateway-namespace # optional
   # labels:
   #   somelabel: somevalue
   # hostnames:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Update Chart's version to 10.8.0
 * Support the installation of the Oracle JDBC Driver
 * Support Kubernetes v1.31
+* Support Gateway on different namespace in HTTPRoute
 
 ## [10.7.0]
 * Update Chart's version to 10.7.0

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -324,13 +324,14 @@ The following table lists the configurable parameters of the SonarQube chart and
 
 ### HttpRoute
 
-| Parameter             | Description                                                                                                   | Default |
-| --------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
-| `httproute.enabled`   | Flag to enable GatewayAPI HttpRoute                                                                           | `False` |
-| `httproute.gateway`   | Name of the gateway located in the same namespace                                                             | `None`  |
-| `httproute.hostnames` | List of hostnames to match the HttpRoute against                                                              | `None`  |
-| `httproute.labels`    | (Optional) List of extra labels to add to the HttpRoute                                                       | `None`  |
-| `httproute.rules`     | (Optional) Extra Rules block of the HttpRoute. A default one is created with SonarWebContext and service port | `None`  |
+| Parameter                    | Description                                                                                                   | Default |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
+| `httproute.enabled`          | Flag to enable GatewayAPI HttpRoute                                                                           | `False` |
+| `httproute.gateway`          | Name of the gateway                                                                                           | `None`  |
+| `httproute.gatewayNamespace` | (Optional) Name of the gateway namespace when located in a different namespace                                | `None`  |
+| `httproute.hostnames`        | List of hostnames to match the HttpRoute against                                                              | `None`  |
+| `httproute.labels`           | (Optional) List of extra labels to add to the HttpRoute                                                       | `None`  |
+| `httproute.rules`            | (Optional) Extra Rules block of the HttpRoute. A default one is created with SonarWebContext and service port | `None`  |
 
 ### Probes
 

--- a/charts/sonarqube/templates/http-route.yaml
+++ b/charts/sonarqube/templates/http-route.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   parentRefs:
   - name: {{ .Values.httproute.gateway }}
+    {{- if .Values.httproute.gatewayNamespace }}
+    namespace: {{ .Values.httproute.gatewayNamespace }}
+    {{- end }}
   hostnames:
     {{- with .Values.httproute.hostnames }}
     {{ toYaml . }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -135,6 +135,7 @@ ingress-nginx:
 httproute:
   enabled: false
   # gateway: my-gateway
+  # gatewayNamespace: my-gateway-namespace # optional
   # labels:
   #   somelabel: somevalue
   # hostnames:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -955,6 +955,7 @@ metadata:
 spec:
   parentRefs:
   - name: my-gateway
+    namespace: my-gateway-namespace
   hostnames:
     - sonarqube.your-org.com
   rules:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -573,6 +573,7 @@ metadata:
 spec:
   parentRefs:
   - name: my-gateway
+    namespace: my-gateway-namespace
   hostnames:
     - sonarqube.your-org.com
   rules:

--- a/tests/unit-compatibility-test/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/sonarqube-dce/http-routes-values.yaml
@@ -1,6 +1,7 @@
 httproute:
   enabled: true
   gateway: my-gateway
+  gatewayNamespace: my-gateway-namespace
   hostnames:
     - sonarqube.your-org.com
   rules:

--- a/tests/unit-compatibility-test/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/sonarqube/http-routes-values.yaml
@@ -1,6 +1,7 @@
 httproute:
   enabled: true
   gateway: my-gateway
+  gatewayNamespace: my-gateway-namespace
   hostnames:
     - sonarqube.your-org.com
   rules:


### PR DESCRIPTION
Improvement: Support using a Gateway in a different namespace

- **feat(httproute): support gateway in different namespace**
- **chore(httproute): update tests**

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
