### PR TITLE
Support lifecycle hooks and fix terminationGracePeriodSeconds for SonarQube container

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [Unreleased]
+* Support lifecycle hooks on the SonarQube container via `lifecycle` value
+* Fix `terminationGracePeriodSeconds` not being applied to the pod spec (ref: SONAR-26367)
+
 ## [2026.2.0]
 * Upgrade Chart's version to 2026.2.0
 * Update ingress-nginx subchart to 4.14.3

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -24,6 +24,7 @@ metadata:
     {{- end }}
 spec:
   automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+  terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   {{- with .Values.schedulerName }}
   schedulerName: {{ . }}
   {{- end }}
@@ -355,6 +356,9 @@ spec:
         {{- with .Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.lifecycle }}
+      lifecycle: {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- with .Values.priorityClassName }}
   priorityClassName: {{ . }}
   {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -312,6 +312,13 @@ extraContainers: []
 extraVolumes: []
 extraVolumeMounts: []
 
+## Lifecycle hooks to add to the SonarQube container
+## Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycle: {}
+# preStop:
+#   exec:
+#     command: ["/bin/sh", "-c", "sleep 40"]
+
 ## Provide a secret containing one or more certificate files in the keys that will be added to cacerts
 ## The cacerts file will be set via SONARQUBE_WEB_JVM_OPTS and SONAR_CE_JAVAOPTS
 ##
@@ -645,5 +652,4 @@ extraConfig:
 # deprecated please use sonarWebContext at the value top level
 #   sonarWebContext: /
 
-# (DEPRECATED) This value is not used in the templates.
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
## Summary

This PR addresses [SONAR-26367](https://sonarsource.atlassian.net/browse/SONAR-26367), re-implementing the work from the previously closed #745.

### Changes

- **Add `lifecycle` value** to allow configuring container lifecycle hooks on the SonarQube container. This enables use cases such as a `preStop` hook to give the load balancer time to drain connections before the pod terminates — particularly important when running on spot/preemptible instances.
- **Fix `terminationGracePeriodSeconds`** — this value has existed in `values.yaml` since v0.9.0 but was never rendered into the pod spec template. It was recently marked as `(DEPRECATED) This value is not used in the templates` in the 10.8.0 changelog, but we believe this is a bug rather than an intentional removal: the value is meaningless if it isn't applied. This PR wires it up correctly.

### Example usage

```yaml
# values.yaml
lifecycle:
  preStop:
    exec:
      command: ["/bin/sh", "-c", "sleep 40"]

terminationGracePeriodSeconds: 60
```

### Checklist

- [x] Explain motives: graceful shutdown support for spot instance workloads and ALB draining
- [x] Changes documented in `CHANGELOG.md`

Relates to: https://sonarsource.atlassian.net/browse/SONAR-26367

[SONAR-26367]: https://sonarsource.atlassian.net/browse/SONAR-26367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ