### PR TITLE
REL-4630 Release SQS 2025.1.8

### DIFF
--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2025.1.7 # Update this value to the desired version
+  GCLOUD_TAG: 2025.1.8 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.1.8]
+* Update Chart's version to 2025.1.8
+* Upgrade SonarQube Server to 2025.1.8
+
 ## [2025.1.7]
 * Update Chart's version to 2025.1.7
 * Upgrade SonarQube Server to 2025.1.7

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.1.7
-appVersion: 2025.1.7
+version: 2025.1.8
+appVersion: 2025.1.8
 keywords:
   - coverage
   - security
@@ -34,9 +34,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 2025.1.7"
+      description: "Update Chart's version to 2025.1.8"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2025.1.7"
+      description: "Upgrade SonarQube Server to 2025.1.8"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/
@@ -45,9 +45,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2025.1.7-datacenter-app
+      image: sonarqube:2025.1.8-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2025.1.7-datacenter-search
+      image: sonarqube:2025.1.8-datacenter-search
   charts.openshift.io/name: sonarqube-dce
 dependencies:
   - name: postgresql

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2025.1.7`
+Compatible SonarQube Version: `2025.1.8`
 
 Supported Kubernetes Versions: From `1.29` to `1.32`
 Supported Openshift Versions: From `4.11` to `4.17`
@@ -293,7 +293,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2025.1.7-datacenter-search`                                           |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2025.1.8-datacenter-search`                                           |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -349,7 +349,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2025.1.7-datacenter-app`                                              |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2025.1.8-datacenter-app`                                              |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/ci-values.yaml
+++ b/charts/sonarqube-dce/ci/ci-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.1.7-master-datacenter-search"
+    tag: "2025.1.8-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.1.7-master-datacenter-app"
+    tag: "2025.1.8-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
 

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -13,7 +13,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.1.7-master-datacenter-search"
+    tag: "2025.1.8-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -22,7 +22,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.1.7-master-datacenter-app"
+    tag: "2025.1.8-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
 

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2025.1.7-datacenter-search
+    tag: 2025.1.8-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -153,7 +153,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2025.1.7-datacenter-app
+    tag: 2025.1.8-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.1.8]
+* Update Chart's version to 2025.1.8
+* Upgrade SonarQube Server to 2025.1.8
+
 ## [2025.1.7]
 * Update Chart's version to 2025.1.7
 * Upgrade SonarQube Server to 2025.1.7

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.1.7
-appVersion: 2025.1.7
+version: 2025.1.8
+appVersion: 2025.1.8
 keywords:
   - coverage
   - security
@@ -39,17 +39,17 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 2025.1.7"
+      description: "Update Chart's version to 2025.1.8"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2025.1.7"
+      description: "Upgrade SonarQube Server to 2025.1.8"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube
       image: sonarqube:25.1.0.102122-community
     - name: sonarqube-developer
-      image: sonarqube:2025.1.7-developer
+      image: sonarqube:2025.1.8-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2025.1.7-enterprise
+      image: sonarqube:2025.1.8-enterprise
   charts.openshift.io/name: sonarqube
 dependencies:
   - name: postgresql

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Compatibility
 
-Compatible SonarQube Server Version: `2025.1.7`
+Compatible SonarQube Server Version: `2025.1.8`
 Compatible SonarQube Community Build: `25.1.0.102122`
 
 Supported Kubernetes Versions: From `1.29` to `1.32`

--- a/charts/sonarqube/ci/ci-values.yaml
+++ b/charts/sonarqube/ci/ci-values.yaml
@@ -5,7 +5,7 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "2025.1.7-master-enterprise"
+  tag: "2025.1.8-master-enterprise"
 monitoringPasscode: "test"
 postgresql:
   securityContext:

--- a/charts/sonarqube/openshift-verifier/values.yaml
+++ b/charts/sonarqube/openshift-verifier/values.yaml
@@ -16,6 +16,6 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "2025.1.7-master-enterprise"
+  tag: "2025.1.8-master-enterprise"
 
 monitoringPasscode: "test"

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2025.1.7
+export TAG=2025.1.8
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 15bf4f4a2d2a72909f375a9beea8138c839fec4fbba962639aff593698905612
-        checksum/config: b52374459082c427c8872cdcd7fad3cb530d5b5582c2c9494fc7956644d199ab
-        checksum/secret: 8a0bb96dc5343de2f6072804aef460bea2ee633b126c371e4d762518f393611d
+        checksum/plugins: 758878df9c457d38f5250253401d4dbf7b66ba1d96a33c5a273a5ae6b9f43663
+        checksum/config: 8062022293b1f65cf243e152c4d6ae13da0a5a8fbe13f7e9f82c6a638ef98602
+        checksum/secret: 813305f0594d6f1318bfdb919d374904d2e8b80fc1ab65c37de6837b49e4de31
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -768,15 +768,15 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 987880ea8ff8645873a2d1ddda5e1f584eea21b5c723b76c201957f1778413f8
-        checksum/init-fs: 4148f1018b07b7a4a8cb8b9247537f1f5a9613128e2b097e98bd94d20838ce46
-        checksum/config: b52374459082c427c8872cdcd7fad3cb530d5b5582c2c9494fc7956644d199ab
-        checksum/secret: 8a0bb96dc5343de2f6072804aef460bea2ee633b126c371e4d762518f393611d
+        checksum/init-sysctl: c05c614bfe051d4b44193a25bc27c6b5424ed2003e7bd8ef41f008163c59fc3b
+        checksum/init-fs: 4f0d74070d656b63d2d37a3e9e5efff63a3127e7df2a45c5bc166b96b69993b3
+        checksum/config: 8062022293b1f65cf243e152c4d6ae13da0a5a8fbe13f7e9f82c6a638ef98602
+        checksum/secret: 813305f0594d6f1318bfdb919d374904d2e8b80fc1ab65c37de6837b49e4de31
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -791,7 +791,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -832,7 +832,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -974,7 +974,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2025.1.7-datacenter-app"
+    version: "2025.1.8-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -1026,14 +1026,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: application-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -148,7 +148,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -211,7 +211,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -314,7 +314,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -338,7 +338,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -364,7 +364,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -391,7 +391,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -400,7 +400,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -417,14 +417,14 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f79e882348f12c259374fcab77e02852e3e0a3e17f15dd2c4623f94af460312b
-        checksum/config: 84c1fdbcd47ffde89390e2e798a14c1a13fc1ec7e442906c2cc338c4fff12dde
-        checksum/secret: faab6e872dfce2069be9ef5b8a987128fdc0fe053b82a1039d43970c879429d9
+        checksum/plugins: 5238573626c3f1b7271d01f3560c0e38e05ed08898ab9048cf95ce113ba97546
+        checksum/config: 53995f76450a3279160f2604ccea2df285c1b3b7a3568129af70b0e561a32c4c
+        checksum/secret: 42412c5ec2c1c483273b7d010619329aaec6b0a8003cd2ebb6827c7fdbe8048b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -442,7 +442,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-configmap.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -466,7 +466,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -494,7 +494,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -522,7 +522,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -819,7 +819,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -828,7 +828,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -857,15 +857,15 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 049f98820f65db849851ca0345b57590c8a533b231143624c200ee12330c8f35
-        checksum/init-fs: 12e0a21fe3bbe05acb737a7c822bbb3d0cdbd0bf15acca7ddc77b429e266aef6
-        checksum/config: 84c1fdbcd47ffde89390e2e798a14c1a13fc1ec7e442906c2cc338c4fff12dde
-        checksum/secret: faab6e872dfce2069be9ef5b8a987128fdc0fe053b82a1039d43970c879429d9
+        checksum/init-sysctl: 3fd73c195ac721583d6129784010940e184f43a2009d253d4dcb8d31cc80d322
+        checksum/init-fs: 50a76ff28ea1891612c85a3c8ce0b2c4ce15dcaafefdc4540fe89e6cc1b80a60
+        checksum/config: 53995f76450a3279160f2604ccea2df285c1b3b7a3568129af70b0e561a32c4c
+        checksum/secret: 42412c5ec2c1c483273b7d010619329aaec6b0a8003cd2ebb6827c7fdbe8048b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -880,7 +880,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -904,7 +904,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -945,7 +945,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1085,14 +1085,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -148,7 +148,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ce5c6cdda0ccb872094fa2412442bf4b3f77edbf3700fd720e6bb7fc8fe8b1fa
-        checksum/config: 0e0242a6479a3763ce95a110d4579bb8a55905dd883c36fe84dc70fd148fda1c
-        checksum/secret: 874f147b6a24548c8cff111d44eb5b1b3c1833057af41695d45910036451eccd
+        checksum/plugins: 8470bbcb3192cf03404a66283b1333d746529f4bfd19166823cef8a98f78e692
+        checksum/config: efdfe4098303489ca2a39afe5cbcb11c6713dcbc29e271536e5239ef1056bc71
+        checksum/secret: a9a93c8d9acd8e749f89466d12c1020cae690731acd8104880085c47ad7f6425
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -426,7 +426,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-secret.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -453,7 +453,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -481,7 +481,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -758,7 +758,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -767,7 +767,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -796,15 +796,15 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a68e63fd707ab5e6eda6e5f2729dcf35d1ec9407f0850f8eec54e305f2f53a7e
-        checksum/init-fs: cdc767f941eb3c5aad846e0d55ec8847b7bf467cc6751cc04102d0eba6824e3f
-        checksum/config: 0e0242a6479a3763ce95a110d4579bb8a55905dd883c36fe84dc70fd148fda1c
-        checksum/secret: 874f147b6a24548c8cff111d44eb5b1b3c1833057af41695d45910036451eccd
+        checksum/init-sysctl: 295838cab70d6b70804d30427f4b53129257448204d61e9bd6550fab924d41af
+        checksum/init-fs: 46d3e35dae54704e442e0ee3ed850a5e064665ace0a13d30ef17362f38f4f1a1
+        checksum/config: efdfe4098303489ca2a39afe5cbcb11c6713dcbc29e271536e5239ef1056bc71
+        checksum/secret: a9a93c8d9acd8e749f89466d12c1020cae690731acd8104880085c47ad7f6425
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -819,7 +819,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -843,7 +843,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -884,7 +884,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1019,14 +1019,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -289,7 +289,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -311,7 +311,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -361,7 +361,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -414,14 +414,14 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e9a67c5a2119f88584bd54f78f98cd07d1deee4bb3d87795d47c3bca8789a8cd
-        checksum/config: 1c1fdf4a14a7f7b45aeecaa91045f9118c3b5f99a78c7968cbf401e04fb873ce
-        checksum/secret: 1d58c90b85dde56336d7a0589bfe7b88c7a8b727f717da5ffcf1b007a2830f04
+        checksum/plugins: 9720ffdeba6eaf245f0c87c079da85f98e5152d3b60ed42bd87358f864360ab2
+        checksum/config: adfce0d2c5f1573fc295fbdf64c1b5062074222d8a8a0e91d23b9e7611266656
+        checksum/secret: 33f195a98a527136184f677bfcd5c38dc9d9d27c5b5a27a2ec0551ac69df730d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -442,7 +442,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -470,7 +470,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -744,7 +744,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -782,15 +782,15 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 77f0041c85f5533508d904b63adbcb3345f2cf64cdac4ab94e80c449c8d6069a
-        checksum/init-fs: 1f926700ec6bd4bdaac3bfba65a97a69ef8822f0f53da1f2155291d7322b5417
-        checksum/config: 1c1fdf4a14a7f7b45aeecaa91045f9118c3b5f99a78c7968cbf401e04fb873ce
-        checksum/secret: 1d58c90b85dde56336d7a0589bfe7b88c7a8b727f717da5ffcf1b007a2830f04
+        checksum/init-sysctl: b1018f8e0b34710a3a9616f311808d89ebe98295802fe17db5e3ac243f9f5413
+        checksum/init-fs: 39a25206ebcd14ac796926cd0a26519871200de07fcb1ae056f4e8abf0cb11ee
+        checksum/config: adfce0d2c5f1573fc295fbdf64c1b5062074222d8a8a0e91d23b9e7611266656
+        checksum/secret: 33f195a98a527136184f677bfcd5c38dc9d9d27c5b5a27a2ec0551ac69df730d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -805,7 +805,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -846,7 +846,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -981,14 +981,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1020,7 +1020,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.1.7"
+    helm.sh/chart: "sonarqube-dce-2025.1.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -281,7 +281,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 
@@ -303,7 +303,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 
@@ -353,7 +353,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 
@@ -380,7 +380,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -389,7 +389,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -406,14 +406,14 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b16afcfecbc9f68cb05c5680058cb8329be82e29921c0792b5075876dbc3688b
-        checksum/config: 66883e3ccea1903e9ec377f59aec072f20689fff35894099c2460ccd19eff4e7
-        checksum/secret: 662464fb27c62f06132448dd97f7c2692499ed6bf177bfe3df309ac1251ddfc9
+        checksum/plugins: 8f35d1271a685a9ff1a40230d5bb968bc264ee2ed28caed8bf455364c8414c9b
+        checksum/config: 54d2e58ef3058c12727d10722f53f5abaeeba46dea24ec49747f22e012f0df6f
+        checksum/secret: d60b15acc6a6c62bd80a95cbcc9c4c183a409611dd7399ecb86ad16aa1aec46c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -431,7 +431,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -470,7 +470,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -498,7 +498,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -797,7 +797,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -835,15 +835,15 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 4a1f320ffee507a6f83c1898fc08aef8a47c5fdad8e3636694eb4e21ab67ab35
-        checksum/init-fs: 816ac1fe7338895a82f4deece06b516e7cb79e28ce00fc059246c4a0afeb9c8f
-        checksum/config: 66883e3ccea1903e9ec377f59aec072f20689fff35894099c2460ccd19eff4e7
-        checksum/secret: 662464fb27c62f06132448dd97f7c2692499ed6bf177bfe3df309ac1251ddfc9
+        checksum/init-sysctl: 0fc15b66a1ed0fbf3c65a6aea904d1d2a670c86eb8006d7f2572433464ed60f0
+        checksum/init-fs: 1b20ef6c8452aa9822c587df1efa96b1d38632a26f8669053416fcde6ff98538
+        checksum/config: 54d2e58ef3058c12727d10722f53f5abaeeba46dea24ec49747f22e012f0df6f
+        checksum/secret: d60b15acc6a6c62bd80a95cbcc9c4c183a409611dd7399ecb86ad16aa1aec46c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -858,7 +858,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -894,7 +894,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -935,7 +935,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1091,14 +1091,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -400,9 +400,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: bd10f878ef293b8e7f62a6ebe554d95ca8a0842ba85fbc34c940ceeaa75936fd
-        checksum/config: 0b088b618a7c4366e5ee3e6a3b8d78e81e13f3892219b0a618593e955309eff1
-        checksum/secret: b5dd6cfe9f18b994cbbca8966e8397774df834e73c22697f6683958ba242a944
+        checksum/plugins: 31cd864b5f67ec6a66ccbd3e122fecca2ba9f9479fec7bb1ace15eaec39cc803
+        checksum/config: 359dbb2da375e550b18aec6335df11842858ba73b016357a6f7038822e43a4c1
+        checksum/secret: 2efa77ab4ef6ce12ee4845d5291b844745e805ba1ff62dea2677ebf9281c6832
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -768,10 +768,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2dfe543532dd48045ceda0c25b087c5b83d02e44b46d2a00177083681231632d
-        checksum/init-fs: b875f6f6349965b7791e11b887e2d6c0327a52ef2b1b6905eb62c2393e85bf72
-        checksum/config: 0b088b618a7c4366e5ee3e6a3b8d78e81e13f3892219b0a618593e955309eff1
-        checksum/secret: b5dd6cfe9f18b994cbbca8966e8397774df834e73c22697f6683958ba242a944
+        checksum/init-sysctl: 0c7040a96cdf41e85474689997694dc183d26215c5aa682f927475fa4035335c
+        checksum/init-fs: ace64bcaa53aef4931e18ca000674ebe729f996e12899b2fccf7d9b14c034a1e
+        checksum/config: 359dbb2da375e550b18aec6335df11842858ba73b016357a6f7038822e43a4c1
+        checksum/secret: 2efa77ab4ef6ce12ee4845d5291b844745e805ba1ff62dea2677ebf9281c6832
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -967,7 +967,7 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0207250ba3596095ddd8b82c4b701e6987a1c140d5130aa14d792d09b8a211af
-        checksum/config: d71a28900b14f789aa1f1c0609f4ee1e9f15519986c5976d11540d44d982482e
-        checksum/secret: 02dd4a7f3450f7fa53dd7e937e22309d5ab09fbfbaff07671cc2a51d4627887d
+        checksum/plugins: f4381c1f67503c746d5f8ed09207d4037f5e2a925a0b8f1a25f047807ed5a0ba
+        checksum/config: cbdb76d7c878e23436c1920d6ff93051d42d978f2b9cd0979377fbb07448583f
+        checksum/secret: 0fe9722c3ce27b6a4f51018cdcdda3e6e000e6fe451c8e3c035a0f20c7ce4848
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -768,15 +768,15 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f923c724188e0b3e848af74cd765a7c6f34ef7258f94626ae9cc8b8e217fe0b7
-        checksum/init-fs: 6ff9d8bf24c7d641caf80e9a90c6b65ca27a926e2b6f5e4880a01cf2cbbe4454
-        checksum/config: d71a28900b14f789aa1f1c0609f4ee1e9f15519986c5976d11540d44d982482e
-        checksum/secret: 02dd4a7f3450f7fa53dd7e937e22309d5ab09fbfbaff07671cc2a51d4627887d
+        checksum/init-sysctl: 97066e48f844c433ffbaab9df510e56eaae760d86e586435a460570aa46ab44a
+        checksum/init-fs: e632f69fc057e867e7cb5d7184ebad5e6950900aca1a5498756fef92c11b42d3
+        checksum/config: cbdb76d7c878e23436c1920d6ff93051d42d978f2b9cd0979377fbb07448583f
+        checksum/secret: 0fe9722c3ce27b6a4f51018cdcdda3e6e000e6fe451c8e3c035a0f20c7ce4848
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -791,7 +791,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -832,7 +832,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -967,14 +967,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c8321ab01288305fbff5820dff04990aaa5243acf765d1e0ecb1746f9c41d91f
-        checksum/config: d447210bb19e35e15975731076235cfb9a91d18a15055f6601a45d65886e099a
-        checksum/secret: c8e158bc0cc78016a1178da6a2a0af3146aab32e70423c84e5dc2c71f0790029
+        checksum/plugins: 8b554061fea13c724dc36981e32367d0b07f92ff04bbc3971f6ac04b97d9ab7f
+        checksum/config: acc6476892117c1ed70acc6b66594cc183db6d7f7e3cec604ff5bfc4f1e1dd60
+        checksum/secret: 1482aa550d4824f21ea9461580b37bbc46f1bdd718334b1cf2faadba12461926
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -768,15 +768,15 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2203cfb98c013f792d07577863477d3798748297dfebe2acf510be9fe4ea946a
-        checksum/init-fs: 8582458d0f6e4197dd794597729c8986ffaafcbe2d68b7b2846e2da1957f4df0
-        checksum/config: d447210bb19e35e15975731076235cfb9a91d18a15055f6601a45d65886e099a
-        checksum/secret: c8e158bc0cc78016a1178da6a2a0af3146aab32e70423c84e5dc2c71f0790029
+        checksum/init-sysctl: 87ae7d0028f094f152b8511b8c9311da5005dcbdeab1ad6164e1f3c91b13dccf
+        checksum/init-fs: 69e483bbfeabc7b78db9383e6b311a4ccdf9bf512489c6b9b365048eeee423e7
+        checksum/config: acc6476892117c1ed70acc6b66594cc183db6d7f7e3cec604ff5bfc4f1e1dd60
+        checksum/secret: 1482aa550d4824f21ea9461580b37bbc46f1bdd718334b1cf2faadba12461926
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -791,7 +791,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -832,7 +832,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -967,14 +967,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: deprecation-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: bf5afc446efb1240623163cd374dffcb4b8ee11600733da5c876a611ca0d7210
-        checksum/config: 049ab96c630a0d186f7dd11b98c59385b9940014bf9936587eea8e4fa64c72a1
-        checksum/secret: cb638ab68256bab30b184aaf285a62ab6ee4e68d28f6514d6869d69b8ea60902
+        checksum/plugins: 1754ff6b2c3dd6688ee20608ebc3135991384b1f3746dbfd06b4e159726e843d
+        checksum/config: 1141a410e9025ce8f87a11164f33ef9867eb64c39d2f288c058d5418c3effe9a
+        checksum/secret: 57b6f5459efeffce4c2f04d7e9d646b44ae61b56f37836a3ad0fd7d20248c066
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -461,7 +461,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -735,7 +735,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -744,7 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -773,15 +773,15 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: df21ae8e24c90fd7387fa642e97ab762a0abfbaaab71b486c9e3c4c6dcc332aa
-        checksum/init-fs: 4ea394deafaf6b6a64190e0c7e10e366e7f8324a4fce122cf9c3dd09c09614de
-        checksum/config: 049ab96c630a0d186f7dd11b98c59385b9940014bf9936587eea8e4fa64c72a1
-        checksum/secret: cb638ab68256bab30b184aaf285a62ab6ee4e68d28f6514d6869d69b8ea60902
+        checksum/init-sysctl: 783047f4852c62819eb09ed6518c5453419e9ef5b14dce0cd4136f913216a352
+        checksum/init-fs: 3cbfb671c7e8339d20780a91addcc9908d8d8ab528485e51a5c0374eb09cab36
+        checksum/config: 1141a410e9025ce8f87a11164f33ef9867eb64c39d2f288c058d5418c3effe9a
+        checksum/secret: 57b6f5459efeffce4c2f04d7e9d646b44ae61b56f37836a3ad0fd7d20248c066
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -796,7 +796,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -837,7 +837,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -972,14 +972,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: cf31d7b78730659c2a3c75db4ae5e5bc65860441eaecf75096a66af3fb76eb77
-        checksum/config: 563569987bed7ae42dec4ec9900eda4d04a8cd82a51ed9d96f315b0b4ba5efd7
-        checksum/secret: 87d8b9f55955ff6d1b34ea0801d570c9975bd4109f65ad2f644871419a030eeb
+        checksum/plugins: 2b17739b8a0e534754d0c4a64897fe5b2d4856e40c4810f1a0dcd005922b3056
+        checksum/config: 7a6fb748c1c971e3e4a88e46a9553d680aa7cb802473ac31c7665d86a82e4ba4
+        checksum/secret: 56ec500cc4b2f93fdcad613b3134b541cff7c03b8aa6c6480adf1b1748d49e28
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -734,7 +734,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -772,15 +772,15 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: abe000cac141c11d985eb72ff2cf3e3fe12fe8a44d6aece2f96856ce2bcaedf5
-        checksum/init-fs: 34fa85fae4b2d534fb73ca9367b97de23a37733451bafd2878f64a025ec9f744
-        checksum/config: 563569987bed7ae42dec4ec9900eda4d04a8cd82a51ed9d96f315b0b4ba5efd7
-        checksum/secret: 87d8b9f55955ff6d1b34ea0801d570c9975bd4109f65ad2f644871419a030eeb
+        checksum/init-sysctl: 6424cc93d029a0e4d83909d6485f20c2e8b5e26173ccc0ab30583cc7c6bee249
+        checksum/init-fs: b2b9240128ff03b71c22d4ed96f9826168a9347a68ae3190175d34cd4f98c87b
+        checksum/config: 7a6fb748c1c971e3e4a88e46a9553d680aa7cb802473ac31c7665d86a82e4ba4
+        checksum/secret: 56ec500cc4b2f93fdcad613b3134b541cff7c03b8aa6c6480adf1b1748d49e28
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -795,7 +795,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -836,7 +836,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -976,14 +976,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -399,14 +399,14 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a11dbc6a3a37725d5cedef5cbc7b1189cf63849ea35e1c25201c335a641e27f0
-        checksum/config: b606389cd570ed58338088363b327debfd023d32b061784dfc8038fa8c851b9e
-        checksum/secret: 06f55d260b94231d01aaa7c5cd08ff4a0f52de367e8b5dd76788e1a4bfa82d66
+        checksum/plugins: c42fe87990676f1e4efe1e32b9f286fc442bca0f4d798849fa38731dd068ec31
+        checksum/config: cc564cf257965d7bec5bfe4ceb2f68c6d71339e8fefea81782069fb4d51c6288
+        checksum/secret: 7f44fbbb9f5848ca1e4768fd216848e152fc7610b86f10b91ec2a567e7ed4223
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -455,7 +455,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -764,7 +764,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -773,7 +773,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -802,15 +802,15 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 61b86f7babc54251b714fc49223477c03eb0317bb3f185b01352ab648cfdb8a2
-        checksum/init-fs: 8c703d654d602d89979ec80e7f356d1d293b5bc845f3136349ec96f960f6d513
-        checksum/config: b606389cd570ed58338088363b327debfd023d32b061784dfc8038fa8c851b9e
-        checksum/secret: 06f55d260b94231d01aaa7c5cd08ff4a0f52de367e8b5dd76788e1a4bfa82d66
+        checksum/init-sysctl: 05919bbdb495ba57f40d5572b6bbcf627ca01397938932c416cb6e1ee0f158e5
+        checksum/init-fs: aebaecf2f3330d49cab6f91f58240bea633d616bc09e9c3bc1a2c36521ab45e6
+        checksum/config: cc564cf257965d7bec5bfe4ceb2f68c6d71339e8fefea81782069fb4d51c6288
+        checksum/secret: 7f44fbbb9f5848ca1e4768fd216848e152fc7610b86f10b91ec2a567e7ed4223
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -825,7 +825,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -866,7 +866,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1001,14 +1001,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: hpa-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5a25371ee1cb24051ba8bf576ad3be94e96821f330483d2068d913b27467cdd7
-        checksum/config: 7e66b65d4ca3f1f22964366870cd50ea98ead596cebaf3566ffbb2bc4ea7a72b
-        checksum/secret: 50e3c2dc24575acad4141532a061c5663bf0fd6baf5de3e53f50c0f407bb787f
+        checksum/plugins: 4a0093e0608f1a3d0f1da8aa86bc9e4b7348549bcd96a555cd0f9d3497cc7585
+        checksum/config: ef46adaf10bb8873ba9098ec434dc88b68851bc662350bb80630070b69ddd9f4
+        checksum/secret: faeddbefc9d045fc66267b89aba6aa4eaba3f5dc2ed2b37555ee5506dbe0dd7c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -768,15 +768,15 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: fd268af34fead6c19da1905a2f54f40206867e878706ab21547140fad2c024c8
-        checksum/init-fs: 62eef3f583186459440d8c72cb68a2dee861ac6e94cf47f6a1b1f116ef4cedec
-        checksum/config: 7e66b65d4ca3f1f22964366870cd50ea98ead596cebaf3566ffbb2bc4ea7a72b
-        checksum/secret: 50e3c2dc24575acad4141532a061c5663bf0fd6baf5de3e53f50c0f407bb787f
+        checksum/init-sysctl: 4104e5b17a9d5fe71c9f8e13e3dbcf783488319ff4f47bcc19c4c9593fc009fb
+        checksum/init-fs: f6692781e56c9fc6a15c1713fc6a76447ecd87a0eb38faadd002badbe03d4f54
+        checksum/config: ef46adaf10bb8873ba9098ec434dc88b68851bc662350bb80630070b69ddd9f4
+        checksum/secret: faeddbefc9d045fc66267b89aba6aa4eaba3f5dc2ed2b37555ee5506dbe0dd7c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -791,7 +791,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -832,7 +832,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -965,7 +965,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -992,14 +992,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: da7f1714e7b0c27fb81adab078dcbde858f03cad51f7d01c68b89552854020e2
-        checksum/config: de10c02dc3989b88f302c1ea85ec67550864ddd9b67ed4c327bbfb05ea865372
-        checksum/secret: e30d0758a6c844233a4944f552c700b97b6d2a3c12149363b170e17e2aa09ff7
+        checksum/plugins: 999859f8cbb049e1df19a70c4d47c5d28b1c3d84f004b7f40f552870a0e31677
+        checksum/config: b3792f0c9886bf2941e577758765f3911190983e56e06f3954ce5d823a3bf268
+        checksum/secret: ffcdf6a33fd90bc976aface8b9f96669d394e99d561b1ddcfc4a5add5749e57c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -768,15 +768,15 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3be8efcdfcfa829cfdce1aef15ac878069c69491d2bd6f259d7ed3ee3e1afcf6
-        checksum/init-fs: 32e81a79250a01a92665073f184f2de0cac8ecde26988b57bd375c44f614bb59
-        checksum/config: de10c02dc3989b88f302c1ea85ec67550864ddd9b67ed4c327bbfb05ea865372
-        checksum/secret: e30d0758a6c844233a4944f552c700b97b6d2a3c12149363b170e17e2aa09ff7
+        checksum/init-sysctl: 595a079f595994a981c69bd2a5cd153b4c07b31d0ddf01624fa0f07100b74c07
+        checksum/init-fs: e5f8c509cff17bb86ea167d376a2d82f9471ec507cb69910ab13dcd71b7efa7e
+        checksum/config: b3792f0c9886bf2941e577758765f3911190983e56e06f3954ce5d823a3bf268
+        checksum/secret: ffcdf6a33fd90bc976aface8b9f96669d394e99d561b1ddcfc4a5add5749e57c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -791,7 +791,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -832,7 +832,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -965,7 +965,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -992,14 +992,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 701d469fc0e3412211aead49ab842024122da8ed207e5785f01f495010e6f46d
-        checksum/config: 18831ce9be5a20dde7e189994064a7f01e6d23ddcccc4556b63c040ed2182222
-        checksum/secret: 6631065431633764079bb9481afaf121094821d8aff449eb25bea1d73e4c36df
+        checksum/plugins: 60a8ef6ef3cd1e33582ad91e6fd889c6056f81a2b92d8580420ebb9696d42efe
+        checksum/config: 759336aaca06d77a70bd4142254fe3ae7003ca0513f5fcf5670eb678514d01fa
+        checksum/secret: 866e56be8400a0db007c7edbc7b696722cfd659b6583e7d527273af75341e940
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -768,15 +768,15 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e36065dda4a55771ff2710ade39d07263035bde4e4c405a12db3cc7fe60cc6ab
-        checksum/init-fs: 9870b51a142a4fd5c10d15bdcade6d487f6cfc81e0c4123017a79137f058e02a
-        checksum/config: 18831ce9be5a20dde7e189994064a7f01e6d23ddcccc4556b63c040ed2182222
-        checksum/secret: 6631065431633764079bb9481afaf121094821d8aff449eb25bea1d73e4c36df
+        checksum/init-sysctl: a779804704a12867b5d864e927825845c881d0fbc89a7c72c49d52ce51145225
+        checksum/init-fs: ea08000c8e4ac8c3b5e884108be345e16d92452c24aa4b7aad3aa5c41c1ca863
+        checksum/config: 759336aaca06d77a70bd4142254fe3ae7003ca0513f5fcf5670eb678514d01fa
+        checksum/secret: 866e56be8400a0db007c7edbc7b696722cfd659b6583e7d527273af75341e940
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -791,7 +791,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -832,7 +832,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -965,7 +965,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -1000,14 +1000,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -72,7 +72,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -87,7 +87,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -137,7 +137,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -163,7 +163,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -179,7 +179,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -226,7 +226,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -591,7 +591,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -613,7 +613,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -637,7 +637,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -663,7 +663,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -816,7 +816,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -825,7 +825,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -842,14 +842,14 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 46b80eca1f902bd8a39ddb9af89406d5196bf3270fdc41a9ee89219026e7e56a
-        checksum/config: 3c81ee83dbddffd859e24afa4aec5c88953614601de824e7e72e6ecb21e7bd54
-        checksum/secret: 20856f4a48300a17256a3372eb3451c2e062da1b0d44b747b75219a93c8b2489
+        checksum/plugins: da18c5e3bc562c845a9df0e86ab7a43509a48830941d70180fff1f863f72f176
+        checksum/config: 0be4f142ab10db49b0fb66d980001175e71c0744e68654e6b6c2fae34575d25a
+        checksum/secret: 130c2a800f991a897741b72e2522df73e655f5ab3efcd3689dc55e01d1c8b908
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -870,7 +870,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -898,7 +898,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -1172,7 +1172,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -1210,15 +1210,15 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: c66ae4488a215f4d35144ebdb0868179f7c7553b67d7a9de5f05c24f722ee69b
-        checksum/init-fs: 6bba5d4e0d3eeb8df1b218445306a96f3d7730101df24b50c2e1383ac7eacada
-        checksum/config: 3c81ee83dbddffd859e24afa4aec5c88953614601de824e7e72e6ecb21e7bd54
-        checksum/secret: 20856f4a48300a17256a3372eb3451c2e062da1b0d44b747b75219a93c8b2489
+        checksum/init-sysctl: c2479ad21c5328926ef6c3827e2f3b3fe0250aa396e2319dcd218bc90dadd562
+        checksum/init-fs: 4289463a7d730f29a08d0f570f21a5495c7d295a6a7abf1f853bc6638fdd7e81
+        checksum/config: 0be4f142ab10db49b0fb66d980001175e71c0744e68654e6b6c2fae34575d25a
+        checksum/secret: 130c2a800f991a897741b72e2522df73e655f5ab3efcd3689dc55e01d1c8b908
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -1233,7 +1233,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1274,7 +1274,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1423,7 +1423,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1623,14 +1623,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -350,7 +350,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -377,7 +377,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -386,7 +386,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -403,14 +403,14 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0df2c9528962ecff2b03ba92c0c1d56696d7bc09f1ff2f917d23083d6248c6d3
-        checksum/config: 99e3ebf02b5e8e84e2e9c5403ef552b1d79ff1af25a0f51086af83e55172a4e1
-        checksum/secret: cdfca30f9059993e287886323a0fb1cf0b20d5c12d13f0067ad17a78b5866534
+        checksum/plugins: 7e5b8e14d185b5977dabdf39475a73e60c7eff7971e8b684c4fa35553bbc72b0
+        checksum/config: 18a64a8d3abc45109c6893769c7d53d70bfe99f5901b495c077019677a49ddb2
+        checksum/secret: ceb1550927310de7b01eb4e6b9a428a920ea0b017ff52930a979cf526f6f5b61
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/install-plugins-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: install-plugins
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -472,7 +472,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -500,7 +500,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -777,7 +777,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -786,7 +786,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -815,15 +815,15 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 86a7496c7f913604262034614dc00c5a03af7cd1f2d12d98dfb45be31cbbcfcd
-        checksum/init-fs: 904f3f7bd70a60fc82b6c19f35d9775bc286dbd64196b0ffb2e57ea3e2f38d57
-        checksum/config: 99e3ebf02b5e8e84e2e9c5403ef552b1d79ff1af25a0f51086af83e55172a4e1
-        checksum/secret: cdfca30f9059993e287886323a0fb1cf0b20d5c12d13f0067ad17a78b5866534
+        checksum/init-sysctl: 062aedff800ed59bc29baf4f7fa52e9b3ad0e4c73257ed6ed2317fc5c2ee2224
+        checksum/init-fs: f1b598b8d2644bd13a829c48a0622988d6c674222b141386e991b3b2c7c7e083
+        checksum/config: 18a64a8d3abc45109c6893769c7d53d70bfe99f5901b495c077019677a49ddb2
+        checksum/secret: ceb1550927310de7b01eb4e6b9a428a920ea0b017ff52930a979cf526f6f5b61
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -838,7 +838,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -879,7 +879,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1014,14 +1014,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 06c99b4617482af7fd56a5211f9447bc6b47430827a38fc02e0ccd27c386a616
-        checksum/config: f734a9d22a6998bafb102548fcdb7590e5efd55e2ac18d17b8a07b91d6e176b8
-        checksum/secret: 53aef3e21c945fde9866732ea43645950daacc5f2f868573fbdc41095e4bc258
+        checksum/plugins: 3c035383a9d3ee286ab66201d94251804a51928538daf05dab1ecfb7e540f928
+        checksum/config: 04811bfce0e95306ec3e2510ef418afe6c5d9af693af1ab3fe5c480f67e167f6
+        checksum/secret: 0c7aac9f0a5470637cd1d2f36395836bb77c003f25d255a6e4299e2132ebd407
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -768,15 +768,15 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 6afbf4182bcad0f9610872e465946de08f7455b25119828d9b0ee173100859ae
-        checksum/init-fs: 4eda1544409aced4eed98ca1a4c4267d04222ededf71a8868de23509b629e1b6
-        checksum/config: f734a9d22a6998bafb102548fcdb7590e5efd55e2ac18d17b8a07b91d6e176b8
-        checksum/secret: 53aef3e21c945fde9866732ea43645950daacc5f2f868573fbdc41095e4bc258
+        checksum/init-sysctl: dfe5e15fd886174bbf66de8fa7857bb10c4dccd901a3dd252a80029e15bcae11
+        checksum/init-fs: 17d20d8c2da0c0b57ac3074027ebd11fbdb61ed8d496e38d9f1e664848ca3c60
+        checksum/config: 04811bfce0e95306ec3e2510ef418afe6c5d9af693af1ab3fe5c480f67e167f6
+        checksum/secret: 0c7aac9f0a5470637cd1d2f36395836bb77c003f25d255a6e4299e2132ebd407
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -791,7 +791,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -832,7 +832,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -967,14 +967,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -67,7 +67,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-database
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -159,7 +159,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -199,7 +199,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -249,7 +249,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -264,7 +264,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -279,7 +279,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -298,7 +298,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -311,7 +311,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -324,7 +324,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -340,7 +340,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -387,7 +387,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -400,7 +400,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -468,7 +468,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -490,7 +490,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -514,7 +514,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -540,7 +540,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -567,7 +567,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -576,7 +576,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -593,14 +593,14 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 10a1344c51757eb67c4954590e48b572fb5faa4d66e258ef02493026cb7e42f4
-        checksum/config: 8ea29c67ca4a5c58bd9ab9986488636b1662a55b72d753489b3e019082ce79ed
-        checksum/secret: fc2f49809fbc1ae0943fe32a120c15207681bcdf08c608e0389320a63d53ec2c
+        checksum/plugins: a068d159b36ccd198dd5ad4cfadefc85ea0d270f63cd514872cbcf8da6238619
+        checksum/config: 3c64be41e1ca6d1300db7c636cd2d429b48aee5e22378c01fcba6f70a45048cc
+        checksum/secret: 359f3c956434190960b2cbf196150619a1d66500668743b685a4de694bb0be22
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -621,7 +621,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -649,7 +649,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -923,7 +923,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -932,7 +932,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -961,15 +961,15 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 7d64786f5e339c1454d39812c2b0baddaa740f8ebd46965b23419c3f62007555
-        checksum/init-fs: 0bd574f238e07ad44e5d71851209d2037d1df3a04da4328db1b275a65791f299
-        checksum/config: 8ea29c67ca4a5c58bd9ab9986488636b1662a55b72d753489b3e019082ce79ed
-        checksum/secret: fc2f49809fbc1ae0943fe32a120c15207681bcdf08c608e0389320a63d53ec2c
+        checksum/init-sysctl: 897a0d956513c823857a687b224372e4f968259a292c34db9d9afe0cfb950bfc
+        checksum/init-fs: be25d61b6e498064ebbc1249f7e46c71a41b671a0ca5d59793ce20cc8c620a52
+        checksum/config: 3c64be41e1ca6d1300db7c636cd2d429b48aee5e22378c01fcba6f70a45048cc
+        checksum/secret: 359f3c956434190960b2cbf196150619a1d66500668743b685a4de694bb0be22
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -984,7 +984,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1025,7 +1025,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1160,14 +1160,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -67,7 +67,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-database
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -159,7 +159,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -199,7 +199,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -249,7 +249,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -264,7 +264,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -279,7 +279,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -298,7 +298,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -311,7 +311,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -324,7 +324,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -340,7 +340,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -387,7 +387,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -400,7 +400,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -468,7 +468,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -490,7 +490,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -514,7 +514,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -540,7 +540,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -567,7 +567,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -576,7 +576,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -593,14 +593,14 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6c59826c9ed67ef373fd221937075f6a3f89b73aa702771eb32a4fa086d22b73
-        checksum/config: 69f03fa142dde5e572472ae767badfbcce698c02fd2571395fe564c5ede3ea81
-        checksum/secret: ecfa1459d32adf6f03a006fbed44dfb59f49e865730743961c9b1ddf2b49da80
+        checksum/plugins: 00f0a7cd11dc31fb59450e7779b25072122a14317d9fea572688817409ed91a6
+        checksum/config: ee94318809b307b071b43aeaec9e51eae098c415c1ef14226ff7870437906dbb
+        checksum/secret: 11d4cbb4783356f889025569004d038fd339ee07220139132f465108b00ae621
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -621,7 +621,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -649,7 +649,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -923,7 +923,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -932,7 +932,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -961,15 +961,15 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0f41f91838beba900e419648ee063a8460db1a95d18295a8804c073da449da58
-        checksum/init-fs: 66b8186c0eab50a78635c6c48b5557e3e3921ecb49a7e1982c507782306813af
-        checksum/config: 69f03fa142dde5e572472ae767badfbcce698c02fd2571395fe564c5ede3ea81
-        checksum/secret: ecfa1459d32adf6f03a006fbed44dfb59f49e865730743961c9b1ddf2b49da80
+        checksum/init-sysctl: 95605edf823cf7007fb79b6ab03e8754ab00b9994668dd84d5b85c4ae1657d3d
+        checksum/init-fs: 4a914cb52dbc079c1c11811668be511e413355e380dcd2191e90b9e181627c6e
+        checksum/config: ee94318809b307b071b43aeaec9e51eae098c415c1ef14226ff7870437906dbb
+        checksum/secret: 11d4cbb4783356f889025569004d038fd339ee07220139132f465108b00ae621
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -984,7 +984,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1025,7 +1025,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1160,14 +1160,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 81e03e294a831a14c70f85cce4a6ad103d9092903ef1213f1caff17f3b9c9586
-        checksum/config: fa57419a0946c518508ad1df3c7193c129da6eb018e124aec3f8b792d4b6a0d2
-        checksum/secret: d7c26f3aae8343c08640ec2f19a23b3cf13cee999dd2195981a9a2bc0f3c5ef4
+        checksum/plugins: dac41155c39fd1a9ba4f9660e00a9ffb7398978ca6ed33bb92c5cd17eb579977
+        checksum/config: a954985963fe9604fadf20d6baf5d9dba87870cd62833dbfe2aefe9454f7d0d5
+        checksum/secret: 1fa305f112afab9a688481dc9fceef4c4427588d757ce0cb4085b84a0cf195a1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -745,7 +745,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -754,7 +754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -783,15 +783,15 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 60e15ff320d6b5b3faa5f5be3ec40b8c305f0234c22f1496b10384347c81d98f
-        checksum/init-fs: 273d4a6fde9c4ac5a331242d17172a06ba2e649457b612ee457bd4e3750838c3
-        checksum/config: fa57419a0946c518508ad1df3c7193c129da6eb018e124aec3f8b792d4b6a0d2
-        checksum/secret: d7c26f3aae8343c08640ec2f19a23b3cf13cee999dd2195981a9a2bc0f3c5ef4
+        checksum/init-sysctl: 6aceac1f8b67e92e3d22bea5431283fb84bc1babb568f0f33c67657cb5b8fb2b
+        checksum/init-fs: 21f114d95693434df05c12bf9d0d5f58a51b9cde46b6fcae803c33331d2f1d34
+        checksum/config: a954985963fe9604fadf20d6baf5d9dba87870cd62833dbfe2aefe9454f7d0d5
+        checksum/secret: 1fa305f112afab9a688481dc9fceef4c4427588d757ce0cb4085b84a0cf195a1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -806,7 +806,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -847,7 +847,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -997,14 +997,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 34dc452cee4102c9d1310360a39415f387f3364f5f616a22b58abc1ad42a5e2b
-        checksum/config: 37c8532cdafb08b9ae6f539e8105affb6effd92baa7de3edd762cc0ce6cfa511
-        checksum/secret: 713cec112e638cf96d0cc19aed709f2b8efa2b52af0990833b843b57f101041e
+        checksum/plugins: 26dba3fd8083d23faff295b6ff34e1172d60b3c2c4dc7a5ab204011078544fb0
+        checksum/config: dcb749d6b74b02d91fcc8443f703f227fbeed8a681123519d6f4b07541a7526e
+        checksum/secret: 268d44974d24cc5fe9d65c274179c650e3b181352baddc362b31d884774ef24f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -745,7 +745,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -754,7 +754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -783,15 +783,15 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 4b6e6e78094afec0eb636d71e7de32cbc1a033e6ff6877e72182d875e936deac
-        checksum/init-fs: ead8fe7a44a86f72cea5215d3b1d5866c0a996d206995fae49b9a993f644a808
-        checksum/config: 37c8532cdafb08b9ae6f539e8105affb6effd92baa7de3edd762cc0ce6cfa511
-        checksum/secret: 713cec112e638cf96d0cc19aed709f2b8efa2b52af0990833b843b57f101041e
+        checksum/init-sysctl: 2fde3f6e1eec448e89eb7175af69f3540edb1fa039d6c73b9969e917cecaf0b7
+        checksum/init-fs: 4227e9cb38637929d527a2754c28a62938e610177b237aae553a32425c09f592
+        checksum/config: dcb749d6b74b02d91fcc8443f703f227fbeed8a681123519d6f4b07541a7526e
+        checksum/secret: 268d44974d24cc5fe9d65c274179c650e3b181352baddc362b31d884774ef24f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -806,7 +806,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -847,7 +847,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -997,14 +997,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: node-topology-values.yml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -305,7 +305,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -377,7 +377,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -404,7 +404,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -413,7 +413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -430,16 +430,16 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ca24ef74b205af631fecb558966169e8183501eb8f33f9015ac3aff66585a06a
-        checksum/config: 48a638a902d9c404f4b35c16c139261f64f78b314f9d24aeb1d6ffe34872dda2
-        checksum/secret: 07ad672469530b2478551248cfa2640ef8dfa1e4121461db628c0e283f474b85
-        checksum/prometheus-config: 6dbd5f6483d32a0689280172a89805d3edb77920b70bb25c352788cb4e2925c1
-        checksum/prometheus-ce-config: e8e3da61ac9970cde697f58458f585a9cb4f46d74ea85e7b8fc79be50d8e2bf5
+        checksum/plugins: 04925be05d4e096a1e966524761b58de060cfa3cbfa09ac9b796fbb28ded72fe
+        checksum/config: 0125a010bf6e208342dae819886bd4252b0a4170bdd020fb8be3a1aba72f5885
+        checksum/secret: 3c25ada108c56783ee563af452ebe1b06865bd05f8fb70d99dae62611aa871e3
+        checksum/prometheus-config: 8b0f6a41010451edb9d3b323a715adf62d4d10e9020cf3b497725a2b562d9c4a
+        checksum/prometheus-ce-config: abd4f044d3a42b3d3e52a3f8357e332de01b460f456e4305acf8d3c212a568e5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -457,7 +457,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/prometheus-monitoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -498,7 +498,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -532,7 +532,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -824,7 +824,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -833,7 +833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -862,15 +862,15 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 89833be7c7f031b2560ec85f156eee60e82b7e955d624ee21fddb0f32e76f21c
-        checksum/init-fs: 7f3695c908f2101ab3ab204edf8697ed44927358c7af50c279c8790d14f1822f
-        checksum/config: 48a638a902d9c404f4b35c16c139261f64f78b314f9d24aeb1d6ffe34872dda2
-        checksum/secret: 07ad672469530b2478551248cfa2640ef8dfa1e4121461db628c0e283f474b85
+        checksum/init-sysctl: e965296f70e2198ff7adf60d0e4af6356c15062547a202f915e781191cf761ea
+        checksum/init-fs: 55f13ba08beaa71d3c581bea9f3b4cb32da7ac3bab5ffd9126ad8db3e65644cb
+        checksum/config: 0125a010bf6e208342dae819886bd4252b0a4170bdd020fb8be3a1aba72f5885
+        checksum/secret: 3c25ada108c56783ee563af452ebe1b06865bd05f8fb70d99dae62611aa871e3
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -885,7 +885,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -926,7 +926,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1098,14 +1098,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -350,7 +350,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -377,7 +377,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -386,7 +386,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -403,14 +403,14 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 21aea1ee2b37a9daee7f6b9f85b2dad92afe3beae863aa9a2b2757a09a582a9a
-        checksum/config: 4b3cbf18944791f8a1f4f95471dee8082178e2c78761785179cda9468ead1da5
-        checksum/secret: c51eabf47c3a8cb685480815354a2f6b845eb00d5b9adc7f04cb036483fdc902
+        checksum/plugins: 629b96f1fbfb39d7eef34c741dd152a46ec4e5fda43acfc696a9cb4443dd3922
+        checksum/config: 92ecbfd9ac6219ecf612cd4308c6b1ecc37dc3c92865e8ca170b377165543940
+        checksum/secret: 16e7693c1363b777309cc301e3ce58047560ca7ae004bd9adb0871432b2ff3b5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-secret-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: install-plugins
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -472,7 +472,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -500,7 +500,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -777,7 +777,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -786,7 +786,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -815,15 +815,15 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 5cfb0509749f4b788c52087e8d07f764dd22045ab5c3755c57c9bd6f38897786
-        checksum/init-fs: 2559d0f78a79773526044848763151b1bbe7312febdbc0220b5701a4040c593c
-        checksum/config: 4b3cbf18944791f8a1f4f95471dee8082178e2c78761785179cda9468ead1da5
-        checksum/secret: c51eabf47c3a8cb685480815354a2f6b845eb00d5b9adc7f04cb036483fdc902
+        checksum/init-sysctl: 787c9331c179ca6cdaa3e90f24a644fad8e708cf391d28be400c13a534a1233e
+        checksum/init-fs: 16a8840c8bcba64cc005cfaa7dbd7f3179840468d53a51d5f1c0ae7dbc625b26
+        checksum/config: 92ecbfd9ac6219ecf612cd4308c6b1ecc37dc3c92865e8ca170b377165543940
+        checksum/secret: 16e7693c1363b777309cc301e3ce58047560ca7ae004bd9adb0871432b2ff3b5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -838,7 +838,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -879,7 +879,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1014,14 +1014,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -308,7 +308,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -330,7 +330,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -354,7 +354,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -380,7 +380,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -407,7 +407,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -416,7 +416,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -433,16 +433,16 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 373173b219e8257a45a13a46eb7e0e9b81f2fd61f9177b1dc4e1c6a22eb44d07
-        checksum/config: 0b5d99fed6d236ce8fb4c2849502296d9958e1d0918e87aeeeeb82f643615e78
-        checksum/secret: c23c48cf3906baef6d88f5ab6942016a0818245e3012abc012c60d1ac8e8bd8a
-        checksum/prometheus-config: 0f3dc2615ee0c85f7574f37591ab3dc5bd174cb0c67491f7074d25dae6b00a48
-        checksum/prometheus-ce-config: 68f27636f58cf12ebee79fd8cc7a92a99a87a24548dea72ce1ea07b2104472d0
+        checksum/plugins: df42f5d2a0717e82f45ec81d18aeceb9f7f227f4bf0892922955b69a361aa043
+        checksum/config: c4414d1219b7f77fdceea07c73fdd3f42b38b363127a40092cd8be943476092d
+        checksum/secret: d4d2e23fcdf2f7e36236bdb5d66b5d29ff966aae1d71faa35f54c8e44136805b
+        checksum/prometheus-config: 77895536b67f4e05d76aa5ae9ddd4bbcd2630960f66bb7776fcd80d4d6ede319
+        checksum/prometheus-ce-config: 6bee8c22aafb5c9f9f1eb17e5df07c460bebc79134ebd11a6fa3f8dac0b8cad5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -460,7 +460,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -498,7 +498,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -542,7 +542,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -576,7 +576,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -871,7 +871,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -880,7 +880,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -909,15 +909,15 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: cf68fa43e90f6dd197fcd1c3ab680c7e19d3785c263811c76a702bf00d6439a6
-        checksum/init-fs: dd27b2c9ed3126f6bc81a74b9264e904fdd1a602cf2defc2e2999c78d6f3e2b4
-        checksum/config: 0b5d99fed6d236ce8fb4c2849502296d9958e1d0918e87aeeeeb82f643615e78
-        checksum/secret: c23c48cf3906baef6d88f5ab6942016a0818245e3012abc012c60d1ac8e8bd8a
+        checksum/init-sysctl: 15ace1d325bd369e4c69473335a455078a14e61df7316271964d51fd8a654d78
+        checksum/init-fs: 58b6c430688ccd6643e50ea35144f223077a1e88aff69c65bac85584470236ff
+        checksum/config: c4414d1219b7f77fdceea07c73fdd3f42b38b363127a40092cd8be943476092d
+        checksum/secret: d4d2e23fcdf2f7e36236bdb5d66b5d29ff966aae1d71faa35f54c8e44136805b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -932,7 +932,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -973,7 +973,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1108,14 +1108,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -347,7 +347,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -374,7 +374,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -400,14 +400,14 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c39f8b12ba1556683bd8cb545d126ff68f74b219de09fa82de2b40ab2c81419a
-        checksum/config: 55c76008e52c7d3bfa2a89e436efba1f78c89d3d722979c86d6a40cc69d35756
-        checksum/secret: fd10ff77ebbe8c5301418d8875ed01ee91395b8dabc3582f5411236bf822555c
+        checksum/plugins: ee6360dd4adacfa7c09d20e7d3e20a6cbfb6c6571836ff55fe97532dd7f88b51
+        checksum/config: e2742fb5ddbaa889fd62b47fdacd0479b6f24c07af25fcd402b2fedf51d6318a
+        checksum/secret: 59f4c7322b851bc15dbc18d88fd2a7322e0bba704c7fba8ef4bb8c6150376169
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -730,7 +730,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -739,7 +739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -770,15 +770,15 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a9b37a9e0fb4869492ba4f3984dbb8e4cb3892dffa8a237fcad92f7c85de94a5
-        checksum/init-fs: ce1bf0e2d2d25a3ef2f3e7e75898c98524a64ff8092c7e2871cc06c865e5540b
-        checksum/config: 55c76008e52c7d3bfa2a89e436efba1f78c89d3d722979c86d6a40cc69d35756
-        checksum/secret: fd10ff77ebbe8c5301418d8875ed01ee91395b8dabc3582f5411236bf822555c
+        checksum/init-sysctl: 6c50afecb30cc4d2876fd51d43878170ca92954804554d76704ad2280f08ecc0
+        checksum/init-fs: 124afe91b101dfaa0de2d0860a6d17332986718dc5c9e87dee7a78b72155d430
+        checksum/config: e2742fb5ddbaa889fd62b47fdacd0479b6f24c07af25fcd402b2fedf51d6318a
+        checksum/secret: 59f4c7322b851bc15dbc18d88fd2a7322e0bba704c7fba8ef4bb8c6150376169
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -793,7 +793,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -834,7 +834,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -969,14 +969,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -203,7 +203,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -229,7 +229,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -256,7 +256,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -282,9 +282,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ce7f07d1dda713044593c54b78b780fe0cade888c5755bf1504fd7dcefaafe92
-        checksum/config: e2992a585f56840eaa5f675960f0ebe0c1ee8d2225c9fa678780e5b900eb419a
-        checksum/secret: c5c3f9b20a023397c937011358644d554bf708a9513671d8287445207ec73189
+        checksum/plugins: adcd4ae638e19bd0ec354a25dddd5ec3c155d3a1609c0cd363d01df01d223e94
+        checksum/config: 32138c2161774116f50a4d3466efcc989464e9ead1743569a9a437a5cb13ab42
+        checksum/secret: 857cbcaf905f7ea220e21813db48ce8725359d0959292340a164c69578b23f3d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -479,7 +479,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -517,8 +517,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: e2992a585f56840eaa5f675960f0ebe0c1ee8d2225c9fa678780e5b900eb419a
-        checksum/secret: c5c3f9b20a023397c937011358644d554bf708a9513671d8287445207ec73189
+        checksum/config: 32138c2161774116f50a4d3466efcc989464e9ead1743569a9a437a5cb13ab42
+        checksum/secret: 857cbcaf905f7ea220e21813db48ce8725359d0959292340a164c69578b23f3d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -691,7 +691,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -304,7 +304,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -357,9 +357,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 183241562638c664e1084cdff8c1c10b504437387a752477fab1b79d505c5178
-        checksum/config: 28249ebe9014b891a63462566d7e4e82a8a941c8e8bb870db870ae22ee2fc739
-        checksum/secret: 406609da5ee3b16c2ba428a77079a113bc83973c5ff102d081629c63d966513d
+        checksum/plugins: e6d91dd574d02dec61116be74b9f4ee6f9269cc90a075e508a763f2d9ed7fe45
+        checksum/config: ec52c7f3cc0935e8db3abb2492a9156d97ab05c979bcb3355c4ffedb2074475d
+        checksum/secret: cae429f4d5e9e68ffaf6f55022f437f50469ca26df7c9634cb10039a2d1df09a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -367,7 +367,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -395,7 +395,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -508,7 +508,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -546,15 +546,15 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2b167c53bb0d0cc8b896d8e06fd39898f4c4d21ff053ad735696bba8d69d5d53
-        checksum/init-fs: 30cd57c7f392f02d75310f60e2b9f305f8dc874a404a60ce8b22e283525b4518
-        checksum/config: 28249ebe9014b891a63462566d7e4e82a8a941c8e8bb870db870ae22ee2fc739
-        checksum/secret: 406609da5ee3b16c2ba428a77079a113bc83973c5ff102d081629c63d966513d
+        checksum/init-sysctl: 8c297c51a4692aaa64c43ade350ac4f5edf8745f50a4b8c67bac6c72afbb96d3
+        checksum/init-fs: 941b4280abf285efbdde9634922210f1f56c09ddfb813ee8a1ad645060e22487
+        checksum/config: ec52c7f3cc0935e8db3abb2492a9156d97ab05c979bcb3355c4ffedb2074475d
+        checksum/secret: cae429f4d5e9e68ffaf6f55022f437f50469ca26df7c9634cb10039a2d1df09a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -569,7 +569,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -745,14 +745,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -784,7 +784,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.1.7"
+    helm.sh/chart: "sonarqube-dce-2025.1.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -304,7 +304,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -332,7 +332,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -361,7 +361,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -392,7 +392,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -418,14 +418,14 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ec5163300e96edd23a12f6072f0a22776caa85a25a0444e16d9a6e501a783768
-        checksum/config: 70881cccc98b5fac40e38d933587730d6d856b8d24a1e848dd0ed1bf492f4bc3
-        checksum/secret: f1513546c4236b35a83d2933e061ef87a0516db096fca4bba95e1c13531ddfa8
+        checksum/plugins: 3591a46b824619c3f2f734561533ed965522c63215cb6c3a9d9302f3a7f796aa
+        checksum/config: af519a50719a065ff6f192a4cd926c34385977df5e17ea031c4030688c7e7172
+        checksum/secret: 47fd72fe765b640a31cb7dc7633be1f43d418070fe1b96c559a7d1b7ffd5b049
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -446,7 +446,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -474,7 +474,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -748,7 +748,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -786,15 +786,15 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3033f555f26695f38a6e1effd6bed90ad9259061fcb53993dd6aee135bd9b760
-        checksum/init-fs: eaf1a66481adefab2f0cfc7588f8965f3e10c4ea38abef5fb3229fc4721c5087
-        checksum/config: 70881cccc98b5fac40e38d933587730d6d856b8d24a1e848dd0ed1bf492f4bc3
-        checksum/secret: f1513546c4236b35a83d2933e061ef87a0516db096fca4bba95e1c13531ddfa8
+        checksum/init-sysctl: f23464a8231937beb91ef2952c72991907ed9a597c619839ffcb2693ff5e139e
+        checksum/init-fs: 6ca31d5856ad80ece7a00c5a0e29e5a162867bf2180459e61e82ba96d02cd65b
+        checksum/config: af519a50719a065ff6f192a4cd926c34385977df5e17ea031c4030688c7e7172
+        checksum/secret: 47fd72fe765b640a31cb7dc7633be1f43d418070fe1b96c559a7d1b7ffd5b049
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -809,7 +809,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -850,7 +850,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -985,14 +985,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -65,7 +65,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -80,7 +80,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -95,7 +95,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -114,7 +114,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -140,7 +140,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -156,7 +156,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -203,7 +203,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -216,7 +216,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -284,7 +284,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -330,7 +330,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -356,7 +356,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -383,7 +383,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -409,14 +409,14 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 621805f2030050018c56f31aa3a869d05bef88854707417cf62770da70601eed
-        checksum/config: 107d3ddb139d7212e21c28c65290dfa46a65461521b092b5eb80f7dd5732da63
-        checksum/secret: a1cef8be45c8dbd2c672de644300042a0d4f71296a0952419477b6f30b9294e1
+        checksum/plugins: 08728ea9a53f2ccbebb3c71e69a99ebe4c144ba62f76d182c9d1e3fac1bbbca7
+        checksum/config: fe23432d0b1c8e7b0b842a63e779bd90227680b7e6d927001f8887f13d1a23ac
+        checksum/secret: 3aeab68863dd7db4ac6a4392f527a38c294de5d49037724a4febad8a0f375969
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -437,7 +437,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -739,7 +739,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -777,15 +777,15 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e9ab6a33098639d744d09259e7e129554e1dd2677503bf0fa5eded595ffc619c
-        checksum/init-fs: c5b37061b6c703c484cb75e09f00291ac6fa4af85296b532709c3a6182088f1d
-        checksum/config: 107d3ddb139d7212e21c28c65290dfa46a65461521b092b5eb80f7dd5732da63
-        checksum/secret: a1cef8be45c8dbd2c672de644300042a0d4f71296a0952419477b6f30b9294e1
+        checksum/init-sysctl: 23dd63be82688ac5167728d6c15edae304e1861f69c8474e6308e63c9511ae1d
+        checksum/init-fs: 6f2c4e61db28042527c59e34e0877c5dbbe030b4fea33738be7c988865197d79
+        checksum/config: fe23432d0b1c8e7b0b842a63e779bd90227680b7e6d927001f8887f13d1a23ac
+        checksum/secret: 3aeab68863dd7db4ac6a4392f527a38c294de5d49037724a4febad8a0f375969
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -800,7 +800,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -841,7 +841,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -976,14 +976,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -209,7 +209,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -222,7 +222,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -290,7 +290,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -312,7 +312,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -336,7 +336,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -362,7 +362,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -389,7 +389,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -415,14 +415,14 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 17d86aab460d402634f28b4eff50f61a4f1cd0ad76e862a0028489fad2a68bea
-        checksum/config: 83679b1e2b553967ce3eb51bf2dfadf76b0a74e3f56655ddf8f70ed27328c7c8
-        checksum/secret: f63536e3802d5a73bfeba0886be01b09f81938b3ec530a29534b5e4a8a9455a7
+        checksum/plugins: 926f5ff38c9b0160507955b418aa65b8130fb4cde6b15f3f023bdc4fe0d737aa
+        checksum/config: 171b84f654c7f41b521631b126314af407693b3193d814f7a3d563698a512334
+        checksum/secret: 5fda2c7f22cb22689f143ebd402bb511bb36cce52c2e98e6f9ff56803604c3b2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -440,7 +440,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -479,7 +479,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -507,7 +507,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -793,7 +793,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -802,7 +802,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -831,15 +831,15 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f6e9f6161844963b91073bdacf23dab79d44c6a43d7ecb754e53d1b352838b19
-        checksum/init-fs: 19f15fa6b5947708a5ac7b2d8fd659bd17cb7b31922d3926b87f099e3c0dfcf9
-        checksum/config: 83679b1e2b553967ce3eb51bf2dfadf76b0a74e3f56655ddf8f70ed27328c7c8
-        checksum/secret: f63536e3802d5a73bfeba0886be01b09f81938b3ec530a29534b5e4a8a9455a7
+        checksum/init-sysctl: 52133bffd4cc97af6624231dce453258d89bc810ce2a885a6d27eca2220ae97a
+        checksum/init-fs: 9f29fc5dfef3762e23f260f704069d1d3a211ca268151ee980e358cc68b878a2
+        checksum/config: 171b84f654c7f41b521631b126314af407693b3193d814f7a3d563698a512334
+        checksum/secret: 5fda2c7f22cb22689f143ebd402bb511bb36cce52c2e98e6f9ff56803604c3b2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -854,7 +854,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -895,7 +895,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1028,7 +1028,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -1053,14 +1053,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1092,7 +1092,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.1.7"
+    helm.sh/chart: "sonarqube-dce-2025.1.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -1109,7 +1109,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2025.1.7-datacenter-app
+        image: sonarqube:2025.1.8-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -289,7 +289,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -311,7 +311,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -361,7 +361,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-app"
+    app.kubernetes.io/version: "2025.1.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -414,14 +414,14 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 095ff842b5637c166e0ff25b5db3a5e213810e2ae9a4116c71c8776be3619c78
-        checksum/config: 9094dea8d53bcb62d6a62502b626c44c66eccebb437a4a0ef578e71813e47ce2
-        checksum/secret: d45bb9a6660ab546ca2aba8013facf3018c009026ea05e11ce958e4fcbadaffa
+        checksum/plugins: 01ca48e83c9a12fb7a7dcf9a8357468c3635db38f76985efb1a7c97912ed041d
+        checksum/config: 561d923934b0ea0d9297cdd466ffe66c0b3be25bacbfb1e326a4d62de5ab0bec
+        checksum/secret: 1795c2d75cbf0cd79f20465a74ca02d288cae9e065e06d913efc29a5412fa884
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -442,7 +442,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -470,7 +470,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -744,7 +744,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.1.7-datacenter-search"
+    app.kubernetes.io/version: "2025.1.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -782,15 +782,15 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: db8753f63a427a9aa2e9d2be5e80abdd2d2629f71c8b85d958613d868e98cdc8
-        checksum/init-fs: 31dfdc0a221ecc5b9e0dd040252486fbb154eb6776ecc764093b0a0d475df714
-        checksum/config: 9094dea8d53bcb62d6a62502b626c44c66eccebb437a4a0ef578e71813e47ce2
-        checksum/secret: d45bb9a6660ab546ca2aba8013facf3018c009026ea05e11ce958e4fcbadaffa
+        checksum/init-sysctl: 2774fbd8062857983874c7ba69d41d5264195b085bf44144fe94e0f6df23e339
+        checksum/init-fs: a83736b0a33e6396392839f2f1bb62d975a8bf58b42b2941456ef4594bc927c8
+        checksum/config: 561d923934b0ea0d9297cdd466ffe66c0b3be25bacbfb1e326a4d62de5ab0bec
+        checksum/secret: 1795c2d75cbf0cd79f20465a74ca02d288cae9e065e06d913efc29a5412fa884
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -805,7 +805,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.1.7-datacenter-app
+          image: sonarqube:2025.1.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -846,7 +846,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.1.7-datacenter-search"
+          image: "sonarqube:2025.1.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -979,7 +979,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -1004,14 +1004,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.1.7
+    chart: sonarqube-dce-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-datacenter-app"
+      image: "sonarqube:2025.1.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1043,7 +1043,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.1.7"
+    helm.sh/chart: "sonarqube-dce-2025.1.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -1060,7 +1060,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2025.1.7-datacenter-app
+        image: sonarqube:2025.1.8-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -214,7 +214,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -396,7 +396,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -404,7 +404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -416,10 +416,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 921d4d83a470b15825450ffa88b3722c752973f84557171b4ffd23422aabf4fe
-        checksum/init-sysctl: 481faecdef99e92464328189f17260e46d6bad892dd3e0e7fd5427316cc7806b
-        checksum/plugins: b65a12d4dec2140541ce4fca43dad19f05217e4c07bb467dcb6c70123120d019
-        checksum/secret: 0edc836e62f0878ee1993e5defd53a64c86190bb392a5600d492585547d66be4
+        checksum/config: 26ca3406884821ff76844a85b9fbd40a15f731f213b84d8683fdee2976aade92
+        checksum/init-sysctl: d9301654c7e2f230248e475a6c2f651f862795a8051277daf77a77a14e565b36
+        checksum/plugins: 5f916df9975842ece4453617bb699ff9d23105f90468945cee03fbe9f5910114
+        checksum/secret: eb2e6f4904a7a8942c7cb595470815b7bb0c2391ae1f8eb12f0d501f80a03247
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -445,7 +445,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-configmap.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -474,7 +474,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -492,7 +492,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -525,7 +525,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -542,7 +542,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -669,14 +669,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e75e9f30ae13d979636d544d768dcaa2d462cd7c34a4058cc7706778281f3c3c
-        checksum/init-sysctl: a0012790af8d0b149bc64fa7ed2ada6db2685e397d183a4c0f0453b6cd50f923
-        checksum/plugins: f879ca0974e2ae7084fc1888c213c18f5667cadfd7ef8bfef5efc57ee486f6bb
-        checksum/secret: 2a5cedc104f89e1d0b58f4ea9c5d37f43f1da8f5277e20a9e3dd542732b99e8b
+        checksum/config: 313309cf188c14244336906229e8e6746dc4729040cfa72470ef9baeb4cdd78d
+        checksum/init-sysctl: 425e17634cea915f6d382c08e2da07f0cabd026409d5a79f35dfc843b942987f
+        checksum/plugins: 3545f7ff0983bc76aa2fafc0c323e614919d1eb18a31e79818dad5fb52a1f22e
+        checksum/secret: b0fd668923eb9661e0c4af070f094141e6ce1fd527eda7c9bd1dc87e74ec32d3
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-secret.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -477,7 +477,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -494,7 +494,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -604,14 +604,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be193f52785f4742b3e460e3d555a9f7099629e88e46d3666f51ccd0308330f4
-        checksum/init-sysctl: e0b12813c4972416d08c39dc2dcd6a72e4d8b80313d269aa41116c29e1aaddfb
-        checksum/plugins: 621ee356fb85a6cd1bc6ce8fc67679e2c87775227263457bf0fe5af90d5c5655
-        checksum/secret: 0302ef1ab6a8bb63f337edb7db6dcae57a893c9273c7e4bdad814be45a5ab608
+        checksum/config: f91ae68ff2d2fb73e5fa80be5ce6b9ea7a6d9aa745eb8c0da975b32ac4028492
+        checksum/init-sysctl: de6de171aa7b3870039e2619f874961e63ab045274e8f8e05fbcf3dd14fa2a2c
+        checksum/plugins: 8bba3a6116a4dbc357e78fabc33113ec4834d97297c42737ad3263d6e2399aa4
+        checksum/secret: a36045774790f83eff289b6c85fcaa6deb0edcf139cbff7182b40ee48e1126c2
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/change-admin-password-hook-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -586,14 +586,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -623,7 +623,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -636,7 +636,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.1.7
+        chart: sonarqube-2025.1.8
         release: change-admin-password-hook-values.yaml
         heritage: Helm
     spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c981270f60ae6bc86b4f465fd7468db7c2ce37e0566d913cf289b0d7aa607e4f
-        checksum/init-sysctl: 895c8ecc0ad3e9a4a09f4e6de3cf7edb017a7f5c3e38cce4754cdb04936e6638
-        checksum/plugins: 13711340472eb4494ff0a338425fc3854ef1c153a8d64a5deb17921cd5887240
-        checksum/secret: d03f8be2dcd782794c865bda4e4009a21d95f9d2ef28c2a13598d9bd8e601c98
+        checksum/config: 1f0acdeaeb324b41200240acf681543f709a4a969dacf3260343f5c893dfa8ee
+        checksum/init-sysctl: d4b440644f578a59039381102020a982897e038862dbbf4b5a6ee698e3d0c452
+        checksum/plugins: aa2c5adca658f1171e374610634fb184d13047d9f2f4bc953ebb64dff88362d2
+        checksum/secret: c72a6a423ecf01f3a1ef34859890666462fda89e6f7e168ce681ec238c434c74
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -572,7 +572,7 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -74,7 +74,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -202,7 +202,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -384,7 +384,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -404,10 +404,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 195770bd239a6317e042d2729c408995f9c683a8faf6d0885cc3e0ed7254f548
-        checksum/init-sysctl: 5a931209835e246ae8b7d9870f50f49084fde9fbcb4d4da9414037dea3151608
-        checksum/plugins: 6e006616ffc9b8938f635d668fd1a83d8fe2e8973b2e3d4c8038b8efc2b7151d
-        checksum/secret: 4dcfc596d33d13fd46ab50d1a6e72c03de461b3f904c038d884f73f30cc28f61
+        checksum/config: 18c5a60f9d092fca5a1bfcd38a3afbec43f31bd24615bc179faecfce015aafee
+        checksum/init-sysctl: 5477571a855cf2e0515de1efb050e139e921d5d58ce5cda21572a466d5069c51
+        checksum/plugins: f6596d78af7e44575222015e9e2dd27d2e050c7bd4a3386ff5a806aaab718541
+        checksum/secret: 907d0e17293ccc1e288c024bfabfb4f60e5665915ed31dd75cba8e9dcd99e99d
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -417,7 +417,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -433,7 +433,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -451,7 +451,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -496,7 +496,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -513,7 +513,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -650,14 +650,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e432d096a68fbaf4b53bb2806ad91d7f1e204de6a2b2e61e053501bd51a2e9e4
-        checksum/init-sysctl: e08d06a03de3f6d5fbc105587807d227e2b78154952a60d6c73026f34916e06a
-        checksum/plugins: 5347e16d07c806e6590a2887ebb16b4bf89d55b0d5ec0da702b50cb006d84e48
-        checksum/secret: 176dc63b8821c289c03ba7ae141808abfd635ffd3fddb2783eb0e025ac9db3ab
+        checksum/config: 48c83c438c957d379492ef6d1b8c1b0ed4592f9564b9efb68a8d5b6bddad9a1d
+        checksum/init-sysctl: f5c1caef36d9b5f5bd1af4c89c0964460477a18a2112b5c0f89a9f41a4d4b7b5
+        checksum/plugins: aabdeab5ef33cb068e4adf43aa649a5b1e720877db46f0e99da6f588a71c2b19
+        checksum/secret: 30c88ddfcd3f9e89bc2d77e54bf53609dfcb7a5e1ea04e093a387dce8eb68282
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -572,7 +572,7 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: default-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be33e544c042ac266c2063bad5d0ac9e10bd22102233a2d71c93abad51990ad0
-        checksum/init-sysctl: ccdb75710249317ae47a2ec0e43eaa7dca99dda69a60040552a6901aeb80398b
-        checksum/plugins: b941045c4f0c779062defd389c4e42f9edf005c3246dd72e176309c6906ec3f7
-        checksum/secret: e97bc43e13581b0b9b8d383ca000db2d655506ff3ce5ed943e44cce555f06e10
+        checksum/config: c73b8ebf314d4fdeaf18346ebc3b0e1f47df99a27400205e7b9b77999fafe44d
+        checksum/init-sysctl: 51db2afcd2f4fdb8285a02389032b9cbed98379af26d192b47509c433e39a3f4
+        checksum/plugins: ed1892a4021b3e3cb34898103813b1e53890887c9b63d91d89047c6cd2d9ac2f
+        checksum/secret: bb2eae23da84008254189ddec4d9ef863fda88e3dd033056ccf80c5c86bcd022
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/default-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -572,14 +572,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -219,7 +219,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -240,10 +240,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be94301fed07bdc4ebfd7ea47bf4e29e611a74e4418428d3377de13eb6650fa8
-        checksum/init-sysctl: 37874cf1915b0963d9dc3c068e1808d02410fa040f833070077a41320834f762
-        checksum/plugins: a9fd0deae78fabd78108d9346cf217c04d0f1967788195e5364379b7ee194210
-        checksum/secret: 45b7494212087a6b61db6ea14892e9e7248c2d8699d4f6d1ce8d49129ffab154
+        checksum/config: d9d8c70f584aa605b3f9363138e6770cc4986f9346b7c1e5ba8822d2684a39e7
+        checksum/init-sysctl: b13b28ecc534a4055ed2f77676cc68d73feaa3a8bba42c4e143fed67628e400e
+        checksum/plugins: 3581697f359ac7baec60709d3893e675c7168585455bae10862520bc9d055668
+        checksum/secret: 08fa1f95abac8cc2e8e28c50a660920dcc8578718db694fb06038cc599802b2a
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -253,7 +253,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -269,7 +269,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/deployment-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -288,7 +288,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -305,7 +305,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -573,14 +573,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: deployment-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -228,7 +228,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -410,7 +410,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -418,7 +418,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -430,12 +430,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b3d4013e33cb8a2718fd93fa79ce41e9a88c9fdd906d0f15a82d5dc046143238
-        checksum/init-sysctl: d5c30caa07554d85740968eacae30ddc0f51e1b97d3759a1228cc2b57d3775b0
-        checksum/plugins: 4f0d18655f9806b6ca694652d10bd7c5c2795cd38066d8f4c146c05127a3eb88
-        checksum/secret: 2d2bd6d73a1ecbd579da379e83abc67457ef4e696953989d7c66037a12bae095
-        checksum/prometheus-config: b6cf82fc095cf8d9bd53715b9686ce58bcfe9d4dab94def70a2db9e530e1c27c
-        checksum/prometheus-ce-config: d42eefeaf1454b9af034e5f6385aa896d511a0886756cde4159aa92c0dc6335b
+        checksum/config: 76240328e5a248c6f2c584635d30114552ec4067a1a30852c68806aef78902de
+        checksum/init-sysctl: 76f65b98a1e77543f42bec24f2617f09feb7c44f1d69e6b04a9bda33ab509dd8
+        checksum/plugins: b4c1063318b6c5e6f13a8cbc3209928ffaa231cabb6ea54f9e083d633f2c40f0
+        checksum/secret: 8dca5f0806f86805e7097994f8d4678de37674d168ba07dd075040626002aeaa
+        checksum/prometheus-config: 388cc013ead823688a09b72c703ed6d4fc373bb39d9ada0a313de93a764850d9
+        checksum/prometheus-ce-config: 1b4a706e5dbf20a2161cf047222ff9133dd96c3854931272bd86be5990b4e6d1
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -445,7 +445,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -461,7 +461,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/duplicated-env-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -486,7 +486,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -536,7 +536,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -559,7 +559,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -691,14 +691,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8195d2664f2e1222e7763d9e5dc9a74f439915650df334e9ba12ffc3c0e09e0
-        checksum/init-sysctl: db49ffe4cd38ddbd9bbe53554bad686f7a451b96098dc485cbfd8dcaa1dabd41
-        checksum/plugins: 70567e6138db148f0c86b721abe9cc40d9c4f95010df8ff52156accc5131e569
-        checksum/secret: 3ad5ee7bb9e533914acf8c4601ec358b661f56aa470f754791bfc9bdd03e47e0
+        checksum/config: af882062beb9c5436192d0361e25cb241581024721018960528813e10de24521
+        checksum/init-sysctl: fb88c05418349b2f364bf6b9e30fd6e5f7b0d646dd524fd10cf65897563e010a
+        checksum/plugins: 6238e1821e16e78597bacdace510b729804f9406abebd8699b846f6e993ea0f0
+        checksum/secret: 7e9731941c1f6e6c6a103a7a4d9d875da91c4889f3bd685468c973d7cf5c6ed4
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/http-routes-default-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -597,14 +597,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0bfeb75616da68845ebe91e4d020f8b27d49ed7c3f10a394ac764137adc6e430
-        checksum/init-sysctl: eaadf9271d993a096005e6a0b98ea3168587315ab5911bf0958aef480fef6868
-        checksum/plugins: 91a85366705796dbcbfd263c9efafd8a91e569d3832bd7bd3f2ebf22b23401a8
-        checksum/secret: 8f738b497ce4b7864689b0b0dc15be3552b32c59bbfa2c0bc95d142015a8bb80
+        checksum/config: e6c4a9929e7a4af8d6004d69e105abfa526eb616a6d25a705cf320914bea2a2f
+        checksum/init-sysctl: a15937ca775b5ebf7005ef32fa9f6ec17d433ea1237619251d584ccc4aec02c6
+        checksum/plugins: 10414109f42b4194040d54ae4994b74899eb855fac70feb3ae8b1f29bcf2251a
+        checksum/secret: fe3cb73d959edaee8cf89a8e4bcd2fa65b9bf8cf1a187451688f68d2eb2927d1
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/http-routes-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -597,14 +597,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 647ded2abb3863e4885fdda89780468cc54dde3175bb9ee82ff9f19541889fd2
-        checksum/init-sysctl: ba94027994d5ed74072425383f368f957bc007934a8a7f393b3b59d24c02c4b3
-        checksum/plugins: dc955270573a04d7c7d56ee483982de6235a264c5381776dba444ef327cf6275
-        checksum/secret: a3aa34a8e02c40faac8fa7a04673311e6879d403a29430cb5ebcd749d8bfa96c
+        checksum/config: 49cffa6487d45e150db5a7a38af2313d0214ea59cf7500679918d241da3b09f1
+        checksum/init-sysctl: 3247317c5b0c5be355bcde170ca1accf2dc299b568c3a039040f0a92d774ed02
+        checksum/plugins: def20acb27389dd95f2286584e3e89bd9d43c9b422c1ad56b452c9682965767c
+        checksum/secret: 48797c0afed57e18895b18f121697dd69db1f063792b5060b42203dda54d05cd
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ingress-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -605,14 +605,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -39,7 +39,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -149,7 +149,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -514,7 +514,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -822,7 +822,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -830,7 +830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -842,10 +842,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ae8c0c8090199d1f91f461a133ff31208d4b80357f741f5c4786d6c35a7b4485
-        checksum/init-sysctl: d0c9649340a352d3f28b17d5ebdc3a7ea3491fdcb283d576dd85f805c296bdab
-        checksum/plugins: 97083a3cea9cd0fc063a3e0f47ff6958900bfffe29cbf4084797f503873c1d07
-        checksum/secret: 03143d8db50270a01f54e4db6f3537bdbc7b8f760322a14f35974abd898e596f
+        checksum/config: 0b67e18aae0724766182f3172be97bcfdc3a39bc07c28f9da2f82c5dfb8a8409
+        checksum/init-sysctl: 2d34dfc0d6f62425d4986af17378070746faf452e787b505fae9a1c65f6e314b
+        checksum/plugins: e86c08d2b3b3d93f40f98065704b8823ad2754b4ae2c1c61c44eb52a9694743a
+        checksum/secret: ac82d528c267327b7a4ca25e131f605dfedbf0d2ab5dcf0f6eaa17a3255b3211
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -855,7 +855,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -871,7 +871,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ingress-with-controller.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -890,7 +890,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -907,7 +907,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -1028,7 +1028,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1228,14 +1228,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -201,7 +201,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -383,7 +383,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -391,7 +391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -403,10 +403,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2221225bb14dbdbe0b6892a0f53831250489192331490137921401df15d2e122
-        checksum/init-sysctl: b0178cf305d7a98e1960768eb10d400a4ee1be2b1b8e27abd8e3c5b79a8db808
-        checksum/plugins: 463c5e8eed15745a506b8bedc69bb4ab99eda3413a505af7163a550bfa74eec5
-        checksum/secret: 9cf59b6564450e5e41ec1661e6b747eda480643acf01188e55cbe59feeeec409
+        checksum/config: 8c4cfccad0182b4c2b9209148f683c3975a02d9b2c02e6c63866bf3bd3f530ca
+        checksum/init-sysctl: 30b261a1055e23363145d54000097f950d2e9e6b389b308b02a05f2aba6a2a3f
+        checksum/plugins: fdbc54407a920ebf69d442a0f4b145a5397dbdc4986d40f7df17409d6fbc18c8
+        checksum/secret: 97304abe8c7e0ae061fe114482b6b572eb4ad23d8a15c0d6c1057fefdfe1a894
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -416,7 +416,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/install-plugins-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -450,7 +450,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -494,7 +494,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -511,7 +511,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -624,14 +624,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3d4d676b260a65b744522c2d2886ebe785e49d38150b6a7eb8fd9fdbc6b5cc7b
-        checksum/init-sysctl: 89416c517ab84ff281b54b79032c62d790a7e7112ea8cda574011a70c3d76612
-        checksum/plugins: 91d8dc9e5059d13cefcffea2a2a89fd15727e9f964a68e9780251a93925fa8f6
-        checksum/secret: 1d64a1c43d1a00b231add619be1a8c536091f7da81a238f1fa9cbd6b29815b60
+        checksum/config: cb6e296cdd86b6df9fb6ba1d6845d11715262d607480c69ada0a5c4f8f3e11c1
+        checksum/init-sysctl: 5bc956eaa7e43a33b77a2370f45d8ef7db2901fceea10a433f71262165e64857
+        checksum/plugins: b562e4397db48fd1414ada2f1463c2b07c49567aa3cfc5c9efdb0b7b4abc53a2
+        checksum/secret: 036a9b298eb290431a3c42f663b131bfec9a7fea19d1342f69d915d81c6a16e2
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/jdbc-config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -572,14 +572,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-database
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -145,7 +145,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -160,7 +160,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -252,7 +252,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -320,7 +320,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -502,7 +502,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -510,7 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -522,10 +522,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a02902fba453bcba650c374f9bef7774a440dd20e52701754ff96fd405f34f55
-        checksum/init-sysctl: cdbde2b488e28e0a7adbb743258ace306fb43bb6559c55f283285f3275e5668f
-        checksum/plugins: ee382e111b53e08245f1d3cfb1688ef23ae87bc052a2f48e6979a701768aa05b
-        checksum/secret: 037da91668a420c428dac1d11bac49533102ed81189768c4801312e1856a0ea5
+        checksum/config: 1c3fa2f3aa862b472cc9da604f4ba9e9157a3b58854c648126ed1104a7ef2501
+        checksum/init-sysctl: 6f362aab7dbeacb17a7f3f86590ed34287106f5eac3941e40320b5aeecb161cd
+        checksum/plugins: 88b61599cb689080c389156bce7717f6f1668f6d253989fc0eb93d1f408a68bc
+        checksum/secret: c6f913807f93533ca745164d47b9b33139b30cdf858238900515d7d7a38961a0
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -535,7 +535,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -551,7 +551,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/networkpolicy-new-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -587,7 +587,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -694,14 +694,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-database
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -145,7 +145,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -160,7 +160,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -252,7 +252,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -320,7 +320,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -502,7 +502,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -510,7 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -522,10 +522,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 132987ba71b6122061fe7c5443744fb4cc73533d8d7067d99614e307f2fa737a
-        checksum/init-sysctl: 904eaa0186d4988c0f6a97a6b43772b5abdf03bc361a92e6d45c89d46b936a35
-        checksum/plugins: ae36a711e413de2af7d7930eff26a6934c4990126c9fd96f25ca41d4726e6431
-        checksum/secret: 7cbbf98c779bc77e1e3ea07bf7e687760f3588bcc5b208a0f0d07e3ac8377473
+        checksum/config: 5816d5df8aaab33fa331d194449abf3b08461c4554cd1c8f1353c548f15eebd2
+        checksum/init-sysctl: 3bd6505dfc00be9285288f0717d5f621446096221ebb4dc3e915df7792557072
+        checksum/plugins: c91ff9b3f5dd06b07ef361b256e8d4a67c9629e153d72a7be438d6a6743786d3
+        checksum/secret: 7c9746d8e0dfefc3e554b5495fb5d561596d3a0c4ffa1a5d71aefae3ff19d208
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -535,7 +535,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -551,7 +551,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/networkpolicy-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -587,7 +587,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -694,14 +694,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -245,7 +245,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -427,7 +427,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -435,7 +435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -447,12 +447,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d70c99bfb2c2e17451bb9160ca2c2afcba8ef57d1edf57d01275f72779425bab
-        checksum/init-sysctl: d233242a67d970cfdbe3d36890a65c6b936bcd349d92656a9aa8034b7fe44f98
-        checksum/plugins: 41c6b2bdd61d031942345623a6b93e016a46d75e18fd507880941f3b84e8ac64
-        checksum/secret: 8e2880758f8e9dbc2db674c3777eab2ec435c9395525b8b4ccf0a878b70662a6
-        checksum/prometheus-config: adacccc77ae1887b208e18e98d39bcf58f5b9597b2bae7ff086806f1755e92b5
-        checksum/prometheus-ce-config: 9a8cf0c8f89e6bdcd1f0d64dbf7e0a9825a8e7ef6ec48470584a646fd0eda993
+        checksum/config: fff84f2078ed51de25d7aad2787177d399e5305e86f4bdc8e9c52fd1e559ba35
+        checksum/init-sysctl: ef6126f95def5a5e95681c43fab7de94752fc8eb45886ecddd9609a73de1a870
+        checksum/plugins: efada5d8273c5eb5729a8afd81b75534b0d7eb59e22975472115648bb114eefb
+        checksum/secret: 7b296aaec05b587b9353ae3778beef5399a8d08593b68ec8cf973b8e8a3266fd
+        checksum/prometheus-config: 35df64569ed355181f5ca880acb955c3d069af73a9a342b5f931af000decb89c
+        checksum/prometheus-ce-config: 7e3449bb618a013d1fb9dba085ef6e17b6bb4e68a040264cc78c5e0f4fb0c91e
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -462,7 +462,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -478,7 +478,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/non-default-security-context-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -496,7 +496,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -538,7 +538,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -582,7 +582,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -605,7 +605,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -736,14 +736,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -773,7 +773,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -786,7 +786,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.1.7
+        chart: sonarqube-2025.1.8
         release: non-default-security-context-values.yaml
         heritage: Helm
     spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -83,7 +83,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -151,7 +151,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -333,7 +333,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -353,9 +353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ed78765164608871e8f6aadd37e09d39fb4abd549e20df277066aba5c679be5d
-        checksum/plugins: 50504b4b76db409f94c7a0232968b2cfaa29cf6e37afe34c889b7d8debbed128
-        checksum/secret: c7d1f6d4215251bac7def2385d13cd94185184ae5af5e5727c231e9ce3a273d2
+        checksum/config: 4eb0edce357e6e25af8bce0596d59f69f0df3038e1c82b36a7ebfc074994cb51
+        checksum/plugins: 0aba523ea40a4c3b1e557327fb20c2ecea4c5024edbbfccb8535fc047af5957c
+        checksum/secret: 04c8b0eb5f2d9aa1f70b64d0e3d61506b15d41b271fdd38cad9d4fd568b44134
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -365,7 +365,7 @@ spec:
         {}
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -380,7 +380,7 @@ spec:
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/openshift-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -397,7 +397,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_JDBC_PASSWORD
@@ -496,7 +496,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -520,14 +520,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: openshift-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ea7c5e248124aa8597f3493500a2339907da7fba6dc87c2279fd6f83bc0f17e4
-        checksum/init-sysctl: 0129cdb226df79ccb4229d7e68d5bb68c57062a50af26827e73bc4100861effd
-        checksum/plugins: afe0a4d7ca70d0a3ff49348d5662c309624b36aec8cc8b81a8428ab801d112a5
-        checksum/secret: be960570c647dc0a287033157268e749a51c3f90b77dedfc0f9a1a1bb6316169
+        checksum/config: 79bcd9941cf9ee140a1b52b4ba186348d0bc2a4856098f5dd90d61988664ee7d
+        checksum/init-sysctl: 650c0cff7cf11beb39b2a82d9a5d61f63d992f4f18e3c4e12e93f5b1ec3cc26a
+        checksum/plugins: 0ddb9e3363094d473e0b4886e2abc055e001d8e099caf1edce06c485e53a7e91
+        checksum/secret: 4cd7fdab720b42dc30badd834a94fc2fcb9ff6218a9748ddef7e36447df31daf
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/prometheus-monitoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -599,14 +599,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -201,7 +201,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -383,7 +383,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -391,7 +391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -403,10 +403,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 38ed4ef4aea15a0a4075d1c031b4bbf108877563f80f5803866b28461ba16bf0
-        checksum/init-sysctl: 4548c35daab93cc20ec5157fed420486e0c17e55832fb78048f6ba5f26451096
-        checksum/plugins: dcf4b2a247f4cb16a6be4341c6dfaf5b0a13905c09ce874180ffd54c60baaf1c
-        checksum/secret: 1996832c3ed2198a2974ecc91a726c0a1e4e4825474cd9e4604824fe6650bfe3
+        checksum/config: 1c6070f5d34ffe68a2fb231087112391987a75f76863bfceccf8711d516d41d1
+        checksum/init-sysctl: 6588a7e23e0ce271e4f82b62063893b665ba7e538413862cd077a98e0abcb4b7
+        checksum/plugins: 3c5e426e53333b0e3848049835538a942c033142bd77e5b6073d660bdf624511
+        checksum/secret: b3c4de91d0d08189610d77f5ca29dd9122d0551437723f8d57b64d853287a835
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -416,7 +416,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-secret-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -450,7 +450,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -494,7 +494,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -511,7 +511,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -624,14 +624,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -231,7 +231,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -421,7 +421,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -433,12 +433,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f7aa1e48fba78fb0945640b94cdcdccc5864e5b84a10db7f62d93be0b34cceb1
-        checksum/init-sysctl: 4054c6501f6b7cc2e6377a9a6715dead955c9d66741d835945ffa1e32a88d64f
-        checksum/plugins: 9a5655dd5345a4c74a3f772ca6eb58c35dad2578112939905b3f720b5d468c91
-        checksum/secret: 3fc87f82c0979fb259a9099929ff5e3ca2ee02ff8dc61863a6fecbcb0ddd8b0b
-        checksum/prometheus-config: db2ab994df62374ef284eeb9069552bf28993c7241b25fde03b4bc728dcaf3bb
-        checksum/prometheus-ce-config: e643c0959cb92035a436931aa05d7a62fca64caadf40edbcfa488e6c3e541766
+        checksum/config: c9068535cf1cb268c5f9c9ff34a04b3fb05badb1d614adc4792955c1147cbe97
+        checksum/init-sysctl: 622967a2c4e4edbc5bc2d3df7f0b42f65feaed368caa5e65fdca6c017e10ab44
+        checksum/plugins: 9b55c4766b68342f8b3e4aaed7228ed4475653922d2fb5f8c1ee924deddb918a
+        checksum/secret: bb6395ccbd151a87562a988ed44b86888085103a1a82ccb4f9f61a91638024b6
+        checksum/prometheus-config: 07008919f1a4ba2ca2db220dcdf4699a5a355ba0ebc2a9dd1d8a3815e3fd8ec2
+        checksum/prometheus-ce-config: 01ab2515eccdbee57b1e91ce46277d13b26b6052f6678d115c2e69a9fee6a1a1
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -448,7 +448,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -464,7 +464,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -482,7 +482,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -524,7 +524,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -568,7 +568,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -591,7 +591,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -722,14 +722,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -233,7 +233,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -415,7 +415,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -423,7 +423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -435,11 +435,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6260824edd236ba925e75b6cfd3e19fbefee4ad0d44b7d3c5fbf1e901e671ff9
-        checksum/init-fs: eeb450f1be522ed299dee6760f61f73e0b2d2d2644850e0b3bd3f25d05d6be59
-        checksum/init-sysctl: 707505e1ae84098c5081b31f6f0723f49fda476f1e21822fcc1de7d8cf97744d
-        checksum/plugins: 63d2ef3a786d6385590e74ed6c115ddbadf3a77f5f4aacf2b3856c79fddfe02d
-        checksum/secret: 39f14ebf04e013656f92ee2ae6f0ca465bcd5c81ee084168c47be6ac138e51dc
+        checksum/config: ed728101579928f878f7ca8455ae6dcbf587378700235f7ff3cbddd6ea5f340a
+        checksum/init-fs: bb0af85b6499de05c92a73ed88429d01bd0a8eefc2f516331410f346006c6b6e
+        checksum/init-sysctl: e1f56c735156bab73337d8ef6c2964f05edbbf64bd83ac80b50f8332d66a9dfc
+        checksum/plugins: 02a1df20af94053b283b583c8314b46842417f6eeb226bae2f46af4b619e0d99
+        checksum/secret: c4745f39e028ba7a92ff638725863610be649ff37a1365a59395233684b185e2
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -449,7 +449,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -465,7 +465,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/pvc-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -483,7 +483,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -518,7 +518,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -535,7 +535,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -648,14 +648,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -34,7 +34,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -49,7 +49,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -81,7 +81,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: secret-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -155,7 +155,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -176,7 +176,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -196,10 +196,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 36f18280eefa2a59d20d9d8af174c5a190a709ce5beb89e4901298e29e9a0e6d
-        checksum/init-sysctl: 02c81793eb98c687ebdfebd9169a40c4ff80ca16c626e8de69695fe2ae0222f6
-        checksum/plugins: c2a49dee937554943afa3cd398059f09b43f7a52997e7e038740380601766f31
-        checksum/secret: e48ace6913b5b726938e533c30d0cdd7593a66a16b44794e4cb8a67bb6a36555
+        checksum/config: 9321a856fa726e2078155bf3dbb518683f2bcfc72a1dc393a9dd1a309e572a40
+        checksum/init-sysctl: 7f5df7d2879028076d75389f504d658ebcf1656d00842f3494e029135bf06e0a
+        checksum/plugins: 71ee922f1d383c7013742f422040a6dcee4e4a1c67daf642ff3ffa50bd0ec7f0
+        checksum/secret: e51ad87e368af1e28f744492e2e04bd8369efde22545721306c9647415ae20f9
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -209,7 +209,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -228,7 +228,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -245,7 +245,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -352,14 +352,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -389,7 +389,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -402,7 +402,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.1.7
+        chart: sonarqube-2025.1.8
         release: secret-values.yaml
         heritage: Helm
     spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: service-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -387,7 +387,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -395,7 +395,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -407,10 +407,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb6b0e69efcef2480ccd1b91cffb0f3f0c105ece548635daeab05b859a6a3c81
-        checksum/init-sysctl: 973413f513edd9a192d0686b9d759fcd8b457a37945543de0cc044d1f6ae7d31
-        checksum/plugins: ff024077918ef8ca7b21d8eb9df85ec5d16052f1fd003f26019cdb066a4fe2c9
-        checksum/secret: 4a797c88a21104ce9c78ec5149238cb93ac630118b148b119a95e74ba8fa0e6d
+        checksum/config: 935597777eeb909b6cfe11ca29af8d54bafeae5d8293d0cc3e61c7214c1d7bd6
+        checksum/init-sysctl: 23cc64f1af672a93ecd13f87001f9a33a9973b7b419ced6b592625ff2deb7fb5
+        checksum/plugins: 955c3f27a83948c6c5d738109f296debcd99ede4df6fface69a007ef4e3a4610
+        checksum/secret: 8d4dec1a774c1cee561e429c4a1128af154953fa920ae791c7603e2b21fe7371
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -420,7 +420,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -436,7 +436,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/service-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -455,7 +455,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -472,7 +472,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -579,14 +579,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -37,7 +37,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 417171ae833296babe2c84564f87eaf8beef6597b609995da9f4648c1639ed6d
-        checksum/init-sysctl: 34ba605a8a4c5e018aa5de0428dfdba64d3d68b07e5c80ee2675fc97360144cc
-        checksum/plugins: f62c142ca9f74302c9b4b4b0ca0aad691faa5c04b672790a60b1280df9c8deef
-        checksum/secret: be28d480d7eb70c21f2f3c98f3548fec839b5bcde85369625f87d15002095a14
+        checksum/config: 97998a2965f90ea0f279c2fde804b06c5efeb296ee430ec012bbf48e5f6d0abe
+        checksum/init-sysctl: 2415f67d37ba0503de24f41794f2fea164e85656df94c569ad2e94a960593208
+        checksum/plugins: 4e09f6b39fda938a710a23a3d7c82c2921b60de78627707412e5b6938264af93
+        checksum/secret: 00dc1dc7c63190daab9259d38b411263d199a4cbb409f7b630531f83b1483414
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/serviceaccount-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -586,14 +586,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -241,7 +241,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -254,10 +254,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 087aa7aab8b59e3373156d82171e318dc93e7d4107fefc6c96202fdc4ffcd536
-        checksum/init-sysctl: 58e50273ab865a8b4eae993fe54527940b577ab8c72ecbd3f969e32d6612d8cf
-        checksum/plugins: c5a3fd877453a5060dc829a518e51cfad49f6d6c1ae578b7bae85efae1ee1be7
-        checksum/secret: 1f81760c6ed1d2edf482241cb006c4b41d54d862a20f2b430061c9b9b4c6952a
+        checksum/config: c008455f5612892ee4fe2a9ccc6ab60564505a3a7a02ddfbcb75a483e3667abf
+        checksum/init-sysctl: 6ac3ae296c6abd88911ec5bc894924f2838576a9312fc677e40da28c403e2161
+        checksum/plugins: 80f76045b942de1776c095da9fd529a4837cb8399b642b6f67d338d7a3548532
+        checksum/secret: 8e1b39519ad4892e0f0611de55467721ff4c551ecd36aedd7777bec1479a2482
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -267,7 +267,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -283,7 +283,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-deployment-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -302,7 +302,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -319,7 +319,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -585,7 +585,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -610,14 +610,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -647,7 +647,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -659,7 +659,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.1.7
+        chart: sonarqube-2025.1.8
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
     spec:
@@ -667,7 +667,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.1.7-enterprise
+        image: sonarqube:2025.1.8-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a5086e58d13ef8a03ce5d8c498a55173dc871fb4a23d1357a75e5fa4a824b95a
-        checksum/init-sysctl: f75b0ca83225a149b4cb7829bf98b38dad7101828f0d9b343c487e876fcebe6d
-        checksum/plugins: 3433ef0b65399153f6c207fa91ce5732f8324dbb6917a5e63a79d78d805fc505
-        checksum/secret: 8b8cddb1593df49f9529cc947bc3837b581e7ceea42438c099bd53e9d96bffaf
+        checksum/config: e85103f9b262d1a15e66ea7cedbfd35e90c29b9632769453f9262b2fe1de2f5d
+        checksum/init-sysctl: 4ac5254a7d3336dbdbc4cc46fd0498fcb9a87d25110dee4920b21807b5025823
+        checksum/plugins: a1b23628e3f7347ad92851ed71e3a5f3369791efc73e47a64347cfe4b21b4b43
+        checksum/secret: eda1cbd61b6ebbf70e71c23dc4f25f4209cfde4fce4187b2bb559d7d2af052ab
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-sts-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -584,7 +584,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -609,14 +609,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -646,7 +646,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -658,7 +658,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.1.7
+        chart: sonarqube-2025.1.8
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
     spec:
@@ -666,7 +666,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.1.7-enterprise
+        image: sonarqube:2025.1.8-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 90cda44ee9adeea468283de3eeb7ce5c82a1db88d92409763bcdecd0f7d94b99
-        checksum/init-sysctl: 0419f0c399a416283e666e363b400b61556ed2e9d1280ade303aac2b11b8ff44
-        checksum/plugins: f5ec03e43a62e5567c696d1baaffc719323568a3e0bc0be0c1e82e58212bb593
-        checksum/secret: 1dcf5598a40a86a169b6243338a1bcb78fc3136d5e8150e406975e5ea1b27f52
+        checksum/config: 78ae8e126aab28468b103d9dd1fa0bd7d8b209b2c8dd4598dbb720b1e5990d82
+        checksum/init-sysctl: 66e44d200c6ef688c38fe47078aa2de8e0c7a61f7cdb4d113bf1f9515dc013a8
+        checksum/plugins: 0cbeaa2da12aa5fdacd4f3c017f69a6b781ca4228568dae79a70b4f84b438c33
+        checksum/secret: 0bfa08e5ecc9269cdb18ded742cedaa0fea17422c9d72bc191f2ad589a5aace4
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -584,7 +584,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -609,14 +609,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -646,7 +646,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -658,7 +658,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.1.7
+        chart: sonarqube-2025.1.8
         release: sonar-web-context-values.yaml
         heritage: Helm
     spec:
@@ -666,7 +666,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.1.7-enterprise
+        image: sonarqube:2025.1.8-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -231,7 +231,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -421,7 +421,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.1.7-enterprise"
+    app.kubernetes.io/version: "2025.1.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -433,11 +433,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 25fd68c0dc686db873fe18a4ce0e3be96a47de9443fc24001864ef9e23cbac10
-        checksum/init-fs: 7c267ffa8aa16ac9d00ef94a2924611523bc44d2d68ea5d31340cfae8750868a
-        checksum/init-sysctl: 8ea7c35631923179e81b6503c555369373e5c99ab8a8b11c8b6545e92dbacbda
-        checksum/plugins: 5c67eaf4931ef1d23d462f70f5eeb60869e3000ac0a72ed4ee5b57a794a219ee
-        checksum/secret: 9263f15ce868d80b926a5c223b1e97778c70e15b2086cc067c00500fc80bb599
+        checksum/config: f17b887f76123cca824b0ac744afcdb343e2b3d909b72c9e19f712a7f7621137
+        checksum/init-fs: 11679c373507c2780365d36c6669051f6f98b74e869b4b13066a8f95088ff503
+        checksum/init-sysctl: 5800aaf3518d3300e679bbc9b44a70712427e8b37fa319c96a9efc4a67388d16
+        checksum/plugins: 6e6edb2bc8d7b29d6cefd4073ec57800f62f0dc5f7526cd772dbfa5ba1f223ab
+        checksum/secret: 456ea6d21e6d1f5882a77f7ce86c21a182cd4ac47b04e3db239443a9f48662c0
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -448,7 +448,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -468,7 +468,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/template-refactoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -490,7 +490,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -529,7 +529,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2025.1.7-enterprise
+          image: sonarqube:2025.1.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -546,7 +546,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.1.7
+              value: 2025.1.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -659,14 +659,14 @@ metadata:
     "helm.sh/hook": test-success
   labels:
     app: sonarqube
-    chart: sonarqube-2025.1.7
+    chart: sonarqube-2025.1.8
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2025.1.7-enterprise"
+      image: "sonarqube:2025.1.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -131,7 +131,7 @@ func TestShouldUseImageTag(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2025.1.7-enterprise"
+	expectedContainerImage := "sonarqube:2025.1.8-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -188,7 +188,7 @@ func TestCiCirrusValues(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarsource/sonarqube:2025.1.7-master-enterprise"
+	expectedContainerImage := "sonarsource/sonarqube:2025.1.8-master-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -203,7 +203,7 @@ func TestCiOpenshiftVerifierValues(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarsource/sonarqube:2025.1.7-master-enterprise"
+	expectedContainerImage := "sonarsource/sonarqube:2025.1.8-master-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -217,7 +217,7 @@ func TestDeveloperEdition(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2025.1.7-developer"
+	expectedContainerImage := "sonarqube:2025.1.8-developer"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2025.1.7-enterprise
+  tag: 2025.1.8-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
  - Upgraded SonarQube Server and Chart versions to `2025.1.8` across all charts and documentation.
- **Configuration updates:**
  - Updated image tags to `2025.1.8` in `values.yaml`, `ci-values.yaml`, and OpenShift verifier files.
  - Updated `GCLOUD_TAG` in `.github/workflows/gcp-marketplace.yml` and deployment scripts.
- **Testing:**
  - Updated `schema_test.go` and associated test-case values to reflect the new `2025.1.8` image versions.

<sub>This will update automatically on new commits.</sub>