### PR TITLE
SONAR-27393 Adapt workflows to immutable releases

### DIFF
--- a/.github/scripts/package.sh
+++ b/.github/scripts/package.sh
@@ -29,8 +29,9 @@ if [[ -n "${ARG_CHART_NAME}" ]] && [[ "${CHARTS[*]}" =~ ${ARG_CHART_NAME} ]]; th
 fi
 
 BUILD_METADATA="-${BUILD_NUMBER}"
-# For GitHub Actions, check if this is a tag-based release
-[[ ${GITHUB_REF_TYPE:-} == "tag" ]] && BUILD_METADATA=""
+if [[ ${GITHUB_REF_NAME} == "master" || ${GITHUB_REF_NAME} == release/* ]]; then
+    BUILD_METADATA=""
+fi
 
 echo "${CHARTS[@]}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   merge_group:
   workflow_dispatch:
   workflow_call:
-  release:
-    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -340,22 +338,14 @@ jobs:
         run: |
           ./.github/scripts/upload_chart.sh ${{ matrix.chart }}
 
-  trigger-release:
+  output-build-number:
     needs: [sonarqube-push-to-repox]
     runs-on: github-ubuntu-latest-s
-    name: Trigger Release
+    name: Output Build Number
     permissions:
-      id-token: write
-      contents: write
-    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      contents: read
+    if: ${{ github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          cache_save: false
-          version: 2026.3.13
       - uses: SonarSource/ci-github-actions/get-build-number@v1
         id: build-number
       - name: Download SonarQube chart artifact
@@ -366,12 +356,6 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: sonarqube-dce-chart-${{ github.run_id }}
-      - id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/github/token/SonarSource-helm-chart-sonarqube-releases token | GITHUB_TOKEN;
-            development/kv/data/slack token | SLACK_TOKEN;
       - name: Check if charts exist
         id: check-charts
         run: |
@@ -381,14 +365,10 @@ jobs:
           else
             echo "charts-exist=false" >> $GITHUB_OUTPUT
           fi
-      - name: Call release workflow
+      - name: Output build number
         if: steps.check-charts.outputs.charts-exist == 'true'
-        env:
-          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
         run: |
-          gh workflow run release.yml \
-            -f version="${{ github.ref_name }}" \
-            -f buildNumber="${{ steps.build-number.outputs.BUILD_NUMBER }}"
+          echo "Build number: \`${{ steps.build-number.outputs.BUILD_NUMBER }}\`" >> "$GITHUB_STEP_SUMMARY"
 
 
   qa-validator:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,61 @@
+on:
+  # TODO: for testing, revert this
+  # release:
+  #   types: [published]
+  workflow_dispatch:
+    inputs:
+      releaseTag:
+        description: "Tag of the Release"
+        required: true
+        type: string
+
+name: Release (Published)
+
+jobs:
+  publish:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+      - name: Resolve release tag
+        id: tag
+        env:
+          RELEASE_TAG: ${{ inputs.releaseTag }}
+          # TODO: for testing, revert this
+          # EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then
+            echo "value=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$EVENT_TAG" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create local repository directory
+        id: local_repo
+        run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> "$GITHUB_OUTPUT"
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
+          TARGET_DIR: ${{ steps.local_repo.outputs.dir }}
+        run: |
+          gh release download "$RELEASE_TAG" --dir "$TARGET_DIR" --pattern '*.tgz' --pattern '*.tgz.prov'
+          if [[ -z "$(ls -A "$TARGET_DIR")" ]]; then
+            echo "No chart assets found for release $RELEASE_TAG" >&2
+            exit 1
+          fi
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Release to GitHub
+        uses: ./.github/actions/helm-index
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          repository-name: "${{ github.event.repository.name }}"
+          package-path: ${{ steps.local_repo.outputs.dir }}
+          release-name: ${{ steps.tag.outputs.value }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,14 @@
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version of the release"
+      releaseTag:
+        description: "Tag of the Draft Release"
         required: true
       buildNumber:
-        description: "Build number of the release"
+        description: "Build number (from the Build workflow)"
         required: true
-  workflow_call:
-    inputs:
-      version:
-        description: "Version of the release"
-        required: true
-        type: string
-      buildNumber:
-        description: "Build number of the release"
-        required: true
-        type: string
 
-name: Release
+name: Release (Drafted)
 
 jobs:
   release:
@@ -32,18 +22,22 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | artifactory_access_token;
-            development/kv/data/slack webhook | slack_webhook_url;
       - uses: SonarSource/jfrog-setup-wrapper@v3
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Fetch history
-        run: git fetch --prune --unshallow
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          cache_save: false
-          version: 2026.3.13
+      - name: Look up draft release
+        id: draft_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.releaseTag }}
+        run: |
+          release_id=$(gh release view "$RELEASE_TAG" --json id,isDraft \
+            --jq 'select(.isDraft) | .id' 2>/dev/null || true)
+          if [[ -z "$release_id" ]]; then
+            echo "No draft release found with tag $RELEASE_TAG" >&2
+            exit 1
+          fi
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
       - name: Promote
         run: jf rt build-promote --status released "${{ github.event.repository.name }}" "${{ inputs.buildNumber }}" sonarsource-helm-releases
       - name: Create local repository directory
@@ -57,20 +51,9 @@ jobs:
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2.11.2
         with:
+          draft: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file_glob: true
           file: ${{ steps.local_repo.outputs.dir }}/*
-          tag: ${{ inputs.version }}
+          release_id: ${{ steps.draft_release.outputs.release_id }}
           overwrite: true
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Release to GitHub
-        uses: ./.github/actions/helm-index
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          repository-name: "${{ github.event.repository.name }}"
-          package-path: ${{ steps.local_repo.outputs.dir }}
-          release-name: "${{ inputs.version}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.releaseTag }}
         run: |
-          release_id=$(gh release view "$RELEASE_TAG" --json id,isDraft \
-            --jq 'select(.isDraft) | .id' 2>/dev/null || true)
+          set -euo pipefail
+          release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            | jq -r --arg tag "$RELEASE_TAG" \
+                '.[] | select(.tag_name==$tag and .draft) | .id' \
+            | head -n1)
           if [[ -z "$release_id" ]]; then
             echo "No draft release found with tag $RELEASE_TAG" >&2
             exit 1

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -472,9 +472,71 @@ You can generate the required certificate, create a secret, and add it to `searc
 
 Finally, do not forget to set the `searchNodes.searchAuthentication.userPassword`.
 
-## License
+### Use custom `cacerts`
 
-SonarQube Server Data Center Edition is licensed under [SonarQube Server Terms and Conditions](https://www.sonarsource.com/legal/sonarqube/terms-and-conditions/).
+In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate `cacerts` which overrides the default one:
+
+1. Create a yaml file `cacerts.yaml` with a secret that contains one or more keys to represent the certificates that you want including
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: my-cacerts
+   stringData:
+     cert-1.crt: |
+       xxxxxxxxxxxxxxxxxxxxxxx
+   ```
+
+2. Upload your `cacerts.yaml` to a secret in the cluster you are installing SonarQube to.
+
+   ```shell
+   kubectl apply -f cacerts.yaml
+   ```
+
+3. Set the following values of the chart:
+
+   ```yaml
+   caCerts:
+     enabled: true
+     secret: my-cacerts
+   ```
+
+### Elasticsearch Settings
+
+Since SonarQube needs Elasticsearch, some [bootstrap checks](https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks.html) of the host settings are done at start.
+
+This chart offers the option to use an initContainer in privilaged mode to automatically set certain kernel settings on the kube worker. While this can ensure proper functionality of Elasticsearch, modifying the underlying kernel settings on the Kubernetes node can impact other users. It may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide.
+
+To enable auto-configuration of the kube worker node, set `elasticsearch.configureNode` to `true`. This is the default behavior, so you do not need to explicitly set this.
+
+This will run `sysctl -w vm.max_map_count=262144` on the worker where the sonarqube pod(s) get scheduled. This needs to be set to `262144` but normally defaults to `65530`. Other kernel settings are recommended by the [docker image](https://hub.docker.com/_/sonarqube/#requirements), but the defaults work fine in most cases.
+
+### Extra Config
+
+For environments where another tool, such as terraform or ansible, is used to provision infrastructure or passwords then setting databases addresses and credentials via helm becomes less than ideal. Ditto for environments where this config may be visible.
+
+In such environments, configuration may be read, via environment variables, from Secrets and ConfigMaps.
+
+1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by SonarQube.
+
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: external-sonarqube-opts
+   data:
+     SONARQUBE_JDBC_USERNAME: foo
+     SONARQUBE_JDBC_URL: jdbc:postgresql://db.example.com:5432/sonar
+   ```
+
+2. Set the following in your `values.yaml` (using the key `extraConfig.secrets` to reference `Secret`s)
+
+   ```yaml
+   extraConfig:
+     configmaps:
+       - external-sonarqube-opts
+   ```
 
 ## Configuration
 
@@ -890,68 +952,6 @@ You can also configure values for the PostgreSQL database via the PostgreSQL [Ch
 
 For overriding variables see: [Customizing the chart](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)
 
-### Use custom `cacerts`
+## License
 
-In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate `cacerts` which overrides the default one:
-
-1. Create a yaml file `cacerts.yaml` with a secret that contains one or more keys to represent the certificates that you want including
-
-   ```yaml
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: my-cacerts
-   stringData:
-     cert-1.crt: |
-       xxxxxxxxxxxxxxxxxxxxxxx
-   ```
-
-2. Upload your `cacerts.yaml` to a secret in the cluster you are installing SonarQube to.
-
-   ```shell
-   kubectl apply -f cacerts.yaml
-   ```
-
-3. Set the following values of the chart:
-
-   ```yaml
-   caCerts:
-     enabled: true
-     secret: my-cacerts
-   ```
-
-### Elasticsearch Settings
-
-Since SonarQube needs Elasticsearch, some [bootstrap checks](https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks.html) of the host settings are done at start.
-
-This chart offers the option to use an initContainer in privilaged mode to automatically set certain kernel settings on the kube worker. While this can ensure proper functionality of Elasticsearch, modifying the underlying kernel settings on the Kubernetes node can impact other users. It may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide.
-
-To enable auto-configuration of the kube worker node, set `elasticsearch.configureNode` to `true`. This is the default behavior, so you do not need to explicitly set this.
-
-This will run `sysctl -w vm.max_map_count=262144` on the worker where the sonarqube pod(s) get scheduled. This needs to be set to `262144` but normally defaults to `65530`. Other kernel settings are recommended by the [docker image](https://hub.docker.com/_/sonarqube/#requirements), but the defaults work fine in most cases.
-
-### Extra Config
-
-For environments where another tool, such as terraform or ansible, is used to provision infrastructure or passwords then setting databases addresses and credentials via helm becomes less than ideal. Ditto for environments where this config may be visible.
-
-In such environments, configuration may be read, via environment variables, from Secrets and ConfigMaps.
-
-1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by SonarQube.
-
-   ```yaml
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: external-sonarqube-opts
-   data:
-     SONARQUBE_JDBC_USERNAME: foo
-     SONARQUBE_JDBC_URL: jdbc:postgresql://db.example.com:5432/sonar
-   ```
-
-2. Set the following in your `values.yaml` (using the key `extraConfig.secrets` to reference `Secret`s)
-
-   ```yaml
-   extraConfig:
-     configmaps:
-       - external-sonarqube-opts
-   ```
+SonarQube Server Data Center Edition is licensed under [SonarQube Server Terms and Conditions](https://www.sonarsource.com/legal/sonarqube/terms-and-conditions/).

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -337,9 +337,144 @@ helm upgrade --install -n sonarqube sonarqube sonarqube/sonarqube \
 
 If you want to make your application publicly visible with Routes, you can set `OpenShift.route.enabled` to true. Please check the [configuration details](#openshift-1) to customize the Route base on your needs.
 
-## License
+### Use custom `cacerts`
 
-SonarQube Community Build is released under the [GNU Lesser General Public License, Version 3.0⁠,](http://www.gnu.org/licenses/lgpl.txt) and packaged with [SSALv1](https://www.sonarsource.com/license/ssal/) analyzers. SonarQube Server Developer and Enterprise are licensed under [SonarQube Server Terms and Conditions](https://www.sonarsource.com/legal/sonarqube/terms-and-conditions/).
+In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate `cacerts` which overrides the default one:
+
+1. Create a yaml file `cacerts.yaml` with a secret that contains one or more keys to represent the certificates that you want including
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: my-cacerts
+   stringData:
+     cert-1.crt: |
+       xxxxxxxxxxxxxxxxxxxxxxx
+   ```
+
+2. Upload your `cacerts.yaml` to a secret in the cluster you are installing SonarQube to.
+
+   ```shell
+   kubectl apply -f cacerts.yaml
+   ```
+
+3. Set the following values of the chart:
+
+   ```yaml
+   caCerts:
+     enabled: true
+     secret: my-cacerts
+   ```
+
+### Elasticsearch Settings
+
+Since SonarQube comes bundled with an Elasticsearch instance, some [bootstrap checks](https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks.html) of the host settings are done at start.
+
+This chart offers the option to use an initContainer in privileged mode to automatically set certain kernel settings on the kube worker. While this can ensure proper functionality of Elasticsearch, modifying the underlying kernel settings on the Kubernetes node can impact other users. It may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide.
+
+To enable auto-configuration of the kube worker node, set `elasticsearch.configureNode` to `true`. This is the default behavior, so you do not need to explicitly set this.
+
+This will run `sysctl -w vm.max_map_count=262144` on the worker where the sonarqube pod(s) get scheduled. This needs to be set to `262144` but normally defaults to `65530`. Other kernel settings are recommended by the [docker image](https://hub.docker.com/_/sonarqube/#requirements), but the defaults work fine in most cases.
+
+To disable worker node configuration, set `elasticsearch.configureNode` to `false`. Note that if node configuration is not enabled, then you will likely need to also disable the Elasticsearch bootstrap checks. These can be explicitly disabled by setting `elasticsearch.bootstrapChecks` to `false`.
+
+### MCP (Model Context Protocol) Server
+
+When `mcp.enabled` is set to `true`, the chart deploys a separate MCP server pod alongside SonarQube and automatically wires the two together.
+
+**What gets deployed:**
+- A `Deployment` running the MCP container
+- A `ClusterIP` Service exposing port `8080` within the cluster
+- A `PersistentVolumeClaim` for MCP's `/data` directory (when `mcp.persistence.enabled=true`)
+
+**How the integration works:**
+
+The MCP pod waits for SonarQube to report `"status":"UP"` before starting (via an init container). Once running, SonarQube is configured to call MCP at `http://<release>-sonarqube-mcp:8080` via the `SONAR_MCP_SERVERURL` and `SONAR_MCP_ENABLED` environment variables, which the chart injects automatically.
+
+**Minimal configuration example:**
+
+```yaml
+mcp:
+  enabled: true
+  image:
+    repository: sonarsource/sonarqube-mcp
+    tag: "1.18.1.2664"
+```
+
+**Accessing the MCP server locally:**
+
+```bash
+kubectl port-forward svc/<release>-sonarqube-mcp 8080:8080 -n <namespace>
+```
+
+**Persistence:**
+
+MCP uses `/data` to store its files. `mcp.persistence.enabled` defaults to `true`. For local testing only (e.g. Kind/minikube), you can disable it — but data will be lost on pod restarts:
+
+```yaml
+mcp:
+  enabled: true
+  persistence:
+    enabled: false
+```
+
+**TLS (encrypted communication):**
+
+When `mcp.tls.enabled` is set to `true`, the MCP server starts in HTTPS mode using the keystore from `mcp.tls.keystoreSecretName`. SonarQube connects to it over `https://`.
+
+If the keystore uses a self-signed certificate, SonarQube's JVM will reject the connection unless the CA certificate is trusted. Use the `caCerts` feature to import it into SonarQube's JVM truststore:
+
+1. Create a Secret containing the CA certificate in PEM format:
+
+   ```bash
+   kubectl create secret generic mcp-ca-cert \
+     --from-file=mcp-ca.crt=/path/to/ca.pem \
+     -n <namespace>
+   ```
+
+2. Reference it in your values:
+
+   ```yaml
+   mcp:
+     tls:
+       enabled: true
+       keystoreSecretName: mcp-keystore-secret
+       keystoreSecretKey: keystore.p12
+       passwordSecretName: mcp-keystore-password
+       passwordSecretKey: password
+       keystoreType: PKCS12
+
+   caCerts:
+     enabled: true
+     secret: mcp-ca-cert
+   ```
+
+### Extra Config
+
+For environments where another tool, such as terraform or ansible, is used to provision infrastructure or passwords then setting databases addresses and credentials via helm becomes less than ideal. Ditto for environments where this config may be visible.
+
+In such environments, configuration may be read, via environment variables, from Secrets and ConfigMaps.
+
+1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by SonarQube.
+
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: external-sonarqube-opts
+   data:
+     SONARQUBE_JDBC_USERNAME: foo
+     SONARQUBE_JDBC_URL: jdbc:postgresql://db.example.com:5432/sonar
+   ```
+
+2. Set the following in your `values.yaml` (using the key `extraConfig.secrets` to reference `Secret`s)
+
+   ```yaml
+   extraConfig:
+     configmaps:
+       - external-sonarqube-opts
+   ```
 
 ## Configuration
 
@@ -709,141 +844,6 @@ and set `persistence.hostPath.path` and `persistence.hostPath.type`.
 
 For overriding variables see: [Customizing the chart](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)
 
-### Use custom `cacerts`
+## License
 
-In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate `cacerts` which overrides the default one:
-
-1. Create a yaml file `cacerts.yaml` with a secret that contains one or more keys to represent the certificates that you want including
-
-   ```yaml
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: my-cacerts
-   stringData:
-     cert-1.crt: |
-       xxxxxxxxxxxxxxxxxxxxxxx
-   ```
-
-2. Upload your `cacerts.yaml` to a secret in the cluster you are installing SonarQube to.
-
-   ```shell
-   kubectl apply -f cacerts.yaml
-   ```
-
-3. Set the following values of the chart:
-
-   ```yaml
-   caCerts:
-     enabled: true
-     secret: my-cacerts
-   ```
-
-### Elasticsearch Settings
-
-Since SonarQube comes bundled with an Elasticsearch instance, some [bootstrap checks](https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks.html) of the host settings are done at start.
-
-This chart offers the option to use an initContainer in privileged mode to automatically set certain kernel settings on the kube worker. While this can ensure proper functionality of Elasticsearch, modifying the underlying kernel settings on the Kubernetes node can impact other users. It may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide.
-
-To enable auto-configuration of the kube worker node, set `elasticsearch.configureNode` to `true`. This is the default behavior, so you do not need to explicitly set this.
-
-This will run `sysctl -w vm.max_map_count=262144` on the worker where the sonarqube pod(s) get scheduled. This needs to be set to `262144` but normally defaults to `65530`. Other kernel settings are recommended by the [docker image](https://hub.docker.com/_/sonarqube/#requirements), but the defaults work fine in most cases.
-
-To disable worker node configuration, set `elasticsearch.configureNode` to `false`. Note that if node configuration is not enabled, then you will likely need to also disable the Elasticsearch bootstrap checks. These can be explicitly disabled by setting `elasticsearch.bootstrapChecks` to `false`.
-
-### MCP (Model Context Protocol) Server
-
-When `mcp.enabled` is set to `true`, the chart deploys a separate MCP server pod alongside SonarQube and automatically wires the two together.
-
-**What gets deployed:**
-- A `Deployment` running the MCP container
-- A `ClusterIP` Service exposing port `8080` within the cluster
-- A `PersistentVolumeClaim` for MCP's `/data` directory (when `mcp.persistence.enabled=true`)
-
-**How the integration works:**
-
-The MCP pod waits for SonarQube to report `"status":"UP"` before starting (via an init container). Once running, SonarQube is configured to call MCP at `http://<release>-sonarqube-mcp:8080` via the `SONAR_MCP_SERVERURL` and `SONAR_MCP_ENABLED` environment variables, which the chart injects automatically.
-
-**Minimal configuration example:**
-
-```yaml
-mcp:
-  enabled: true
-  image:
-    repository: sonarsource/sonarqube-mcp
-    tag: "1.18.1.2664"
-```
-
-**Accessing the MCP server locally:**
-
-```bash
-kubectl port-forward svc/<release>-sonarqube-mcp 8080:8080 -n <namespace>
-```
-
-**Persistence:**
-
-MCP uses `/data` to store its files. `mcp.persistence.enabled` defaults to `true`. For local testing only (e.g. Kind/minikube), you can disable it — but data will be lost on pod restarts:
-
-```yaml
-mcp:
-  enabled: true
-  persistence:
-    enabled: false
-```
-
-**TLS (encrypted communication):**
-
-When `mcp.tls.enabled` is set to `true`, the MCP server starts in HTTPS mode using the keystore from `mcp.tls.keystoreSecretName`. SonarQube connects to it over `https://`.
-
-If the keystore uses a self-signed certificate, SonarQube's JVM will reject the connection unless the CA certificate is trusted. Use the `caCerts` feature to import it into SonarQube's JVM truststore:
-
-1. Create a Secret containing the CA certificate in PEM format:
-
-   ```bash
-   kubectl create secret generic mcp-ca-cert \
-     --from-file=mcp-ca.crt=/path/to/ca.pem \
-     -n <namespace>
-   ```
-
-2. Reference it in your values:
-
-   ```yaml
-   mcp:
-     tls:
-       enabled: true
-       keystoreSecretName: mcp-keystore-secret
-       keystoreSecretKey: keystore.p12
-       passwordSecretName: mcp-keystore-password
-       passwordSecretKey: password
-       keystoreType: PKCS12
-
-   caCerts:
-     enabled: true
-     secret: mcp-ca-cert
-   ```
-
-### Extra Config
-
-For environments where another tool, such as terraform or ansible, is used to provision infrastructure or passwords then setting databases addresses and credentials via helm becomes less than ideal. Ditto for environments where this config may be visible.
-
-In such environments, configuration may be read, via environment variables, from Secrets and ConfigMaps.
-
-1. Create a `ConfigMap` (or `Secret`) containing key/value pairs, as expected by SonarQube.
-
-   ```yaml
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: external-sonarqube-opts
-   data:
-     SONARQUBE_JDBC_USERNAME: foo
-     SONARQUBE_JDBC_URL: jdbc:postgresql://db.example.com:5432/sonar
-   ```
-
-2. Set the following in your `values.yaml` (using the key `extraConfig.secrets` to reference `Secret`s)
-
-   ```yaml
-   extraConfig:
-     configmaps:
-       - external-sonarqube-opts
-   ```
+SonarQube Community Build is released under the [GNU Lesser General Public License, Version 3.0⁠,](http://www.gnu.org/licenses/lgpl.txt) and packaged with [SSALv1](https://www.sonarsource.com/license/ssal/) analyzers. SonarQube Server Developer and Enterprise are licensed under [SonarQube Server Terms and Conditions](https://www.sonarsource.com/legal/sonarqube/terms-and-conditions/).


### PR DESCRIPTION
### Adapt our release process to support immutable releases:

New workflow:

1.  Push -> triggers build, outputs build number
2. Manually create a draft release with the correct tag
3. Manually run "Release (Drafted)" -> will attach assets to the draft release
4. Manually publish the release -> will publish to the Github Pages

Also reorganized sections in README.md of the Charts for a better reading experience. 

### Testing
Tested on branch `release/test-0.0.0`:

- [Build workflow](https://github.com/SonarSource/helm-chart-sonarqube/actions/runs/26171890611)
- [Release workflow](https://github.com/SonarSource/helm-chart-sonarqube/actions/runs/26172624490)
- [Draft release](https://github.com/SonarSource/helm-chart-sonarqube/releases/tag/untagged-be8a3e3a14b71faaa599)