### PR TITLE
SONAR-25113 increase fixture memory to prevent oom killed

### DIFF
--- a/.cirrus/tasks.yml
+++ b/.cirrus/tasks.yml
@@ -5,7 +5,7 @@ chart_fixture_test_task:
   eks_container:
     <<: *CONTAINER_TEMPLATE
     cpu: 1
-    memory: 1Gb
+    memory: 2Gb
   <<: *CLONE_SCRIPT_TEMPLATE
   script:
     - ./.cirrus/build_chart_dependencies.sh charts/sonarqube


### PR DESCRIPTION
[SONAR-25113](https://sonarsource.atlassian.net/browse/SONAR-25113)



[SONAR-25113]: https://sonarsource.atlassian.net/browse/SONAR-25113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ