### PR TITLE
Allow change admin password hook to run only on install

### DIFF
--- a/charts/sonarqube/templates/change-admin-password-hook.yaml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yaml
@@ -8,7 +8,11 @@ metadata:
   name: {{ template "sonarqube.fullname" . }}-change-admin-password-hook
   labels: {{- include "sonarqube.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.account.installOnlyHook }}
+    "helm.sh/hook": post-install
+    {{- else }}
     "helm.sh/hook": post-install, post-upgrade
+    {{- end }}
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- range $key, $value := .Values.adminJobAnnotations | default .Values.account.annotations }}
     {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Change to allow change admin password hook to run only on install or on install and upgrade by default.

We needed to only have this hook run on install vs on install and upgrade, so we were trying to kustomize patch out the post-upgrade bit via a post render but we ran into a problem with helm/flux not being able to patch hooks (https://github.com/helm/helm/issues/7891). We are pulling in the SonarQube chart as a sub-chart so directly editing the hook is not really an option.

After some discussion, we thought it would be faster to try and just make a small change to this chart vs wait for a new helm release and subsequent inclusion in flux. 

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Please ensure your pull request adheres to the following guidelines:
- [ x ] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`