### PR TITLE
SONAR-27771: Fix MCP init container and SONARQUBE_URL to respect sonarWebContext

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Upgrade Chart's version to 2026.3.0
 * Add `applicationNodes.topologySpreadConstraints` and `searchNodes.topologySpreadConstraints` to support spreading pods across topology domains
 * Add MCP (Model Context Protocol) server support via `mcp.enabled`
+* Fix MCP init container and SONARQUBE_URL to respect `sonarWebContext` when non-root
 
 ## [2026.2.0]
 * Upgrade Chart's version to 2026.2.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -45,6 +45,8 @@ annotations:
       description: "Add topology spread constraints support for application and search pods"
     - kind: added
       description: "Add MCP (Model Context Protocol) server support via mcp.enabled"
+    - kind: fixed
+      description: "Fix MCP init container and SONARQUBE_URL to respect sonarWebContext when non-root"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/mcp.yaml
+++ b/charts/sonarqube-dce/templates/mcp.yaml
@@ -43,7 +43,7 @@ spec:
             - sh
             - -c
             - |
-              until curl -sf "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}/api/system/status" | grep -q '"status":"UP"'; do
+              until curl -sf "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}{{ include "sonarqube.webcontext" . }}api/system/status" | grep -q '"status":"UP"'; do
                 echo "Waiting for SonarQube to be UP..."; sleep 10;
               done
       containers:
@@ -58,7 +58,7 @@ spec:
             - name: STORAGE_PATH
               value: /data
             - name: SONARQUBE_URL
-              value: {{ printf "http://%s:%d" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) }}
+              value: {{ printf "http://%s:%d%s" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) (trimSuffix "/" (include "sonarqube.webcontext" .)) }}
             - name: SONARQUBE_HTTP_HOST
               value: "0.0.0.0"
             - name: SONARQUBE_HTTP_PORT

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -5,6 +5,7 @@ All changes to this chart will be documented in this file.
 * Upgrade Chart's version to 2026.3.0
 * Upgrade SonarQube Community build to 26.4.0.121862
 * Add MCP (Model Context Protocol) server support via `mcp.enabled`
+* Fix MCP init container and SONARQUBE_URL to respect `sonarWebContext` when non-root
 
 ## [2026.2.0]
 * Upgrade Chart's version to 2026.2.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -44,6 +44,8 @@ annotations:
       description: "Upgrade SonarQube Community build to 26.4.0.121862"
     - kind: added
       description: "Add MCP (Model Context Protocol) server support via mcp.enabled"
+    - kind: fixed
+      description: "Fix MCP init container and SONARQUBE_URL to respect sonarWebContext when non-root"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community

--- a/charts/sonarqube/templates/mcp.yaml
+++ b/charts/sonarqube/templates/mcp.yaml
@@ -43,7 +43,7 @@ spec:
             - sh
             - -c
             - |
-              until curl -sf "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}/api/system/status" | grep -q '"status":"UP"'; do
+              until curl -sf "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}{{ include "sonarqube.webcontext" . }}api/system/status" | grep -q '"status":"UP"'; do
                 echo "Waiting for SonarQube to be UP..."; sleep 10;
               done
       containers:
@@ -58,7 +58,7 @@ spec:
             - name: STORAGE_PATH
               value: /data
             - name: SONARQUBE_URL
-              value: {{ printf "http://%s:%d" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) }}
+              value: {{ printf "http://%s:%d%s" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) (trimSuffix "/" (include "sonarqube.webcontext" .)) }}
             - name: SONARQUBE_HTTP_HOST
               value: "0.0.0.0"
             - name: SONARQUBE_HTTP_PORT

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
@@ -1,0 +1,902 @@
+---
+# Source: sonarqube-dce/templates/pod-disruption-budget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-search
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+spec:
+  minAvailable: 2
+
+  selector:
+    matchLabels:
+      sonarqube.datacenter/type: "search"
+---
+# Source: sonarqube-dce/templates/pod-disruption-budget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-app
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+spec:
+  minAvailable: 1
+
+  selector:
+    matchLabels:
+      sonarqube.datacenter/type: "app"
+---
+# Source: sonarqube-dce/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-monitoring-passcode
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+type: Opaque
+data:
+  SONAR_WEB_SYSTEMPASSCODE: "dGVzdA=="
+---
+# Source: sonarqube-dce/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+type: Opaque
+data:
+  jdbc-password: "cGFzcw=="
+---
+# Source: sonarqube-dce/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-jwt
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+type: Opaque
+data:
+  SONAR_AUTH_JWTBASE64HS256SECRET: "c29tZS1zZWNyZXQ="
+---
+# Source: sonarqube-dce/templates/secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-http-proxies
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+type: Opaque
+stringData:
+  PLUGINS-HTTP-PROXY: ""
+  PLUGINS-HTTPS-PROXY: ""
+  PLUGINS-NO-PROXY: ""
+  PROMETHEUS-EXPORTER-HTTP-PROXY: ""
+  PROMETHEUS-EXPORTER-HTTPS-PROXY: ""
+  PROMETHEUS-EXPORTER-NO-PROXY: ""
+---
+# Source: sonarqube-dce/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-app-config
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  sonar.properties: |
+---
+# Source: sonarqube-dce/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-search-config
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  sonar.properties: |
+---
+# Source: sonarqube-dce/templates/init-fs.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-init-fs
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  init_fs.sh: |-
+    chown -R 1000:0 /opt/sonarqube/data
+    chown -R 1000:0 /opt/sonarqube/temp
+    chown -R 1000:0 /opt/sonarqube/logs
+---
+# Source: sonarqube-dce/templates/init-sysctl.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-init-sysctl
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  init_sysctl.sh: |-
+    set -o errexit
+    set -o xtrace
+    vmMaxMapCount=524288
+    if [[ "$(sysctl -n vm.max_map_count)" -lt $vmMaxMapCount ]]; then
+      sysctl -w vm.max_map_count=$vmMaxMapCount
+      if [[ "$(sysctl -n vm.max_map_count)" -lt $vmMaxMapCount ]]; then
+        echo "Failed to set initSysctl.vmMaxMapCount"; exit 1
+      fi
+    fi
+    fsFileMax=131072
+    if [[ "$(sysctl -n fs.file-max)" -lt $fsFileMax ]]; then
+      sysctl -w fs.file-max=$fsFileMax
+      if [[ "$(sysctl -n fs.file-max)" -lt $fsFileMax ]]; then
+        echo "Failed to set initSysctl.fsFileMax"; exit 1
+      fi
+    fi
+    nofile=131072
+    if [[ "$(ulimit -n)" != "unlimited" ]]; then
+      if [[ "$(ulimit -n)" -lt $nofile ]]; then
+        ulimit -n $nofile
+        if [[ "$(ulimit -n)" -lt $nofile ]]; then
+          echo "Failed to set initSysctl.nofile"; exit 1
+        fi
+      fi
+    fi
+    nproc=8192
+    if [[ "$(ulimit -u)" != "unlimited" ]]; then
+      if [[ "$(ulimit -u)" -lt $nproc ]]; then
+        ulimit -u $nproc
+        if [[ "$(ulimit -u)" -lt $nproc ]]; then
+          echo "Failed to set initSysctl.nproc"; exit 1
+        fi
+      fi
+    fi
+---
+# Source: sonarqube-dce/templates/install-plugins.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-install-plugins
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  install_plugins.sh: |-
+---
+# Source: sonarqube-dce/templates/jdbc-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-jdbc-config
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  SONAR_JDBC_USERNAME: "user"
+  SONAR_JDBC_URL: "jdbc:postgresql://myPostgres/myDatabase?socketTimeout=1500"
+---
+# Source: sonarqube-dce/templates/mcp-pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-mcp
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "2Gi"
+---
+# Source: sonarqube-dce/templates/mcp-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-mcp
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: sonarqube-dce-mcp
+    release: mcp-web-context-values.yaml
+---
+# Source: sonarqube-dce/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: sonarqube-dce
+    release: mcp-web-context-values.yaml
+---
+# Source: sonarqube-dce/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-headless
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9003
+      targetPort: hazelcast
+      protocol: TCP
+      appProtocol: tcp
+      name: hazelcast
+  selector:
+    app: sonarqube-dce
+    release: mcp-web-context-values.yaml
+---
+# Source: sonarqube-dce/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-search
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9001
+      targetPort: search-port
+      protocol: TCP
+      name: search
+    - port: 9002
+      targetPort: es-port
+      protocol: TCP
+      name: es
+  selector:
+    app: sonarqube-dce-search
+    release: mcp-web-context-values.yaml
+---
+# Source: sonarqube-dce/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-search-headless
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9001
+      targetPort: search-port
+      protocol: TCP
+      name: search
+    - port: 9002
+      targetPort: es-port
+      protocol: TCP
+      name: es
+  selector:
+    app: sonarqube-dce-search
+    release: mcp-web-context-values.yaml
+---
+# Source: sonarqube-dce/templates/mcp.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-mcp
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarqube-dce-mcp
+      release: mcp-web-context-values.yaml
+  template:
+    metadata:
+      labels:
+        app: sonarqube-dce-mcp
+        release: mcp-web-context-values.yaml
+    spec:
+      initContainers:
+        - name: wait-for-sonarqube
+          image: sonarqube:2026.2.0-datacenter-app
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "http://mcp-web-context-values.yaml-sonarqube-dce:9000/sonarqube-pre-prod/api/system/status" | grep -q '"status":"UP"'; do
+                echo "Waiting for SonarQube to be UP..."; sleep 10;
+              done
+      containers:
+        - name: mcp
+          image: mcp/sonarqube:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: STORAGE_PATH
+              value: /data
+            - name: SONARQUBE_URL
+              value: http://mcp-web-context-values.yaml-sonarqube-dce:9000/sonarqube-pre-prod
+            - name: SONARQUBE_HTTP_HOST
+              value: "0.0.0.0"
+            - name: SONARQUBE_HTTP_PORT
+              value: "8080"
+            - name: SONARQUBE_TRANSPORT
+              value: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: mcp-data
+              mountPath: /data
+      volumes:
+        - name: mcp-data
+          persistentVolumeClaim:
+            claimName: mcp-web-context-values.yaml-sonarqube-dce-mcp
+---
+# Source: sonarqube-dce/templates/sonarqube-application.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-app
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/name: mcp-web-context-values.yaml
+    sonarqube.datacenter/type: "app"
+    app.kubernetes.io/instance: mcp-web-context-values.yaml
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: sonarqube
+    app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
+    app.kubernetes.io/version: "2026.2.0-datacenter-app"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sonarqube-dce
+      release: mcp-web-context-values.yaml
+  template:
+    metadata:
+      labels:
+        app: sonarqube-dce
+        release: mcp-web-context-values.yaml
+        sonarqube.datacenter/type: "app"
+      annotations:
+        checksum/plugins: 6c150410ac9b45dabef947fa81a7f22bbae6a6d59cb90f8e2f02e5cfe4ace3c3
+        checksum/config: 2b5f123416452fd3d17d421380c8a9f68a397a9d1cff147762b4360eac00ca27
+        checksum/secret: 83ce67ba6b2cb426929b679a576c6d41d1c18d24556887973e23c6c9c74c8691
+    spec:
+      automountServiceAccountToken: false
+      initContainers:
+      securityContext:
+        fsGroup: 0
+      containers:
+        - name: sonarqube-dce
+          image: sonarqube:2026.2.0-datacenter-app
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+            - name: hazelcast
+              containerPort: 9003
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 800m
+              ephemeral-storage: 512000M
+              memory: 4096M
+            requests:
+              cpu: 400m
+              ephemeral-storage: 1536M
+              memory: 4096M
+          env:
+            - name: SONAR_WEB_CONTEXT
+              value: /sonarqube-pre-prod/
+            - name: SONAR_WEB_JAVAOPTS
+              value: ""
+            - name: SONAR_CE_JAVAOPTS
+              value: ""
+            - name: SONAR_LOG_JSONOUTPUT
+              value: "false"
+            - name: SONAR_HELM_CHART_VERSION
+              value: 2026.3.0
+            - name: SONAR_CLUSTER_SEARCH_HOSTS
+              value: "mcp-web-context-values.yaml-sonarqube-dce-search"
+            - name: SONAR_CLUSTER_KUBERNETES
+              value: "true"
+            - name: SONAR_CLUSTER_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SONAR_CLUSTER_HOSTS
+              value: "mcp-web-context-values.yaml-sonarqube-dce-headless"
+            - name: SONAR_AUTH_JWTBASE64HS256SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "mcp-web-context-values.yaml-sonarqube-dce-jwt"
+                  key: SONAR_AUTH_JWTBASE64HS256SECRET
+            - name: SONAR_JDBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-web-context-values.yaml-sonarqube-dce
+                  key: jdbc-password
+            - name: SONAR_WEB_SYSTEMPASSCODE
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-web-context-values.yaml-sonarqube-dce-monitoring-passcode
+                  key: SONAR_WEB_SYSTEMPASSCODE
+            - name: SONAR_MCP_ENABLED
+              value: "true"
+            - name: SONAR_MCP_SERVERURL
+              value: "http://mcp-web-context-values.yaml-sonarqube-dce-mcp:8080"
+          envFrom:
+            - configMapRef:
+                name: mcp-web-context-values.yaml-sonarqube-dce-jdbc-config
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - |-
+                host="$(hostname -i || echo '127.0.0.1')"
+                curl --noproxy "*" -fsS -o /dev/null --max-time 1 -H "X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" "http://${host}:9000/sonarqube-pre-prod/api/system/liveness"
+            failureThreshold: 6
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            timeoutSeconds: 1
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - |-
+                #!/bin/bash
+                # A Sonarqube container is considered ready if the status is UP, DB_MIGRATION_NEEDED or DB_MIGRATION_RUNNING
+                # status about migration are added to prevent the node to be kill while sonarqube is upgrading the database.
+                host="$(hostname -i || echo '127.0.0.1')"
+                if curl --noproxy "*" -s http://${host}:9000/sonarqube-pre-prod/api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'; then
+                  exit 0
+                fi
+                exit 1
+            failureThreshold: 8
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              scheme: HTTP
+              path: /sonarqube-pre-prod/api/system/status
+              port: http
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            failureThreshold: 32
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /opt/sonarqube/data
+              name: sonarqube
+              subPath: data
+            - mountPath: /opt/sonarqube/temp
+              name: sonarqube
+              subPath: temp
+            - mountPath: /opt/sonarqube/logs
+              name: sonarqube
+              subPath: logs
+            - mountPath: /tmp
+              name: tmp-dir
+      serviceAccountName: default
+      volumes:
+      
+      - name: install-plugins
+        configMap:
+          name: mcp-web-context-values.yaml-sonarqube-dce-install-plugins
+          items:
+            - key: install_plugins.sh
+              path: install_plugins.sh
+      - name: sonarqube
+        emptyDir:
+          {}
+      - name : tmp-dir
+        emptyDir:
+          {}
+---
+# Source: sonarqube-dce/templates/sonarqube-search.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-dce-search
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/name: "mcp-web-context-values.yaml"
+    sonarqube.datacenter/type: "search"
+    app.kubernetes.io/instance: mcp-web-context-values.yaml
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: sonarqube
+    app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
+    app.kubernetes.io/version: "2026.2.0-datacenter-search"
+spec:
+  podManagementPolicy : Parallel
+  replicas: 3
+  serviceName: mcp-web-context-values.yaml-sonarqube-dce-search
+  selector:
+    matchLabels:
+      app: sonarqube-dce-search
+      release: mcp-web-context-values.yaml
+  volumeClaimTemplates:
+  - metadata:
+      name: mcp-web-context-values.yaml-sonarqube-dce
+      labels:
+        release: mcp-web-context-values.yaml
+        chart: "sonarqube-dce"
+        app: "mcp-web-context-values.yaml-sonarqube-dce"
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: "5Gi"
+  template:
+    metadata:
+      labels:
+        app: sonarqube-dce-search
+        release: mcp-web-context-values.yaml
+        sonarqube.datacenter/type: "search"
+      annotations:
+        checksum/init-sysctl: 8180f528405fd3135137649a208c6db34da051fd273e1738740e07422e058509
+        checksum/init-fs: d6a8054332664f9f71b1241b703dd42232d4914d3b5fa856887adc1908479499
+        checksum/config: 2b5f123416452fd3d17d421380c8a9f68a397a9d1cff147762b4360eac00ca27
+        checksum/secret: 83ce67ba6b2cb426929b679a576c6d41d1c18d24556887973e23c6c9c74c8691
+    spec:
+      automountServiceAccountToken: false
+      initContainers:
+        - name: init-sysctl
+          image: sonarqube:2026.2.0-datacenter-app
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+          resources:
+            {}
+          command: ["/bin/bash",
+            "-e",
+            "/tmp/scripts/init_sysctl.sh"]
+          volumeMounts:
+            - name: init-sysctl
+              mountPath: /tmp/scripts/
+        - name: init-fs
+          image: sonarqube:2026.2.0-datacenter-app
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+              - CHOWN
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            {}
+          command: ["sh",
+            "-ex",
+            "/tmp/scripts/init_fs.sh"]
+          volumeMounts:
+            - name: init-fs
+              mountPath: /tmp/scripts/
+            - mountPath: /opt/sonarqube/certs
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: certs
+            - mountPath: /opt/sonarqube/data
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: data
+            - mountPath: /opt/sonarqube/temp
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: temp
+            - mountPath: /opt/sonarqube/logs
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: logs
+            - mountPath: /tmp
+              name: tmp-dir
+      securityContext:
+        fsGroup: 0
+      containers:
+        - name: sonarqube-dce-search
+          image: "sonarqube:2026.2.0-datacenter-search"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: search-port
+              containerPort: 9001
+              protocol: TCP
+            - name: es-port
+              containerPort: 9002
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 800m
+              ephemeral-storage: 512000M
+              memory: 3072M
+            requests:
+              cpu: 400m
+              ephemeral-storage: 1536M
+              memory: 3072M
+          env:
+            - name: SONAR_LOG_JSONOUTPUT
+              value: "false"
+            - name: SONAR_CLUSTER_ES_HOSTS
+              value: "mcp-web-context-values.yaml-sonarqube-dce-search-0,mcp-web-context-values.yaml-sonarqube-dce-search-1,mcp-web-context-values.yaml-sonarqube-dce-search-2,"
+            - name: SONAR_CLUSTER_ES_DISCOVERY_SEED_HOSTS
+              value: "mcp-web-context-values.yaml-sonarqube-dce-search-headless"
+            - name: SONAR_CLUSTER_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                #!/bin/bash
+                # A Sonarqube search node container is considered live if http call returns 200
+                host="$(hostname -i || echo '127.0.0.1')"
+                if curl --noproxy "*" -sS "http://${host}:9001/_cluster/health?local=true" | grep -q -e '"status":"green"' -e '"status":"yellow"'; then
+                  exit 0
+                fi
+                exit 1
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 1
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                #!/bin/bash
+                # A Sonarqube search node container is considered ready if the status of embedded ES is green or yellow
+                host="$(hostname -i || echo '127.0.0.1')"
+                if curl --noproxy "*" -s "http://${host}:9001/_cluster/health?wait_for_status=yellow&timeout=50s" | grep -q -e '"status":"green"' -e '"status":"yellow"'; then
+                  exit 0
+                fi
+                exit 1
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 1
+          startupProbe:
+            exec:
+             command:
+              - sh
+              - -c
+              - |
+                #!/bin/bash
+                # A Sonarqube search node container is considered started if http call returns 200
+                host="$(hostname -i || echo '127.0.0.1')"
+                if curl --noproxy "*" -sS "http://${host}:9001/_cluster/health?local=true" | grep -q -e '"status":"green"' -e '"status":"yellow"'; then
+                  exit 0
+                fi
+                exit 1
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 24
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /opt/sonarqube/certs
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: certs
+              readOnly: true
+            - mountPath: /opt/sonarqube/data
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: data
+            - mountPath: /opt/sonarqube/temp
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: temp
+            - mountPath: /opt/sonarqube/logs
+              name: "mcp-web-context-values.yaml-sonarqube-dce"
+              subPath: logs
+            - mountPath: /tmp
+              name: tmp-dir
+      serviceAccountName: default
+      volumes:
+      
+      - name: init-sysctl
+        configMap:
+          name: mcp-web-context-values.yaml-sonarqube-dce-init-sysctl
+          items:
+            - key: init_sysctl.sh
+              path: init_sysctl.sh
+      - name: init-fs
+        configMap:
+          name: mcp-web-context-values.yaml-sonarqube-dce-init-fs
+          items:
+            - key: init_fs.sh
+              path: init_fs.sh
+      - name: "mcp-web-context-values.yaml-sonarqube-dce"
+      - name : tmp-dir
+        emptyDir:
+          {}
+---
+# Source: sonarqube-dce/templates/tests/sonarqube-test.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "mcp-web-context-values.yaml-ui-test"
+  annotations:
+    "helm.sh/hook": test-success
+    # Disable Istio sidecar injection for this test pod
+    "sidecar.istio.io/inject": "false"
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+spec:
+  automountServiceAccountToken: false
+  containers:
+    - name: mcp-web-context-values.yaml-ui-test
+      image: "sonarqube:2026.2.0-datacenter-app"
+      imagePullPolicy: IfNotPresent
+      command: ['curl']
+      args: [
+        '--retry-connrefused',
+        '--retry',
+        '1200',
+        '--retry-delay',
+        '1',
+        '--max-time',
+        '5',
+        '-s',
+        'mcp-web-context-values.yaml-sonarqube-dce:9000/api/system/status'
+        ]
+      resources:
+        limits:
+          cpu: 500m
+          ephemeral-storage: 1000M
+          memory: 200M
+        requests:
+          cpu: 500m
+          ephemeral-storage: 100M
+          memory: 200M
+  restartPolicy: Never

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
@@ -1,0 +1,474 @@
+---
+# Source: sonarqube/templates/secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-monitoring-passcode
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+type: Opaque
+data:
+  SONAR_WEB_SYSTEMPASSCODE: "dGVzdA=="
+---
+# Source: sonarqube/templates/secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-http-proxies
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+type: Opaque
+stringData:
+  PLUGINS-HTTP-PROXY: ""
+  PLUGINS-HTTPS-PROXY: ""
+  PLUGINS-NO-PROXY: ""
+  PROMETHEUS-EXPORTER-HTTP-PROXY: ""
+  PROMETHEUS-EXPORTER-HTTPS-PROXY: ""
+  PROMETHEUS-EXPORTER-NO-PROXY: ""
+---
+# Source: sonarqube/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-config
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  sonar.properties: |
+---
+# Source: sonarqube/templates/init-sysctl.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-init-sysctl
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  init_sysctl.sh: |-
+    set -o errexit
+    set -o xtrace
+    vmMaxMapCount=524288
+    if [[ "$(sysctl -n vm.max_map_count)" -lt $vmMaxMapCount ]]; then
+      sysctl -w vm.max_map_count=$vmMaxMapCount
+      if [[ "$(sysctl -n vm.max_map_count)" -lt $vmMaxMapCount ]]; then
+        echo "Failed to set initSysctl.vmMaxMapCount"; exit 1
+      fi
+    fi
+    fsFileMax=131072
+    if [[ "$(sysctl -n fs.file-max)" -lt $fsFileMax ]]; then
+      sysctl -w fs.file-max=$fsFileMax
+      if [[ "$(sysctl -n fs.file-max)" -lt $fsFileMax ]]; then
+        echo "Failed to set initSysctl.fsFileMax"; exit 1
+      fi
+    fi
+    nofile=131072
+    if [[ "$(ulimit -n)" != "unlimited" ]]; then
+      if [[ "$(ulimit -n)" -lt $nofile ]]; then
+        ulimit -n $nofile
+        if [[ "$(ulimit -n)" -lt $nofile ]]; then
+          echo "Failed to set initSysctl.nofile"; exit 1
+        fi
+      fi
+    fi
+    nproc=8192
+    if [[ "$(ulimit -u)" != "unlimited" ]]; then
+      if [[ "$(ulimit -u)" -lt $nproc ]]; then
+        ulimit -u $nproc
+        if [[ "$(ulimit -u)" -lt $nproc ]]; then
+          echo "Failed to set initSysctl.nproc"; exit 1
+        fi
+      fi
+    fi
+---
+# Source: sonarqube/templates/install-plugins.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-install-plugins
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+data:
+  install_plugins.sh: |-
+---
+# Source: sonarqube/templates/mcp-pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-mcp
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "2Gi"
+---
+# Source: sonarqube/templates/mcp-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-mcp
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: sonarqube-mcp
+    release: mcp-web-context-values.yaml
+---
+# Source: sonarqube/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: sonarqube
+    release: mcp-web-context-values.yaml
+---
+# Source: sonarqube/templates/mcp.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube-mcp
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarqube-mcp
+      release: mcp-web-context-values.yaml
+  template:
+    metadata:
+      labels:
+        app: sonarqube-mcp
+        release: mcp-web-context-values.yaml
+    spec:
+      initContainers:
+        - name: wait-for-sonarqube
+          image: sonarqube:2026.2.0-enterprise
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "http://mcp-web-context-values.yaml-sonarqube:9000/sonarqube-pre-prod/api/system/status" | grep -q '"status":"UP"'; do
+                echo "Waiting for SonarQube to be UP..."; sleep 10;
+              done
+      containers:
+        - name: mcp
+          image: mcp/sonarqube:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: STORAGE_PATH
+              value: /data
+            - name: SONARQUBE_URL
+              value: http://mcp-web-context-values.yaml-sonarqube:9000/sonarqube-pre-prod
+            - name: SONARQUBE_HTTP_HOST
+              value: "0.0.0.0"
+            - name: SONARQUBE_HTTP_PORT
+              value: "8080"
+            - name: SONARQUBE_TRANSPORT
+              value: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: mcp-data
+              mountPath: /data
+      volumes:
+        - name: mcp-data
+          persistentVolumeClaim:
+            claimName: mcp-web-context-values.yaml-sonarqube-mcp
+---
+# Source: sonarqube/templates/sonarqube-sts.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mcp-web-context-values.yaml-sonarqube
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+    app.kubernetes.io/name: mcp-web-context-values.yaml
+    app.kubernetes.io/instance: mcp-web-context-values.yaml
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: sonarqube
+    app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube
+    app.kubernetes.io/version: "2026.2.0-enterprise"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  serviceName: mcp-web-context-values.yaml-sonarqube
+  selector:
+    matchLabels:
+      app: sonarqube
+      release: mcp-web-context-values.yaml
+  template:
+    metadata:
+      annotations:
+        checksum/config: e6a43247e33b665e1912996ffe87acb18212f7f77fc2c400acd0fdbd89b2663e
+        checksum/init-sysctl: 4b08e8811aa86fefd6c372c930531ff1416b7547ba99944f21490d16911619a2
+        checksum/plugins: 5e993323231464b9b5edf5b5b8db87f21d68865e42c44d543caf82a04da1d4ed
+        checksum/secret: 87a0c78a641d5eafd1b4be808cb50ec5bb1ac4b41e7acd327b78263e238c33fa
+      labels:
+        app: sonarqube
+        release: mcp-web-context-values.yaml
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 0
+      initContainers:
+        - name: init-sysctl
+          image: sonarqube:2026.2.0-enterprise
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+          command: ["/bin/bash", "-e", "/tmp/scripts/init_sysctl.sh"]
+          volumeMounts:
+            - name: init-sysctl
+              mountPath: /tmp/scripts/
+          env:
+            - name: SONAR_WEB_CONTEXT
+              value: /sonarqube-pre-prod/
+            - name: SONAR_WEB_JAVAOPTS
+              value: ""
+            - name: SONAR_CE_JAVAOPTS
+              value: ""
+      containers:
+        - name: sonarqube
+          image: sonarqube:2026.2.0-enterprise
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 800m
+              ephemeral-storage: 512000M
+              memory: 6144M
+            requests:
+              cpu: 400m
+              ephemeral-storage: 1536M
+              memory: 2048M
+          env:
+            - name: SONAR_HELM_CHART_VERSION
+              value: 2026.3.0
+            - name: SONAR_WEB_SYSTEMPASSCODE
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-web-context-values.yaml-sonarqube-monitoring-passcode
+                  key: SONAR_WEB_SYSTEMPASSCODE
+            - name: SONAR_MCP_ENABLED
+              value: "true"
+            - name: SONAR_MCP_SERVERURL
+              value: "http://mcp-web-context-values.yaml-sonarqube-mcp:8080"
+            - name: SONAR_WEB_CONTEXT
+              value: /sonarqube-pre-prod/
+            - name: SONAR_WEB_JAVAOPTS
+              value: ""
+            - name: SONAR_CE_JAVAOPTS
+              value: ""
+          envFrom:
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                curl --noproxy "*" -fsS -o /dev/null --max-time 1 -H "X-Sonar-Passcode: $SONAR_WEB_SYSTEMPASSCODE" "http://localhost:9000/sonarqube-pre-prod/api/system/liveness"
+            failureThreshold: 6
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 1
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - |
+                #!/bin/bash
+                # A Sonarqube container is considered ready if the status is UP, DB_MIGRATION_NEEDED or DB_MIGRATION_RUNNING
+                # status about migration are added to prevent the node to be kill while SonarQube is upgrading the database.
+                if curl --noproxy "*" -s http://localhost:9000/sonarqube-pre-prod/api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'; then
+                  exit 0
+                fi
+                exit 1
+            failureThreshold: 6
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              scheme: HTTP
+              path: /sonarqube-pre-prod/api/system/status
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 24
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /opt/sonarqube/data
+              name: sonarqube
+              subPath: data
+            - mountPath: /opt/sonarqube/temp
+              name: sonarqube
+              subPath: temp
+            - mountPath: /opt/sonarqube/logs
+              name: sonarqube
+              subPath: logs
+            - mountPath: /tmp
+              name: tmp-dir
+            - mountPath: /opt/sonarqube/extensions
+              name: sonarqube
+              subPath: extensions
+      serviceAccountName: default
+      volumes:
+        
+        - name: init-sysctl
+          configMap:
+            name: mcp-web-context-values.yaml-sonarqube-init-sysctl
+            items:
+              - key: init_sysctl.sh
+                path: init_sysctl.sh
+        - name: sonarqube
+          emptyDir:
+            {}
+        - name : tmp-dir
+          emptyDir:
+            {}
+---
+# Source: sonarqube/templates/tests/sonarqube-test.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "mcp-web-context-values.yaml-ui-test"
+  annotations:
+    "helm.sh/hook": test-success
+    # Disable Istio sidecar injection for this test pod
+    "sidecar.istio.io/inject": "false"
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.3.0
+    release: mcp-web-context-values.yaml
+    heritage: Helm
+spec:
+  automountServiceAccountToken: false
+  containers:
+    - name: mcp-web-context-values.yaml-ui-test
+      image: "sonarqube:2026.2.0-enterprise"
+      imagePullPolicy: IfNotPresent
+      command: ['curl']
+      args: [
+        '--retry-connrefused',
+        '--retry',
+        '12',
+        '--retry-delay',
+        '1',
+        '--max-time',
+        '5',
+        '-s',
+        'mcp-web-context-values.yaml-sonarqube:9000/api/system/status'
+        ]
+      resources:
+        limits:
+          cpu: 500m
+          ephemeral-storage: 1000M
+          memory: 200M
+        requests:
+          cpu: 500m
+          ephemeral-storage: 100M
+          memory: 200M
+  restartPolicy: Never

--- a/tests/unit-compatibility-test/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/sonarqube-dce/mcp-web-context-values.yaml
@@ -1,0 +1,10 @@
+sonarWebContext: /sonarqube-pre-prod/
+mcp:
+  enabled: true
+  image:
+    repository: mcp/sonarqube
+    tag: "1.0.0"
+  port: 8080
+  persistence:
+    enabled: true
+    size: 2Gi

--- a/tests/unit-compatibility-test/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/sonarqube/mcp-web-context-values.yaml
@@ -1,0 +1,11 @@
+edition: enterprise
+sonarWebContext: /sonarqube-pre-prod/
+mcp:
+  enabled: true
+  image:
+    repository: mcp/sonarqube
+    tag: "1.0.0"
+  port: 8080
+  persistence:
+    enabled: true
+    size: 2Gi


### PR DESCRIPTION
SONAR-27771: Fix MCP init container and SONARQUBE_URL to respect sonarWebContext when non-root.

## Problem

Two failures occur when `sonarWebContext` is set to a non-root value (e.g. `/sonarqube-pre-prod/`):

- The `wait-for-sonarqube` init container polls `/api/system/status` without the context prefix — the loop never exits even when SonarQube is up.
- `SONARQUBE_URL` is built without the web context — the MCP server calls `<URL>/api/system/status` and receives an HTML redirect instead of JSON, causing a `JsonSyntaxException` (`Expected BEGIN_OBJECT but was STRING`).

## Changes

Both `charts/sonarqube/templates/mcp.yaml` and `charts/sonarqube-dce/templates/mcp.yaml`:

- Init container curl URL: prepend `{{ include "sonarqube.webcontext" . }}` before `api/system/status`
- `SONARQUBE_URL`: use `trimSuffix "/"` on the webcontext result so the MCP server receives a clean base URL without trailing slash (e.g. `http://service:9000/sonarqube-pre-prod`)

Uses the existing `sonarqube.webcontext` helper, which normalises the value to always start and end with `/` and is already used by app node probes and the change-admin-password hook.

Root context (`sonarWebContext: /`) is unaffected: `trimSuffix "/"` on `/` yields an empty string, leaving the URL unchanged.

## Tests

Added `mcp-web-context-values.yaml` test cases for both charts and regenerated fixtures. All kubeconform compatibility tests pass.