### PR TITLE
Allow JDBC URL to be read from a secret

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.4.0]
+* Update Chart's version to 2025.4.0
+* Add key `jdbcOverwrite.jdbcSecretURLKey` which takes priority over `jdbcOverwrite.jdbcUrl`
+
 ## [2025.3.0]
 * Update Chart's version to 2025.3.0
 * Normalizes the extension for all templates

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -499,7 +499,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 ### JDBC Overwrite
 
 | Parameter                                   | Description                                                                                                                                                    | Default                                    |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------------------------------------ |
 | `jdbcOverwrite.enable`                      | (DEPRECATED) Enable JDBC overwrites for external Databases (disables `postgresql.enabled`) ,Please use jdbcOverwrite.enabled instead                           | `false`                                    |
 | `jdbcOverwrite.enabled`                     | Enable JDBC overwrites for external Databases (disables `postgresql.enabled`)                                                                                  | `false`                                    |
 | `jdbcOverwrite.jdbcUrl`                     | The JDBC url to connect the external DB                                                                                                                        | `jdbc:postgresql://myPostgress/myDatabase` |
@@ -507,6 +507,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `jdbcOverwrite.jdbcPassword`                | (DEPRECATED) The DB password that should be used for the JDBC connection, please use `jdbcOverwrite.jdbcSecretName`  and `jdbcOverwrite.jdbcSecretPasswordKey` | `sonarPass`                                |
 | `jdbcOverwrite.jdbcSecretName`              | Alternatively, use a pre-existing k8s secret containing the DB password                                                                                        | `None`                                     |
 | `jdbcOverwrite.jdbcSecretPasswordKey`       | If the pre-existing k8s secret is used this allows the user to overwrite the 'key' of the password property in the secret                                      | `None`                                     |
+| `jdbcOverwrite.jdbcSecretURLKey`            | If the pre-existing k8s secret is used this allows the user to overwrite the 'key' of the URL property in the secret                                           | `None`                                     |
 | `jdbcOverwrite.oracleJdbcDriver.url`        | The URL of the Oracle JDBC driver to be downloaded                                                                                                             | `None`                                     |
 | `jdbcOverwrite.oracleJdbcDriver.netrcCreds` | Name of the secret containing .netrc file to use creds when downloading the Oracle JDBC driver                                                                 | `None`                                     |
 

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -147,7 +147,7 @@ Determine JDBC username
 {{- end -}}
 
 {{/*
-Determine the k8s secretKey contrining the JDBC password
+Determine the k8s secretKey containing the JDBC password
 */}}
 {{- define "jdbc.secretPasswordKey" -}}
 {{- if .Values.postgresql.enabled -}}
@@ -165,6 +165,16 @@ Determine the k8s secretKey contrining the JDBC password
 {{- else -}}
   {{- "jdbc-password" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Determine the k8s secretKey containing the JDBC URL
+*/}}
+{{- define "jdbc.secretURLKey" -}}
+{{- if or .Values.jdbcOverwrite.enabled .Values.jdbcOverwrite.enable -}}
+  {{- if and .Values.jdbcOverwrite.jdbcSecretName .Values.jdbcOverwrite.jdbcSecretURLKey -}}
+  {{- .Values.jdbcOverwrite.jdbcSecretURLKey -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -280,6 +280,13 @@ spec:
             secretKeyRef:
               name: {{ include "jdbc.secret" . }}
               key: {{ include "jdbc.secretPasswordKey" . }}
+        {{- if .Values.jdbcOverwrite.jdbcSecretURLKey }}
+        - name: SONAR_JDBC_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "jdbc.secret" . }}
+              key: {{ include "jdbc.secretURLKey" . }}
+        {{- end }}
         - name: SONAR_WEB_SYSTEMPASSCODE
           valueFrom:
             secretKeyRef:

--- a/charts/sonarqube/templates/jdbc-config.yaml
+++ b/charts/sonarqube/templates/jdbc-config.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{- include "sonarqube.labels" . | nindent 4 }}
 data:
   SONAR_JDBC_USERNAME: {{ template "jdbc.username" . }}
-  {{- if or .Values.jdbcOverwrite.enabled .Values.jdbcOverwrite.enable }}
+  {{- if (or .Values.jdbcOverwrite.enabled .Values.jdbcOverwrite.enable) and not .Values.jdbcOverwrite.jdbcSecretURLKey }} }}
   SONAR_JDBC_URL: {{ .Values.jdbcOverwrite.jdbcUrl | trim | quote }}
   {{- else if and .Values.postgresql.service.port .Values.postgresql.postgresqlDatabase }}
   SONAR_JDBC_URL: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresqlDatabase -}}"

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -529,7 +529,7 @@ jdbcOverwrite:
   ## and the secretValueKey of the password found within that secret
   # jdbcSecretPasswordKey: "jdbc-password"
   ## and the secretValueKey of the URL found within that secret
-  # jdbcSecretURLKey: "jdbc-password"
+  # jdbcSecretURLKey: "jdbc-url"
   # To install the oracle JDBC driver, set the following URL (in this example, we set the URL for the Oracle 11 driver. Please update it to your target driver URL.).
   # If downloading the driver requires authentication, please set the .netrc secret file with a key "netrc" to use basic auth.
   # oracleJdbcDriver:

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -528,6 +528,8 @@ jdbcOverwrite:
   # jdbcSecretName: "sonarqube-jdbc"
   ## and the secretValueKey of the password found within that secret
   # jdbcSecretPasswordKey: "jdbc-password"
+  ## and the secretValueKey of the URL found within that secret
+  # jdbcSecretURLKey: "jdbc-password"
   # To install the oracle JDBC driver, set the following URL (in this example, we set the URL for the Oracle 11 driver. Please update it to your target driver URL.).
   # If downloading the driver requires authentication, please set the .netrc secret file with a key "netrc" to use basic auth.
   # oracleJdbcDriver:


### PR DESCRIPTION
Hi all,

we are creating our databases via a Terraform module which creates the DB and the role for it. It also creates and AWS secret containing all needed information like `role-name`, `role-password` and `database-url`. 

Currently, we have to hardcode the URL of the database to the helm chart values. We would like to avoid that and grab the URL directly from the already existing secret (where we also get the password from). 

This change should make that possible. I tried to integrate it into the current logic without changing too much and also make it backwards compatible. 

Let me know what you think!

___

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`