### PR TITLE
Add extraManifests to Helm Chart to enable deployment of encrypted sensitive data

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
+## [2025.3.1]
+* Update Chart's version to 2025.3.1
+* Add ExtraManifests to deploy additional Manifests alongside with the Helm Chart e.g. in favor of encrypted Secrets
 
 ## [2025.3.0]
 * Update Chart's version to 2025.3.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.3.0
+version: 2025.3.1
 appVersion: 2025.2.0
 keywords:
   - coverage

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -454,3 +454,19 @@ Remove incompatible user/group values that do not work in Openshift out of the b
 {{- $accountDeprecation := (include "deepMerge" (dict "map1" $map1 "map2" $map2)) -}}
 {{- $accountDeprecation }}
 {{- end -}}
+
+{{- /*
+Render ExtraManifests
+*/}}
+{{- define "extraManifests.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}

--- a/charts/sonarqube/templates/extra-manifests.yaml
+++ b/charts/sonarqube/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ include "extraManifests.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -653,6 +653,23 @@ extraConfig:
   secrets: []
   configmaps: []
 
+# extraManifests is used to Deploy additional Manifests alongside with the Helm Chart
+# This is useful for checking sensitive data into your git in encrypted form (e.g. as SealedSecret) 
+# instead of unencrypted in plain text.
+# extraManifests:
+#   - apiVersion: bitnami.com/v1alpha1
+#     kind: SealedSecret
+#     metadata:
+#       name: my-secret
+#       namespace: default
+#     spec:
+#       encryptedData:
+#         password: <encrypted password>
+#         username: <encrypted username>
+#         values.yaml: <encrypted values data>
+
+extraManifests: []
+
 # setAdminPassword:
 # The values can be set to define the current and the (new) custom admin passwords at the startup (the username will remain "admin")
 #  newPassword: AdminAdmin_12$


### PR DESCRIPTION
Used Versions:
  * [Helm Chart](https://github.com/SonarSource/helm-chart-sonarqube) Version: 2025.2.0
  * Sonarqube Version: 2025.2.0 (25.1.0.102122)
  * Edition: Community
  * Kubernetes Version: 1.30.1

I am implementing GitOps with Helm Charts and ArgoCD. All resources needed to run a Sonarqube instance should be declared in a single app. 
I want to prevent sensitive data such as passwords from being shared in plain text in my Git and the data required for the instance from being distributed across several apps or tools.
* Prevent listing sensitive data like jdbc-password or monitoringPasscode in plain text into values-file in git
* Preserve the single-point-of-configuration by keep using a single values.yaml file for deployment

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`