### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/azure-marketplace.yml
+++ b/.github/workflows/azure-marketplace.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-azure-staging-app:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Build Azure Staging App
     permissions:
       id-token: write
@@ -66,7 +66,7 @@ jobs:
 
   build-azure-prod-app:
     needs: [build-azure-staging-app]
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Build Azure Prod App
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   chart-fixture-test:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Chart Fixture Test
     permissions:
       id-token: write
@@ -41,7 +41,7 @@ jobs:
           git diff --exit-code
 
   chart-schema-test:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Chart Schema Test
     permissions:
       id-token: write
@@ -65,7 +65,7 @@ jobs:
 
 
   static-compatibility-test:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Static Compatibility Test (${{ matrix.chart }})
     strategy:
       matrix:
@@ -183,11 +183,11 @@ jobs:
         include:
           - chart: sonarqube
             config: ct-sonarqube-test.yaml
-            runner: github-ubuntu-latest-s
+            runner: warp-custom-ubuntu-24-04
             secrets_id: secrets
           - chart: sonarqube-dce
             config: ct-sonarqube-dce-test.yaml
-            runner: github-ubuntu-latest-m
+            runner: warp-custom-ubuntu-24-04
             secrets_id: dcesecrets
     runs-on: ${{ matrix.runner }}
     name: Kind Test (${{ matrix.chart }})
@@ -249,7 +249,7 @@ jobs:
 
   sonarqube-packaging:
     needs: [kind-test,openshift-test]
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: ${{ matrix.chart }} Packaging
     strategy:
       matrix:
@@ -302,7 +302,7 @@ jobs:
 
   sonarqube-push-to-repox:
     needs: [sonarqube-packaging]
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     strategy:
       matrix:
         include:
@@ -342,7 +342,7 @@ jobs:
 
   trigger-release:
     needs: [sonarqube-push-to-repox]
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Trigger Release
     permissions:
       id-token: write
@@ -402,7 +402,7 @@ jobs:
       - kind-test
       - sonarqube-packaging
       - sonarqube-push-to-repox
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     outputs:
       SUCCESS: ${{ steps.alls-green.outputs.success }}
     steps:

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   build-gcp-staging-app:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Build GCP Staging App
     permissions:
       id-token: write
@@ -73,7 +73,7 @@ jobs:
 
   verify-gcp-staging-app:
     needs: [build-gcp-staging-app]
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Verify GCP Staging App
     permissions:
       id-token: write
@@ -127,7 +127,7 @@ jobs:
 
   release-gcp-prod-app:
     needs: [verify-gcp-staging-app]
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Release GCP Prod App
     permissions:
       id-token: write

--- a/.github/workflows/next-scan.yml
+++ b/.github/workflows/next-scan.yml
@@ -13,7 +13,7 @@ on:
 name: Main Workflow
 jobs:
   next:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       actions: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ name: Release
 
 jobs:
   release:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -8,7 +8,7 @@ jobs:
     name: Slack Notification
     permissions:
       id-token: write
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Vault Secrets
         id: secrets


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/azure-marketplace.yml`
- `.github/workflows/build.yml`
- `.github/workflows/gcp-marketplace.yml`
- `.github/workflows/next-scan.yml`
- `.github/workflows/pr-cleanup.yml`
- `.github/workflows/release.yml`
- `.github/workflows/slack_notify.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
