### PR TITLE
chore: use the quote function to handle the .Release.Name

### DIFF
--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -73,7 +73,7 @@ Common labels
 {{- define "sonarqube.labels" -}}
 app: {{ include "sonarqube.name" . }}
 chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
-release: {{ .Release.Name }}
+release: {{ .Release.Name | quote }}
 heritage: {{ .Release.Service }}
 {{- end -}}
 

--- a/charts/sonarqube-dce/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube-dce/templates/change-admin-password-hook.yml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
   {{- range $key, $value := .Values.service.labels }}
     {{ $key }}: {{ $value | quote }}
@@ -29,7 +29,7 @@ spec:
       labels:
         app: {{ template "sonarqube.name" . }}
         heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | quote }}
       {{- range $key, $value := .Values.service.labels }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}

--- a/charts/sonarqube-dce/templates/config.yaml
+++ b/charts/sonarqube-dce/templates/config.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   sonar.properties: |
@@ -26,7 +26,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   sonar.properties: |

--- a/charts/sonarqube-dce/templates/http-route.yml
+++ b/charts/sonarqube-dce/templates/http-route.yml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
     {{- with .Values.httproute.labels }}
     {{- toYaml . | nindent 4 }}

--- a/charts/sonarqube-dce/templates/ingress.yaml
+++ b/charts/sonarqube-dce/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 {{- if .Values.ingress.labels }}
 {{ .Values.ingress.labels | toYaml | trimSuffix "\n"| indent 4 -}}
@@ -26,7 +26,7 @@ metadata:
 {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote}}
   {{- else if or (.Values.nginx).enabled (index .Values "ingress-nginx" "enabled") }}
   ingressClassName: "nginx"
   {{- end }}

--- a/charts/sonarqube-dce/templates/init-fs.yaml
+++ b/charts/sonarqube-dce/templates/init-fs.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   init_fs.sh: |-

--- a/charts/sonarqube-dce/templates/install-oracle-jdbc-driver.yaml
+++ b/charts/sonarqube-dce/templates/install-oracle-jdbc-driver.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   install_oracle_jdbc_driver.sh: |-

--- a/charts/sonarqube-dce/templates/install-plugins.yaml
+++ b/charts/sonarqube-dce/templates/install-plugins.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   install_plugins.sh: |-

--- a/charts/sonarqube-dce/templates/jdbc-config.yaml
+++ b/charts/sonarqube-dce/templates/jdbc-config.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   SONAR_JDBC_USERNAME: {{ template "jdbc.username" . }}

--- a/charts/sonarqube-dce/templates/networkpolicy.yaml
+++ b/charts/sonarqube-dce/templates/networkpolicy.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 spec:
   podSelector:
@@ -24,7 +24,7 @@ spec:
         - podSelector:
             matchLabels:
               app: {{ template "sonarqube.name" . }}
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
               sonarqube.datacenter/type: app
 {{ if .Values.ApplicationNodes.prometheusExporter.enabled }}
     - from:
@@ -84,7 +84,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 spec:
   podSelector:
@@ -140,13 +140,13 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: postgresql
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | quote }}
   policyTypes:
     - Ingress
     - Egress
@@ -180,7 +180,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 spec:
 {{- if.Values.networkPolicy.additionalNetworkPolicys -}}

--- a/charts/sonarqube-dce/templates/pod-disruption-budget.yaml
+++ b/charts/sonarqube-dce/templates/pod-disruption-budget.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 spec:
 {{ if .Values.searchNodes.podDistributionBudget }}
@@ -31,7 +31,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 spec:
 {{ if .Values.ApplicationNodes.podDistributionBudget }}

--- a/charts/sonarqube-dce/templates/prometheus-ce-config.yaml
+++ b/charts/sonarqube-dce/templates/prometheus-ce-config.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   prometheus-ce-config.yaml: |-

--- a/charts/sonarqube-dce/templates/prometheus-config.yaml
+++ b/charts/sonarqube-dce/templates/prometheus-config.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 data:
   prometheus-config.yaml: |-

--- a/charts/sonarqube-dce/templates/secret.yaml
+++ b/charts/sonarqube-dce/templates/secret.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
@@ -26,7 +26,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
@@ -42,7 +42,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
@@ -58,7 +58,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
@@ -77,7 +77,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
@@ -110,7 +110,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 type: Opaque
 stringData:

--- a/charts/sonarqube-dce/templates/service.yaml
+++ b/charts/sonarqube-dce/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
   {{- range $key, $value := .Values.service.labels }}
     {{ $key }}: {{ $value | quote }}
@@ -30,7 +30,7 @@ spec:
       {{- end }}
   selector:
     app: {{ template "sonarqube.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
@@ -51,7 +51,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
   {{- range $key, $value := .Values.service.labels }}
     {{ $key }}: {{ $value | quote }}
@@ -74,7 +74,7 @@ spec:
       name: hazelcast
   selector:
     app: {{ template "sonarqube.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
 
 
 ---
@@ -85,7 +85,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
   {{- range $key, $value := .Values.service.labels }}
     {{ $key }}: {{ $value | quote }}
@@ -109,7 +109,7 @@ spec:
       name: es
   selector:
     app: {{ template "sonarqube.name" . }}-search
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
 
 ---
 apiVersion: v1
@@ -119,7 +119,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
   {{- range $key, $value := .Values.service.labels }}
     {{ $key }}: {{ $value | quote }}
@@ -145,4 +145,4 @@ spec:
       name: es
   selector:
     app: {{ template "sonarqube.name" . }}-search
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -7,11 +7,11 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ .Release.Name | quote }}
     sonarqube.datacenter/type: "app"
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: {{ template "sonarqube.fullname" . }}
@@ -26,12 +26,12 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sonarqube.name" . }}
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
         app: {{ template "sonarqube.name" . }}
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | quote }}
         sonarqube.datacenter/type: "app"
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -7,11 +7,11 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
     app.kubernetes.io/name: "{{ .Release.Name }}"
     sonarqube.datacenter/type: "search"
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: {{ template "sonarqube.fullname" . }}
@@ -23,13 +23,13 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sonarqube.name" . }}-search
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | quote }}
 {{- if .Values.searchNodes.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: {{ template "sonarqube.fullname" . }}
       labels:
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | quote }}
         chart: "{{ .Chart.Name }}"
         app: "{{ template "sonarqube.fullname" . }}"
     {{- with .Values.searchNodes.persistence.annotations  }}
@@ -54,7 +54,7 @@ spec:
     metadata:
       labels:
         app: {{ template "sonarqube.name" . }}-search
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | quote }}
         sonarqube.datacenter/type: "search"
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}

--- a/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
+++ b/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: {{ template "sonarqube.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service }}
 spec:
   automountServiceAccountToken: false

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -24,7 +24,7 @@ Common labels
 {{- define "sonarqube.labels" -}}
 app: {{ include "sonarqube.name" . }}
 chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
-release: {{ .Release.Name }}
+release: {{ .Release.Name | quote }}
 heritage: {{ .Release.Service }}
 {{- end -}}
 
@@ -33,7 +33,7 @@ Selector labels
 */}}
 {{- define "sonarqube.selectorLabels" -}}
 app: {{ include "sonarqube.name" . }}
-release: {{ .Release.Name }}
+release: {{ .Release.Name | quote }}
 {{- end -}}
 
 {{/*
@@ -41,8 +41,8 @@ Workload labels (Deployment or StatefulSet)
 */}}
 {{- define "sonarqube.workloadLabels" -}}
 {{- include "sonarqube.labels" . }}
-app.kubernetes.io/name: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ .Release.Name | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: sonarqube
 app.kubernetes.io/component: {{ include "sonarqube.fullname" . }}

--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
   {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- else if or (.Values.nginx).enabled (index .Values "ingress-nginx" "enabled") }}
   ingressClassName: "nginx"
   {{- end }}

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -17,7 +17,7 @@ spec:
         - podSelector:
             matchLabels:
               app: {{ template "sonarqube.name" . }}
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
       ports:
         - port: {{ .Values.service.internalPort }}
     {{ if .Values.prometheusExporter.enabled }}

--- a/charts/sonarqube/templates/service.yaml
+++ b/charts/sonarqube/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
       {{- end }}
   selector:
     app: {{ template "sonarqube.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:


### PR DESCRIPTION
When deploying via helm, an error is reported when the helm Release.Name is a numeric, because the label cannot use numbers. 

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/a799c00e-f219-4ac2-9cad-0c3e6094754f" />

This problem can be solved by the handling of the `quote` function.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`