### PR TITLE
Adding condition for the creation of the HTTP proxies secret

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.3.0]
+* Update Chart's version to 2025.3.0
+* Adding condition for the creation of the HTTP proxies secret
+
 ## [2025.2.0]
 * Update Chart's version to 2025.2.0
 * Update ingress-nginx subchart to 4.12.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.2.0
+version: 2025.3.0
 appVersion: 2025.1.0
 keywords:
   - coverage
@@ -31,9 +31,9 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 2025.2.0"
+      description: "Update Chart's version to 2025.3.0"
     - kind: changed
-      description: "Update ingress-nginx subchart to 4.12.0"
+      description: "Adding condition for the creation of the HTTP proxies secret"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -37,6 +37,7 @@ stringData:
 {{- end }}
 {{- end }}
 ---
+{{- if or .Values.prometheusExporter.httpProxy .Values.httpProxy }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -44,9 +45,14 @@ metadata:
   labels: {{- include "sonarqube.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if .Values.httpProxy }}
   PLUGINS-HTTP-PROXY: {{ default .Values.httpProxy .Values.plugins.httpProxy | quote }}
   PLUGINS-HTTPS-PROXY: {{ default .Values.httpsProxy .Values.plugins.httpsProxy | quote }}
   PLUGINS-NO-PROXY: {{ default .Values.noProxy .Values.plugins.noProxy | quote }}
+  {{- end }}
+  {{- if .Values.prometheusExporter.httpProxy }}
   PROMETHEUS-EXPORTER-HTTP-PROXY: {{ default .Values.httpProxy .Values.prometheusExporter.httpProxy | quote }}
   PROMETHEUS-EXPORTER-HTTPS-PROXY: {{ default .Values.httpsProxy .Values.prometheusExporter.httpsProxy | quote }}
   PROMETHEUS-EXPORTER-NO-PROXY: {{ default .Values.noProxy .Values.prometheusExporter.noProxy | quote }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
**Description**
This PR adds a condition for creating the HTTP proxies secret. The secret is now only created if either prometheusExporter.httpProxy or httpProxy is set in the values.

**Changes**
Wrapped the HTTP proxies Secret resource in a conditional block to ensure it is only created when necessary.

**Why?**
This change prevents unnecessary secret creation when HTTP proxy values are not set, improving configuration clarity and avoiding innecesary resources.