### PR TITLE
SONAR-27393 Use major version tags for SonarSource GitHub Actions

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -16,7 +16,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/jira user | JIRA_USER;

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -18,7 +18,7 @@ jobs:
             || github.event.review.state == 'approved')
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/jira user | JIRA_USER;

--- a/.github/workflows/azure-marketplace.yml
+++ b/.github/workflows/azure-marketplace.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           version: 2026.3.13
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/team/sonarqube/kv/data/azure-marketplace-staging url | AZURE_ACR_REGISTRY_STAGING;
@@ -80,7 +80,7 @@ jobs:
         with:
           version: 2026.3.13
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/team/sonarqube/kv/data/azure-marketplace-production url | AZURE_ACR_REGISTRY_PRODUCTION;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           version: 2026.3.13
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/docker/sonardockerrw username | DOCKER_USERNAME;
@@ -222,7 +222,7 @@ jobs:
         if: matrix.chart == 'sonarqube-dce'
         run: NAMESPACE=test ./.github/scripts/setup_external_postgres.sh
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/docker/sonardockerrw username | DOCKER_USERNAME;
@@ -266,10 +266,10 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
+      - uses: SonarSource/ci-github-actions/get-build-number@v1
         id: build-number
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/SonarSource-helm-chart-sonarqube-releases token | GITHUB_TOKEN;
@@ -320,14 +320,14 @@ jobs:
         with:
           cache_save: false
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
+      - uses: SonarSource/ci-github-actions/get-build-number@v1
         id: build-number
       - name: Download ${{ matrix.chart }} chart artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ matrix.chart }}-chart-${{ github.run_id }}
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/repox url | ARTIFACTORY_URL;
@@ -356,7 +356,7 @@ jobs:
         with:
           cache_save: false
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
+      - uses: SonarSource/ci-github-actions/get-build-number@v1
         id: build-number
       - name: Download SonarQube chart artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -367,7 +367,7 @@ jobs:
         with:
           name: sonarqube-dce-chart-${{ github.run_id }}
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/SonarSource-helm-chart-sonarqube-releases token | GITHUB_TOKEN;

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           version: 2026.3.13
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/team/sonarqube/kv/data/gcp-marketplace-registry-staging key | DOCKER_GCLOUD_SA_KEY;
@@ -95,7 +95,7 @@ jobs:
       - name: Setup GCP tools
         run: ./.github/scripts/setup.sh
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/team/sonarqube/kv/data/gcp-marketplace-registry-staging key | DOCKER_GCLOUD_SA_KEY;
@@ -144,7 +144,7 @@ jobs:
         with:
           version: 2026.3.13
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/team/sonarqube/kv/data/gcp-marketplace-registry-staging key | DOCKER_GCLOUD_SA_KEY;

--- a/.github/workflows/next-scan.yml
+++ b/.github/workflows/next-scan.yml
@@ -24,7 +24,7 @@ jobs:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
     - id: secrets
-      uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+      uses: SonarSource/vault-action-wrapper@v3
       with:
         secrets: |
           development/kv/data/next token | sq_next_token;

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -9,4 +9,4 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: SonarSource/ci-github-actions/pr_cleanup@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
       contents: write
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | artifactory_access_token;
             development/kv/data/slack webhook | slack_webhook_url;
-      - uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # v3.6.0
+      - uses: SonarSource/jfrog-setup-wrapper@v3
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
       - name: Create local repository directory
         id: local_repo
         run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> "$GITHUB_OUTPUT"
-      - uses: SonarSource/gh-action_release/download-build@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
+      - uses: SonarSource/gh-action_release/download-build@v6
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
           remote-repo: sonarsource-helm

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Vault Secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/slack token | SLACK_TOKEN;


### PR DESCRIPTION
Replace SHA pins with major version tags so CI always resolves to the latest patch release.

- `ci-github-actions/get-build-number` → `@v1`
- `ci-github-actions/pr_cleanup` → `@v1`
- `gh-action_release/download-build` → `@v6`
- `jfrog-setup-wrapper` → `@v3`
- `vault-action-wrapper` → `@v3`