### PR TITLE
REL-4573: Release SonarQube Community Build 26.5

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2026.3.0]
 * Upgrade Chart's version to 2026.3.0
-* Upgrade SonarQube Community build to 26.4.0.121862
+* Upgrade SonarQube Community build to 26.5.0.122743
 * Add MCP (Model Context Protocol) server support via `mcp.enabled`
 
 ## [2026.2.0]

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -41,13 +41,13 @@ annotations:
     - kind: changed
       description: "Upgrade Chart's version to 2026.3.0"
     - kind: added
-      description: "Upgrade SonarQube Community build to 26.4.0.121862"
+      description: "Upgrade SonarQube Community build to 26.5.0.122743"
     - kind: added
       description: "Add MCP (Model Context Protocol) server support via mcp.enabled"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community
-      image: sonarqube:26.4.0.121862-community
+      image: sonarqube:26.5.0.122743-community
     - name: sonarqube-developer
       image: sonarqube:2026.2.0-developer
     - name: sonarqube-enterprise

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -16,7 +16,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 SonarQube Server Version: `2026.2.0`
 
-SonarQube Community Build: `26.4.0.121862`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
+SonarQube Community Build: `26.5.0.122743`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 
 ## Kubernetes and Openshift Compatibility
 
@@ -363,7 +363,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `annotations`           | SonarQube Pod annotations                                                                                             | `{}`               |
 | `edition`               | SonarQube Edition to use (`developer` or `enterprise`).                                                               | `None`             |
 | `community.enabled`     | Install SonarQube Community Build. When set to `true`, `edition` must not be set.                                     | `false`            |
-| `community.buildNumber` | The SonarQube Community Build number to install                                                                       | `26.4.0.121862`    |
+| `community.buildNumber` | The SonarQube Community Build number to install                                                                       | `26.5.0.122743`    |
 | `sonarWebContext`       | SonarQube web context, also serve as default value for `ingress.path`, `account.sonarWebContext` and probes path.     | ``                 |
 | `httpProxySecret`       | Should contain `http_proxy`, `https_proxy` and `no_proxy` keys, will supersede every other proxy variables            | ``                 |
 | `httpProxy`             | HTTP proxy for downloading JMX agent and install plugins, will supersede initContainer specific http proxy variables  | ``                 |

--- a/charts/sonarqube/ci/ci-values.yaml
+++ b/charts/sonarqube/ci/ci-values.yaml
@@ -5,7 +5,7 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "26.4.0.121862-master-community"
+  tag: "26.5.0.122743-master-community"
 monitoringPasscode: "test"
 
 resources:

--- a/charts/sonarqube/openshift-verifier/values.yaml
+++ b/charts/sonarqube/openshift-verifier/values.yaml
@@ -10,6 +10,6 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "26.4.0.121862-master-community"
+  tag: "26.5.0.122743-master-community"
 
 monitoringPasscode: "test"

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -54,7 +54,7 @@ OpenShift:
 # Set the chart to use the latest released SonarQube Community Build
 community:
   enabled: false
-  buildNumber: "26.4.0.121862"
+  buildNumber: "26.5.0.122743"
 
 # The following settings are used when deploying to Azure Marketplace
 # global:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: host-path-values.yaml-sonarqube
-    app.kubernetes.io/version: "26.4.0.121862-community"
+    app.kubernetes.io/version: "26.5.0.122743-community"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -202,7 +202,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:26.4.0.121862-community
+          image: sonarqube:26.5.0.122743-community
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -220,7 +220,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:26.4.0.121862-community
+          image: sonarqube:26.5.0.122743-community
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -255,7 +255,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:26.4.0.121862-community
+          image: sonarqube:26.5.0.122743-community
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -388,7 +388,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: host-path-values.yaml-ui-test
-      image: "sonarqube:26.4.0.121862-community"
+      image: "sonarqube:26.5.0.122743-community"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -23,7 +23,7 @@ var chartPath string = "../../charts/sonarqube"
 var releaseName string = "sonarqube"
 
 // Community Build Version
-var expectedContainerImage string = "sonarqube:26.4.0.121862"
+var expectedContainerImage string = "sonarqube:26.5.0.122743"
 
 // Ensure we are using the dry-run flag
 var helmOptions *helm.Options = &helm.Options{

--- a/tests/unit-test/test-cases-values/sonarqube/test-build-number.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-build-number.yaml
@@ -1,3 +1,3 @@
 community:
   enabled: true
-  buildNumber: "26.4.0.121862"
+  buildNumber: "26.5.0.122743"


### PR DESCRIPTION
## Summary

Release SonarQube Community Build 26.5 (`26.5.0.122743`).

## Changes

- `charts/sonarqube/Chart.yaml`: bump community image to `26.5.0.122743-community`
- `charts/sonarqube/values.yaml`: bump `community.buildNumber` to `26.5.0.122743`
- `charts/sonarqube/ci/ci-values.yaml`, `openshift-verifier/values.yaml`: bump image tag
- `charts/sonarqube/CHANGELOG.md`, `README.md`: update version references
- `tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml`: regenerated fixture

Jira: https://sonarsource.atlassian.net/browse/REL-4573