### PR TITLE
SONAR-24702 Update ingress-nginx to 4.12.1

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2025.2.0]
 * Update Chart's version to 2025.2.0
-* Update ingress-nginx subchart to 4.12.0
+* Update ingress-nginx subchart to 4.12.1
 
 ## [2025.1.0]
 * Update Chart's version to 2025.1.0

--- a/charts/sonarqube-dce/Chart.lock
+++ b/charts/sonarqube-dce/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 10.15.0
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.12.0
-digest: sha256:f03be3f9956a16f18143380a5fff221ecceb4cc59dd81e0a6dd530beff76ebb3
-generated: "2025-01-27T16:26:08.00355+01:00"
+  version: 4.12.1
+digest: sha256:2858b0091bab45938e195687ebb0f98faaae33baaca3cfee3944f2bf9e5fab6e
+generated: "2025-03-25T10:43:27.092359+01:00"

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -47,6 +47,6 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: ingress-nginx
-    version: 4.12.0
+    version: 4.12.1
     repository: https://kubernetes.github.io/ingress-nginx
     condition: nginx.enabled,ingress-nginx.enabled

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2025.2.0]
 * Update Chart's version to 2025.2.0
-* Update ingress-nginx subchart to 4.12.0
+* Update ingress-nginx subchart to 4.12.1
 
 ## [2025.1.0]
 * Update Chart's version to 2025.1.0

--- a/charts/sonarqube/Chart.lock
+++ b/charts/sonarqube/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 10.15.0
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.12.0
-digest: sha256:f03be3f9956a16f18143380a5fff221ecceb4cc59dd81e0a6dd530beff76ebb3
-generated: "2025-01-27T16:26:55.281405+01:00"
+  version: 4.12.1
+digest: sha256:2858b0091bab45938e195687ebb0f98faaae33baaca3cfee3944f2bf9e5fab6e
+generated: "2025-03-25T10:42:08.870326+01:00"

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -45,6 +45,6 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: ingress-nginx
-    version: 4.12.0
+    version: 4.12.1
     repository: https://kubernetes.github.io/ingress-nginx
     condition: nginx.enabled,ingress-nginx.enabled

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -38,10 +38,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -119,10 +119,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -251,10 +251,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-with-controller.yaml-ingress-nginx
@@ -335,10 +335,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-with-controller.yaml-ingress-nginx
@@ -356,10 +356,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -450,10 +450,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -473,10 +473,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -500,10 +500,10 @@ kind: Service
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -688,10 +688,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -709,10 +709,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ingress-nginx-4.12.0
+        helm.sh/chart: ingress-nginx-4.12.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-with-controller.yaml
-        app.kubernetes.io/version: "1.12.0"
+        app.kubernetes.io/version: "1.12.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -720,7 +720,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:e6b8de175acda6ca913891f0f727bca4527e797d52688cbe9fec9040d6f6b6fa
+          image: registry.k8s.io/ingress-nginx/controller:v1.12.1@sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -1404,10 +1404,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -1460,10 +1460,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1502,10 +1502,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1520,10 +1520,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1545,10 +1545,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1571,10 +1571,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1597,10 +1597,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1662,10 +1662,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1674,17 +1674,17 @@ spec:
     metadata:
       name: ingress-with-controller.yaml-ingress-nginx-admission-create
       labels:
-        helm.sh/chart: ingress-nginx-4.12.0
+        helm.sh/chart: ingress-nginx-4.12.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-with-controller.yaml
-        app.kubernetes.io/version: "1.12.0"
+        app.kubernetes.io/version: "1.12.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: create
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0@sha256:aaafd456bda110628b2d4ca6296f38731a3aaf0bf7581efae824a41c770a8fc4
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2@sha256:e8825994b7a2c7497375a9b945f386506ca6a3eda80b89b74ef2db743f66a5ea
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -1722,10 +1722,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1734,17 +1734,17 @@ spec:
     metadata:
       name: ingress-with-controller.yaml-ingress-nginx-admission-patch
       labels:
-        helm.sh/chart: ingress-nginx-4.12.0
+        helm.sh/chart: ingress-nginx-4.12.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-with-controller.yaml
-        app.kubernetes.io/version: "1.12.0"
+        app.kubernetes.io/version: "1.12.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: patch
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0@sha256:aaafd456bda110628b2d4ca6296f38731a3aaf0bf7581efae824a41c770a8fc4
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2@sha256:e8825994b7a2c7497375a9b945f386506ca6a3eda80b89b74ef2db743f66a5ea
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -71,10 +71,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -174,10 +174,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-with-controller.yaml-ingress-nginx
@@ -258,10 +258,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-with-controller.yaml-ingress-nginx
@@ -279,10 +279,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -373,10 +373,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -396,10 +396,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -423,10 +423,10 @@ kind: Service
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -533,10 +533,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -554,10 +554,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ingress-nginx-4.12.0
+        helm.sh/chart: ingress-nginx-4.12.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-with-controller.yaml
-        app.kubernetes.io/version: "1.12.0"
+        app.kubernetes.io/version: "1.12.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -565,7 +565,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:e6b8de175acda6ca913891f0f727bca4527e797d52688cbe9fec9040d6f6b6fa
+          image: registry.k8s.io/ingress-nginx/controller:v1.12.1@sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -1009,10 +1009,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -1065,10 +1065,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1107,10 +1107,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1125,10 +1125,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1150,10 +1150,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1176,10 +1176,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1202,10 +1202,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1267,10 +1267,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1279,17 +1279,17 @@ spec:
     metadata:
       name: ingress-with-controller.yaml-ingress-nginx-admission-create
       labels:
-        helm.sh/chart: ingress-nginx-4.12.0
+        helm.sh/chart: ingress-nginx-4.12.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-with-controller.yaml
-        app.kubernetes.io/version: "1.12.0"
+        app.kubernetes.io/version: "1.12.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: create
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0@sha256:aaafd456bda110628b2d4ca6296f38731a3aaf0bf7581efae824a41c770a8fc4
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2@sha256:e8825994b7a2c7497375a9b945f386506ca6a3eda80b89b74ef2db743f66a5ea
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -1327,10 +1327,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.12.0
+    helm.sh/chart: ingress-nginx-4.12.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-with-controller.yaml
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -1339,17 +1339,17 @@ spec:
     metadata:
       name: ingress-with-controller.yaml-ingress-nginx-admission-patch
       labels:
-        helm.sh/chart: ingress-nginx-4.12.0
+        helm.sh/chart: ingress-nginx-4.12.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-with-controller.yaml
-        app.kubernetes.io/version: "1.12.0"
+        app.kubernetes.io/version: "1.12.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: patch
-          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0@sha256:aaafd456bda110628b2d4ca6296f38731a3aaf0bf7581efae824a41c770a8fc4
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2@sha256:e8825994b7a2c7497375a9b945f386506ca6a3eda80b89b74ef2db743f66a5ea
           imagePullPolicy: IfNotPresent
           args:
             - patch


### PR DESCRIPTION
[SONAR-24702](https://sonarsource.atlassian.net/browse/SONAR-24702)



[SONAR-24702]: https://sonarsource.atlassian.net/browse/SONAR-24702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ