### PR TITLE
feat: httproute sectionName option added

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Upgrade Chart's version to 2026.2.0
 * Update ingress-nginx subchart to 4.14.3
 * Replace wget with curl in health probes
+* Added optional sectionName option to httproute
 
 ## [2026.1.0]
 * Upgrade SonarQube Server to 2026.1.0

--- a/charts/sonarqube-dce/templates/http-route.yaml
+++ b/charts/sonarqube-dce/templates/http-route.yaml
@@ -19,6 +19,9 @@ spec:
     {{- if .Values.httproute.gatewayNamespace }}
     namespace: {{ .Values.httproute.gatewayNamespace }}
     {{- end }}
+    {{- if .Values.httproute.gatewaySectionName }}
+    sectionName: {{ .Values.httproute.gatewaySectionName }}
+    {{- end }}
   hostnames:
     {{- with .Values.httproute.hostnames }}
     {{- toYaml . | nindent 4 }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -471,6 +471,7 @@ httproute:
   enabled: false
   # gateway: my-gateway
   # gatewayNamespace: my-gateway-namespace # optional
+  # gatewaySectionName: my-gateway-section # optional
   # labels:
   #   somelabel: somevalue
   # hostnames:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to this chart will be documented in this file.
 * Update ingress-nginx subchart to 4.14.3
 * Upgrade SonarQube Community build to 26.3.0.120487
 * Replace wget with curl in health probes
+* Added optional sectionName option to httproute
 
 ## [2026.1.0]
 * Upgrade SonarQube Server to 2026.1.0

--- a/charts/sonarqube/templates/http-route.yaml
+++ b/charts/sonarqube/templates/http-route.yaml
@@ -14,6 +14,9 @@ spec:
     {{- if .Values.httproute.gatewayNamespace }}
     namespace: {{ .Values.httproute.gatewayNamespace }}
     {{- end }}
+    {{- if .Values.httproute.gatewaySectionName }}
+    sectionName: {{ .Values.httproute.gatewaySectionName }}
+    {{- end }}
   hostnames:
     {{- with .Values.httproute.hostnames }}
     {{- toYaml . | nindent 4 }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -154,6 +154,7 @@ httproute:
   enabled: false
   # gateway: my-gateway
   # gatewayNamespace: my-gateway-namespace # optional
+  # gatewaySectionName: my-gateway-section # optional
   # labels:
   #   somelabel: somevalue
   # hostnames:


### PR DESCRIPTION
Added optional sectionName option to httproute for when the gateway has multiple sections.

Please ensure your pull request adheres to the following guidelines:
- [ X ] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ X ] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`