### PR TITLE
SONAR-27393 Adapt workflows to immutable releases (2025.1)

### DIFF
--- a/.github/scripts/package.sh
+++ b/.github/scripts/package.sh
@@ -30,7 +30,9 @@ if [[ -n "${ARG_CHART_NAME}" ]] && [[ "${CHARTS[*]}" =~ ${ARG_CHART_NAME} ]]; th
 fi
 
 BUILD_METADATA="-${BUILD_NUMBER}"
-[[ ${GITHUB_REF_TYPE} == "tag" ]] && BUILD_METADATA=""
+if [[ ${GITHUB_REF_NAME} == "master" || ${GITHUB_REF_NAME} == release/* ]]; then
+    BUILD_METADATA=""
+fi
 
 echo "${CHARTS[@]}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
@@ -48,9 +48,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - name: Install additional tools
         run: |
           pip install yamllint==1.37.1 yamale==6.0.0
@@ -75,9 +75,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - name: Build chart dependencies
         run: ./.github/scripts/build_chart_dependencies.sh charts/${{ matrix.chart }}
       - name: Run unit helm compatibility test
@@ -105,9 +105,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - id: secrets
         uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
         with:
@@ -193,9 +193,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
       - name: Create kind cluster
@@ -248,9 +248,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
         id: build-number
       - id: secrets
@@ -301,10 +301,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache_save: false
-          version: 2025.7.12
+          version: 2026.3.13
       - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
         id: build-number
       - name: Download ${{ matrix.chart }} chart artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   merge_group:
   workflow_dispatch:
   workflow_call:
-  release:
-    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -327,22 +325,14 @@ jobs:
         run: |
           ./.github/scripts/upload_chart.sh ${{ matrix.chart }}
 
-  trigger-release:
+  output-build-number:
     needs: [sonarqube-push-to-repox]
     runs-on: github-ubuntu-latest-s
-    name: Trigger Release
+    name: Output Build Number
     permissions:
-      id-token: write
-      contents: write
-    if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      contents: read
+    if: ${{ github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
-        with:
-          cache_save: false
-          version: 2025.7.12
       - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
         id: build-number
       - name: Download SonarQube chart artifact
@@ -353,12 +343,6 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: sonarqube-dce-chart-${{ github.run_id }}
-      - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
-        with:
-          secrets: |
-            development/github/token/SonarSource-helm-chart-sonarqube-releases token | GITHUB_TOKEN;
-            development/kv/data/slack token | SLACK_TOKEN;
       - name: Check if charts exist
         id: check-charts
         run: |
@@ -368,14 +352,10 @@ jobs:
           else
             echo "charts-exist=false" >> $GITHUB_OUTPUT
           fi
-      - name: Call release workflow
+      - name: Output build number
         if: steps.check-charts.outputs.charts-exist == 'true'
-        env:
-          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
         run: |
-          gh workflow run release.yml \
-            -f version="${{ github.ref_name }}" \
-            -f buildNumber="${{ steps.build-number.outputs.BUILD_NUMBER }}"
+          echo "Build number: \`${{ steps.build-number.outputs.BUILD_NUMBER }}\`" >> "$GITHUB_STEP_SUMMARY"
 
 
   qa-validator:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Install kubectl CLI
         uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
         with:
-          version: 'v1.35.0'
+          version: 'v1.35.5'
       - name: Install OpenShift CLI
         run: |
           curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${{ env.OPENSHIFT_VERSION }}/openshift-client-linux.tar.gz

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -38,9 +38,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - id: secrets
         uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
         with:
@@ -89,9 +89,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - name: Setup GCP tools
         run: ./.github/scripts/setup.sh
       - id: secrets
@@ -134,9 +134,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2025.7.12
+          version: 2026.3.13
       - id: secrets
         uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,59 @@
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      releaseTag:
+        description: "Tag of the Release"
+        required: true
+        type: string
+
+name: Release (Published)
+
+jobs:
+  publish:
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+      - name: Resolve release tag
+        id: tag
+        env:
+          RELEASE_TAG: ${{ inputs.releaseTag }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then
+            echo "value=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$EVENT_TAG" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create local repository directory
+        id: local_repo
+        run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> "$GITHUB_OUTPUT"
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.value }}
+          TARGET_DIR: ${{ steps.local_repo.outputs.dir }}
+        run: |
+          gh release download "$RELEASE_TAG" --dir "$TARGET_DIR" --pattern '*.tgz' --pattern '*.tgz.prov'
+          if [[ -z "$(ls -A "$TARGET_DIR")" ]]; then
+            echo "No chart assets found for release $RELEASE_TAG" >&2
+            exit 1
+          fi
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Release to GitHub
+        uses: ./.github/actions/helm-index
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          repository-name: "${{ github.event.repository.name }}"
+          package-path: ${{ steps.local_repo.outputs.dir }}
+          release-name: ${{ steps.tag.outputs.value }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,14 @@
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version of the release"
+      releaseTag:
+        description: "Tag of the Draft Release"
         required: true
       buildNumber:
-        description: "Build number of the release"
+        description: "Build number (from the Build workflow)"
         required: true
-  workflow_call:
-    inputs:
-      version:
-        description: "Version of the release"
-        required: true
-        type: string
-      buildNumber:
-        description: "Build number of the release"
-        required: true
-        type: string
 
-name: Release
+name: Release (Drafted)
 
 jobs:
   release:
@@ -32,20 +22,29 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | artifactory_access_token;
-            development/kv/data/slack webhook | slack_webhook_url;
       - uses: SonarSource/jfrog-setup-wrapper@e0f353c7f1bcc7b2f663063d72b5fec7948f6815 # v3.6.0
         with:
           jfrogAccessToken: ${{ fromJSON(steps.secrets.outputs.vault).artifactory_access_token }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Fetch history
-        run: git fetch --prune --unshallow
-      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
-        with:
-          cache_save: false
-          version: 2025.7.12
+      - name: Look up draft release
+        id: draft_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.releaseTag }}
+        run: |
+          set -euo pipefail
+          release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            | jq -r --arg tag "$RELEASE_TAG" \
+                '.[] | select(.tag_name==$tag and .draft) | .id' \
+            | head -n1)
+          if [[ -z "$release_id" ]]; then
+            echo "No draft release found with tag $RELEASE_TAG" >&2
+            exit 1
+          fi
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
       - name: Promote
-        run: jf rt build-promote --status released "${{ github.event.repository.name }}" "${{ inputs.buildNumber }}" sonarsource-helm-releases
+        env:
+          BUILD_NUMBER: ${{ inputs.buildNumber }}
+        run: jf rt build-promote --status released "${{ github.event.repository.name }}" "$BUILD_NUMBER" sonarsource-helm-releases
       - name: Create local repository directory
         id: local_repo
         run: echo "dir=$(mktemp -d repo.XXXXXXXX)" >> "$GITHUB_OUTPUT"
@@ -57,20 +56,9 @@ jobs:
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2.11.2
         with:
+          draft: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file_glob: true
           file: ${{ steps.local_repo.outputs.dir }}/*
-          tag: ${{ inputs.version }}
+          release_id: ${{ steps.draft_release.outputs.release_id }}
           overwrite: true
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Release to GitHub
-        uses: ./.github/actions/helm-index
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          repository-name: "${{ github.event.repository.name }}"
-          package-path: ${{ steps.local_repo.outputs.dir }}
-          release-name: "${{ inputs.version}}"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 # Helm for chart operations
 helm = "4.0.5"
 # kubectl for Kubernetes operations
-kubectl = "1.35.0"
+kubectl = "1.35.5"
 # Python for yamllint and yamale
 python = "3.12"
 # Go for chart-testing and other tools


### PR DESCRIPTION
Backport from b607878436a731afc7c1d85180c384f386e539a6

----
## Summary by Gitar

- **Tooling upgrades:**
  - Bumped `kubectl` to `1.35.5` in `mise.toml` and build workflows.
  - Updated `jdx/mise-action` to `v4.0.1` and `mise` version to `2026.3.13` across all CI workflows.
- **Release workflow overhaul:**
  - Refactored `release.yml` to support draft-based releases and added `release-publish.yml` for post-publication indexing.
  - Updated `package.sh` to handle build metadata logic for master and release branches.
  - Removed `trigger-release` job from `build.yml` in favor of an `output-build-number` step.


<sub>This will update automatically on new commits.</sub>