### PR TITLE
Support annotations in HTTPRoute

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Upgrade Chart's version to 2026.5.0
 * **Breaking**: Remove the deprecated `ingress-nginx.enabled`/`nginx.enabled` bundled ingress-nginx controller subchart dependency. `ingress.enabled` remains supported for use with a self-managed ingress controller; `httproute.enabled` (Gateway API) is also available
 * Add `gateway-api-migration-scripts/nginx-to-istio-migration.sh` to help migrate from the bundled ingress-nginx controller to Gateway API
+* Support annotations in HTTPRoute
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -39,6 +39,8 @@ annotations:
       description: "Upgrade Chart's version to 2026.5.0"
     - kind: removed
       description: "Remove the deprecated ingress-nginx.enabled/nginx.enabled bundled ingress-nginx controller subchart dependency; ingress.enabled remains supported for a self-managed controller, or use httproute (Gateway API)"
+    - kind: added
+      description: "Support annotations in HTTPRoute"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/http-route.yaml
+++ b/charts/sonarqube-dce/templates/http-route.yaml
@@ -13,6 +13,12 @@ metadata:
     {{- with .Values.httproute.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.httproute.annotations }}
+  annotations:
+    {{- with .Values.httproute.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
 spec:
   parentRefs:
   - name: {{ .Values.httproute.gateway }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -482,6 +482,8 @@ httproute:
   # gatewayNamespace: my-gateway-namespace # optional
   # labels:
   #   somelabel: somevalue
+  # annotations:
+  #   someannotation: somevalue
   # hostnames:
   #   - sonarqube.your-org.com
   # The rules are optional, by default we will create one with the SonarWebContext prefix and the SonarQube service values

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file.
 * Upgrade SonarQube Community build to 26.3.0.120487
 * Replace wget with curl in health probes
 * Use -fS flag in curl to show errors in liveness probes
+* Support annotations in HTTPRoute
 
 ## [2026.1.0]
 * Upgrade SonarQube Server to 2026.1.0

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -34,6 +34,7 @@ All changes to this chart will be documented in this file.
 * Upgrade SonarQube Community build to 26.3.0.120487
 * Replace wget with curl in health probes
 * Use -fS flag in curl to show errors in liveness probes
+* Support annotations in HTTPRoute
 
 ## [2026.1.0]
 * Upgrade SonarQube Server to 2026.1.0

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Upgrade Chart's version to 2026.5.0
 * **Breaking**: Remove the deprecated `ingress-nginx.enabled`/`nginx.enabled` bundled ingress-nginx controller subchart dependency. `ingress.enabled` remains supported for use with a self-managed ingress controller; `httproute.enabled` (Gateway API) is also available
 * Add `gateway-api-migration-scripts/nginx-to-istio-migration.sh` to help migrate from the bundled ingress-nginx controller to Gateway API
+* Support annotations in HTTPRoute
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
@@ -34,7 +35,6 @@ All changes to this chart will be documented in this file.
 * Upgrade SonarQube Community build to 26.3.0.120487
 * Replace wget with curl in health probes
 * Use -fS flag in curl to show errors in liveness probes
-* Support annotations in HTTPRoute
 
 ## [2026.1.0]
 * Upgrade SonarQube Server to 2026.1.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -44,6 +44,8 @@ annotations:
       description: "Upgrade Chart's version to 2026.5.0"
     - kind: removed
       description: "Remove the deprecated ingress-nginx.enabled/nginx.enabled bundled ingress-nginx controller subchart dependency; ingress.enabled remains supported for a self-managed controller, or use httproute (Gateway API)"
+    - kind: added
+      description: "Support annotations in HTTPRoute"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community

--- a/charts/sonarqube/templates/http-route.yaml
+++ b/charts/sonarqube/templates/http-route.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.httproute.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- with .Values.httproute.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   parentRefs:
   - name: {{ .Values.httproute.gateway }}

--- a/charts/sonarqube/templates/http-route.yaml
+++ b/charts/sonarqube/templates/http-route.yaml
@@ -8,10 +8,12 @@ metadata:
     {{- with .Values.httproute.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.httproute.annotations }}
   annotations:
     {{- with .Values.httproute.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}
 spec:
   parentRefs:
   - name: {{ .Values.httproute.gateway }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -156,6 +156,8 @@ httproute:
   # gatewayNamespace: my-gateway-namespace # optional
   # labels:
   #   somelabel: somevalue
+  # annotations:
+  #   someannotation: somevalue
   # hostnames:
   #   - sonarqube.your-org.com
   # The rules are optional, by default we will create one with the SonarWebContext prefix and the SonarQube service values
@@ -507,8 +509,7 @@ persistence:
   #   type: DirectoryOrCreate
 
 # In case you want to specify different resources for emptyDir than {}
-emptyDir:
-  {}
+emptyDir: {}
   # Example of resouces that might be used:
   # medium: Memory
   # sizeLimit: 16Mi

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -143,6 +143,8 @@ httproute:
   # gatewayNamespace: my-gateway-namespace # optional
   # labels:
   #   somelabel: somevalue
+  # annotations:
+  #   someannotation: somevalue
   # hostnames:
   #   - sonarqube.your-org.com
   # The rules are optional, by default we will create one with the SonarWebContext prefix and the SonarQube service values
@@ -495,8 +497,7 @@ persistence:
   #   type: DirectoryOrCreate
 
 # In case you want to specify different resources for emptyDir than {}
-emptyDir:
-  {}
+emptyDir: {}
   # Example of resouces that might be used:
   # medium: Memory
   # sizeLimit: 16Mi


### PR DESCRIPTION
# Motivation

Most external tools (like external-dns or cert-manager) rely on annotations instead of labels. Currently, only labels can be set while using the chart, which limit the interaction with external tools.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`