### PR TITLE
Allow persistence for plugins when installing both via values and marketplace

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -7,6 +7,7 @@ All changes to this chart will be documented in this file.
 * Upgrade nginx subchart to 4.12.2
 * Support Kubernetes v1.32
 * Add the possibility of to save the data with hostpath
+* Allow persistence for plugins when installing both via values and marketplace
 
 ## [2025.3.0]
 * Update Chart's version to 2025.3.0

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -193,7 +193,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     {{- end }}
-    {{- if .Values.plugins.install }}
+    {{- if or .Values.plugins.install .Values.persistence.enabled }}
     - name: install-plugins
       image: {{ default (include "sonarqube.image" $) .Values.plugins.image }}
       imagePullPolicy: {{ .Values.image.pullPolicy  }}
@@ -440,7 +440,7 @@ spec:
           - key: init_fs.sh
             path: init_fs.sh
     {{- end }}
-    {{- if .Values.plugins.install }}
+    {{- if or .Values.plugins.install .Values.persistence.enabled }}
     - name: install-plugins
       configMap:
         name: {{ include "sonarqube.fullname" . }}-install-plugins

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -5,10 +5,28 @@ metadata:
   labels: {{- include "sonarqube.labels" . | nindent 4 }}
 data:
   install_plugins.sh: |-
+    cd {{ .Values.sonarqubeFolder }}/extensions/plugins
+    if [ -f "installed-plugins.txt" ]; then
+        echo "Found existing installed-plugins.txt. Cleaning up old files..."
+        
+        while IFS= read -r plugin_file; do
+            if [ -f "$plugin_file" ]; then
+                echo "Deleting $plugin_file..."
+                rm -f "$plugin_file"
+            else
+                echo "File $plugin_file not found, skipping..."
+            fi
+        done < installed-plugins.txt
+
+        rm -f installed-plugins.txt
+    else
+        echo "installed-plugins.txt not found. Deleting all files in the folder..."
+        rm -f ./*
+    fi
+
+    touch installed-plugins.txt
     {{- if .Values.plugins.install }}
-      rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
-      cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.plugins.install }}
-      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
+      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }} && echo "$(basename {{ $val | quote }})" >> installed-plugins.txt
       {{- end }}
     {{- end }}


### PR DESCRIPTION
Hello,

I would like to suggest a small change in the algorithm of plugin installation. Currently, if `plugins.install` value is not an empty array, all plugins added via marketplace and not mentioned in values are wiped out on pod restart, despite having persistence enabled in values. It poses an issue in cases where a user has to use helm values for some base plugins, but wants to enable those who work with Sonarqube later to install additional plugins from marketplace as needed.

**Proposed solution:**

I have modified *install-plugin.sh* script, so that it would write the names of plugin jars installed via values in *installed-plugins.txt* file and delete only these jars on restart (thus not deleting the plugins installed in another way).

This is NOT a breaking change. If the *installed-plugins.txt* is not found, the script reverts to original behavior and deletes all plugin files before creating a new txt file and downloading plugins requested in values.

Additionally, I modified the chart to execute the *install-plugin.sh* script not only if `plugins.install` array is not empty, but also if persistence is enabled. It seems necessary since with enabled persistence even if currently there are no plugins to install in values, there can be plugin jars remaining from the previous deployment  in the persistent volume which need to be removed.

I hope you will take my suggestion into consideration. It would be a helpful feature for users like me. Thank you for your time.

Please ensure your pull request adheres to the following guidelines:
- [X] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`