### PR TITLE
feat: allow extraVolumeMounts and additional curl options for install-plugins

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.6.0]
+* Update Chart's version to 2025.6.0
+* Allow extraVolumeMounts and additional curl options for install-plugins initContainer
+
 ## [2025.5.0]
 * Update Chart's version to 2025.5.0
 * Update the image repository and readinessProbe used by postgresql after they migrated to a legacy repository

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.5.0
+version: 2025.6.0
 appVersion: 2025.4.0
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -457,6 +457,8 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `plugins.netrcCreds`         | Name of the secret containing .netrc file to use creds when downloading plugins | `""`                                                                   |
 | `plugins.noCheckCertificate` | Flag to not check server's certificate when downloading plugins                 | `false`                                                                |
 | `plugins.securityContext`    | Security context for the container to download plugins                          | [Restricted podSecurityStandard](#kubernetes---pod-security-standards) |
+| `plugins.extraVolumeMounts`  | Additional volumeMounts for the install-plugins initContainer                   | `{}`                                                                   |
+| `plugins.curlOpts`           | Additional options for the install-plugins `curl` command                       | `""`                                                                   |
 
 ### SonarQube Specific
 

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -214,6 +214,9 @@ spec:
         - name: plugins-netrc-file
           mountPath: /root
         {{- end }}
+        {{- with .Values.plugins.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       env:
         {{- with (include "sonarqube.install-plugins-proxy.env" .) }}
         {{- . | nindent 8 }}

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -9,6 +9,6 @@ data:
       rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
       cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.plugins.install }}
-      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
+      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} {{ if $.Values.plugins.curlOpts }}{{$.Values.plugins.curlOpts}}{{ end }} -fsSLO {{ $val | quote }}
       {{- end }}
     {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -421,6 +421,10 @@ plugins:
   noCheckCertificate: false
   # Reuse default initcontainers.securityContext that match restricted pod security standard
   # securityContext: {}
+  # Additional volumeMounts for the install-plugins initContainer
+  # extraVolumeMounts: {}
+  # Additional options for the install-plugins curl command
+  # curlOpts: ""
 
 ## (DEPRECATED) The following value sets SONAR_WEB_JAVAOPTS (e.g., jvmOpts: "-Djava.net.preferIPv4Stack=true"). However, this is deprecated, please set SONAR_WEB_JAVAOPTS or sonar.web.javaOpts directly instead.
 jvmOpts: ""


### PR DESCRIPTION
This Commit introduces two new helm values for configuring extraVolumeMounts and additonal curl options for the install-plugins initContainer. The values can be used to mount additonal CABundles into the install-plugins container. With curlOpts the mounted CABundle can be used in the shell script that invokes curl to download the plugins.

For example:

```yaml
plugins:
  curlOpts: "--cacert=/certs/myCABundle.crt" 
  extraVolumeMounts:
    - mountPath: /certs/myCABundle.crt 
      subPath: myCABundle.crt 
      name: my-ca-bundle
```

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`