### PR TITLE
REL-4629 Release SQS 2025.4.7

### DIFF
--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2025.4.6 # Update this value to the desired version
+  GCLOUD_TAG: 2025.4.7 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.4.7]
+* Update Chart's version to 2025.4.7
+* Upgrade SonarQube Server to 2025.4.7
+
 ## [2025.4.6]
 * Update Chart's version to 2025.4.6
 * Upgrade SonarQube Server to 2025.4.6

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.4.6
-appVersion: 2025.4.6
+version: 2025.4.7
+appVersion: 2025.4.7
 keywords:
   - coverage
   - security
@@ -34,9 +34,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 2025.4.6"
+      description: "Update Chart's version to 2025.4.7"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2025.4.6"
+      description: "Upgrade SonarQube Server to 2025.4.7"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/
@@ -45,9 +45,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2025.4.6-datacenter-app
+      image: sonarqube:2025.4.7-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2025.4.6-datacenter-search
+      image: sonarqube:2025.4.7-datacenter-search
   charts.openshift.io/name: sonarqube-dce
 dependencies:
   - name: postgresql

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2025.4.6`
+Compatible SonarQube Version: `2025.4.7`
 
 Supported Kubernetes Versions: From `1.30` to `1.33`
 Supported Openshift Versions: From `4.11` to `4.17`
@@ -314,7 +314,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2025.4.6-datacenter-search`                                             |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2025.4.7-datacenter-search`                                             |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -370,7 +370,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2025.4.6-datacenter-app`                                                |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2025.4.7-datacenter-app`                                                |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/cirrus-values.yaml
+++ b/charts/sonarqube-dce/ci/cirrus-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 3
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.6-master-datacenter-search"
+    tag: "2025.4.7-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.6-master-datacenter-app"
+    tag: "2025.4.7-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
   webPort: 4023

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -13,7 +13,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.6-master-datacenter-search"
+    tag: "2025.4.7-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -22,7 +22,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.6-master-datacenter-app"
+    tag: "2025.4.7-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
 

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2025.4.6-datacenter-search
+    tag: 2025.4.7-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -153,7 +153,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2025.4.6-datacenter-app
+    tag: 2025.4.7-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.4.7]
+* Update Chart's version to 2025.4.7
+* Upgrade SonarQube Server to 2025.4.7
+
 ## [2025.4.6]
 * Update Chart's version to 2025.4.6
 * Upgrade SonarQube Server to 2025.4.6

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.4.6
-appVersion: 2025.4.6
+version: 2025.4.7
+appVersion: 2025.4.7
 keywords:
   - coverage
   - security
@@ -39,17 +39,17 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 2025.4.6"
+      description: "Update Chart's version to 2025.4.7"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2025.4.6"
+      description: "Upgrade SonarQube Server to 2025.4.7"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community
       image: sonarqube:25.8.0.112029-community
     - name: sonarqube-developer
-      image: sonarqube:2025.4.6-developer
+      image: sonarqube:2025.4.7-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2025.4.6-enterprise
+      image: sonarqube:2025.4.7-enterprise
   charts.openshift.io/name: sonarqube
 dependencies:
   - name: postgresql

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Default Versions
 
-SonarQube Server Version: `2025.4.6`
+SonarQube Server Version: `2025.4.7`
 
 SonarQube Community Build: `25.8.0.112029`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2025.4.6
+export TAG=2025.4.7
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -361,7 +361,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-static-hazelcast-values.yaml
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -414,14 +414,14 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 00f53759629307422711ed3e2efc86ba37786d5bf34201137b4f9472dd87c0d8
-        checksum/config: 214245659b58e54cbafd601e1d3261b270f75b54c12737031d0da35d3e47d67d
-        checksum/secret: 9ee12c8482f91042c01f6e5ea34f26d477f5794086eb00ad75af5218db67352b
+        checksum/plugins: 79ebd7bbf57a187317e157cba40f13bdfe84874f485f03627495f91dced37a6b
+        checksum/config: 56610911ed0a40a5c2c7fe3e9a6fc47c74d973f75230d5c207bba83fa3476f93
+        checksum/secret: 96155e529acb32789248107bd95042bd83152789f8b72d92c13a5dd524f98f6d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -439,7 +439,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/application-static-hazelcast-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -478,7 +478,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-static-hazelcast-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -798,7 +798,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-static-hazelcast-values.yaml"
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -836,15 +836,15 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 5d58df4731ac1b3e5626e390971c4151f44220f6697993f6b9aa58b660e92bb2
-        checksum/init-fs: 530a6427408d0348003a4e9b70baf5d2454e9b28a797862f8e144e44b395e1f4
-        checksum/config: 214245659b58e54cbafd601e1d3261b270f75b54c12737031d0da35d3e47d67d
-        checksum/secret: 9ee12c8482f91042c01f6e5ea34f26d477f5794086eb00ad75af5218db67352b
+        checksum/init-sysctl: 0dc215b9d2d6ac8d217a2eca6405c14eb7d64df95b8b2ce1b6d633f4920f33d6
+        checksum/init-fs: 43542b0e18390167b8f93a8827619bdf38ff66dca64df35d9d445a5599228933
+        checksum/config: 56610911ed0a40a5c2c7fe3e9a6fc47c74d973f75230d5c207bba83fa3476f93
+        checksum/secret: 96155e529acb32789248107bd95042bd83152789f8b72d92c13a5dd524f98f6d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -859,7 +859,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -900,7 +900,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1037,14 +1037,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-static-hazelcast-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2918be6c4c53b685efbb3be880ecf1749cb8f1f806088b950d992f147f481923
-        checksum/config: 8303c9ff9c0b24885d8ff52392089c310788dc8bebb132f7b87e2a4437892e03
-        checksum/secret: 98e701e0e5cc0d0c2af9b677c4a11b16b309b578dab593d4e2b97628e809c3d2
+        checksum/plugins: d4b9236bee2184cb15f529c9c8e8e333d28612f241c90c98f18607dde10f9806
+        checksum/config: 469652c2ee476ddf1f0a11a29a258d4c5972e35c2cbdde1c4dbcf1c10158a0a0
+        checksum/secret: c4285c0564cb8a585d3cb1044bebe2c3cc25aba9eb82667a51b10ccbe33d0959
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 4b84df050d0a5638dc71efc6c4b76194b2878488a2a66d769540677427736200
-        checksum/init-fs: f81fcd10236ac8e128a2a80159f648883a1a397faf26779089362e73c391dcd7
-        checksum/config: 8303c9ff9c0b24885d8ff52392089c310788dc8bebb132f7b87e2a4437892e03
-        checksum/secret: 98e701e0e5cc0d0c2af9b677c4a11b16b309b578dab593d4e2b97628e809c3d2
+        checksum/init-sysctl: b33fc672732b2a5cffba3a4c6c5a0a546d218e382b3a1450d10486e073252d8d
+        checksum/init-fs: 916fb98fcaea457adbc6b4477efc753e06cfe892e82278ee11078f98b26e4481
+        checksum/config: 469652c2ee476ddf1f0a11a29a258d4c5972e35c2cbdde1c4dbcf1c10158a0a0
+        checksum/secret: c4285c0564cb8a585d3cb1044bebe2c3cc25aba9eb82667a51b10ccbe33d0959
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -975,7 +975,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2025.4.6-datacenter-app"
+    version: "2025.4.7-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -1029,14 +1029,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: application-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -148,7 +148,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -211,7 +211,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -314,7 +314,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -339,7 +339,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -365,7 +365,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -392,7 +392,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -418,14 +418,14 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b35cf137462d6f997793de9e6436a859ae8c27c6470153e0f9a4c2f6e44c8f75
-        checksum/config: fdd2fcb1549dcd0ff86df3634b67b1e6b320661ff1a5864a612d8168e5e911f4
-        checksum/secret: 6610b15e94ceddbfdf2a198b141d5aebafa304925dc2a760ebbf9799217b0e22
+        checksum/plugins: e81f48ea4d801009ec6137531fe05412b31a0650b31aec9956a07fca30f7302d
+        checksum/config: 130ca94b1a1ec671088402c62597bf19488e6df6a17e831f1e172db6fc61045f
+        checksum/secret: b46447c8a1578eb3f75215a655a6f4fa21a910e5032e5264177b4ef206758645
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-configmap.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -467,7 +467,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -495,7 +495,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -523,7 +523,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -820,7 +820,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -829,7 +829,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -858,15 +858,15 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 304f7afa14cae5c072ad5aca1ead963449800b46279b3424e0e6071cc273c44b
-        checksum/init-fs: ec65afc7351b87a611dcd0d900683a23ed0b3f53bef298cf8832b4add313d8ac
-        checksum/config: fdd2fcb1549dcd0ff86df3634b67b1e6b320661ff1a5864a612d8168e5e911f4
-        checksum/secret: 6610b15e94ceddbfdf2a198b141d5aebafa304925dc2a760ebbf9799217b0e22
+        checksum/init-sysctl: 411a533eb82cbc08415dbf7e73e5964c49da6dede20ec802de64a29f204bad27
+        checksum/init-fs: 6fe9767bc8524af5283e066dc4be539ed93405e6f33a4f48908b9d851e887a82
+        checksum/config: 130ca94b1a1ec671088402c62597bf19488e6df6a17e831f1e172db6fc61045f
+        checksum/secret: b46447c8a1578eb3f75215a655a6f4fa21a910e5032e5264177b4ef206758645
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -881,7 +881,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -905,7 +905,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -946,7 +946,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1088,14 +1088,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -148,7 +148,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -323,7 +323,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -349,7 +349,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -376,7 +376,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -385,7 +385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -402,14 +402,14 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5869d07a4e8c76ecfba6019e10ce0543dbe09e4c4501d545e8496b0af1cc2629
-        checksum/config: e5353c8cba910c6e386ddb3c285210b292a06c34eb0f7f8f3e782367d8227b2e
-        checksum/secret: 71830990c5f368783c1fb31947df7c921973993e3c1aa48662fb99fafe3e1a19
+        checksum/plugins: 88034d25257df5c8bea3e7e40e3a9651e330462326106388b75609d2888fbb84
+        checksum/config: 3ce3903a397af26f6e7f8799122be5e7db46b0441157ee710072013dfa51b631
+        checksum/secret: 6765d53dc2462169dc1def596af5d193631075a9aa5d5e46cb93e07c8e3f3ab2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -427,7 +427,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-secret.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -454,7 +454,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -482,7 +482,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -759,7 +759,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -768,7 +768,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -797,15 +797,15 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9b76aee509577d4937df7c285520256c4611c18a58982dd7fc1871c42444b69f
-        checksum/init-fs: e205bd6e24fbdedbea1dc63dcd8ccf8e5e2cfa710d4e6f908fdab1667f130b05
-        checksum/config: e5353c8cba910c6e386ddb3c285210b292a06c34eb0f7f8f3e782367d8227b2e
-        checksum/secret: 71830990c5f368783c1fb31947df7c921973993e3c1aa48662fb99fafe3e1a19
+        checksum/init-sysctl: 3fb8ae011b72997734723f880ed835acce5d9c21bb325f5282c1b6a7cd6a6da2
+        checksum/init-fs: 95ace96ab3eced916fe966ad6909b44c1231ef3b7222180af504043b963e81c9
+        checksum/config: 3ce3903a397af26f6e7f8799122be5e7db46b0441157ee710072013dfa51b631
+        checksum/secret: 6765d53dc2462169dc1def596af5d193631075a9aa5d5e46cb93e07c8e3f3ab2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -820,7 +820,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -844,7 +844,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -885,7 +885,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1022,14 +1022,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -289,7 +289,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -311,7 +311,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -336,7 +336,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -362,7 +362,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -389,7 +389,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -415,14 +415,14 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ccc22051d5cf924ace0d03810138cec309cdecabd8f0a577406774049e13a1c5
-        checksum/config: 615befccdb25049f2a7f790172ed5406851b491bafbb1b85ba02a0b662b10a93
-        checksum/secret: 19bd04059c4b1e33271fb0d79cffdae4cb301505d1333766f0c19089abbb2ea1
+        checksum/plugins: 33a43d7eeead083ec464b3ee56af2f6960818b012fdf9525e81d5ef93886f21a
+        checksum/config: 8cedceb8ba476c2f929f751c0d54cb48a8fa18dc15e42f8a68b142671ddbfef5
+        checksum/secret: cd08a0c20b0f1d711fe5dc89c0bde67ae211ada2e4354b9b5ef5f3387344749c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -471,7 +471,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -745,7 +745,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -754,7 +754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -783,15 +783,15 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: ffb708ff30da0e7db9c11eddcc020a81d4106284b78138c82a1d3b6f541c1e2e
-        checksum/init-fs: 510ed0c036885c81f600815362c3e0e43d937496462f0f6192aaed882f4d1096
-        checksum/config: 615befccdb25049f2a7f790172ed5406851b491bafbb1b85ba02a0b662b10a93
-        checksum/secret: 19bd04059c4b1e33271fb0d79cffdae4cb301505d1333766f0c19089abbb2ea1
+        checksum/init-sysctl: 99884dfc3326ea044680eb777947a51fe7b1ea1f7f2fa4cb4d00c70c51b370fa
+        checksum/init-fs: e7ef1eeadae2a1cdf26488029cf4687c20df083d58777aa70295a9f85841922a
+        checksum/config: 8cedceb8ba476c2f929f751c0d54cb48a8fa18dc15e42f8a68b142671ddbfef5
+        checksum/secret: cd08a0c20b0f1d711fe5dc89c0bde67ae211ada2e4354b9b5ef5f3387344749c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -806,7 +806,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -847,7 +847,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -984,14 +984,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1023,7 +1023,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.6"
+    helm.sh/chart: "sonarqube-dce-2025.4.7"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -281,7 +281,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 
@@ -303,7 +303,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 
@@ -328,7 +328,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 
@@ -354,7 +354,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 
@@ -381,7 +381,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -407,14 +407,14 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f2b72785970e9425d54a88fdb9f93c2c1f674286af825d4afc5c17ea5462f6ce
-        checksum/config: aab3226572d2c46e769f2fa9bbd7ce9c3d5e72a3e18a1466e5f17aa1bba8821f
-        checksum/secret: 6c20945828d1c8e4800d0e6e38f8e449657cefbd228957d1e52a9686f30615b4
+        checksum/plugins: 81e32c6b7ddded1e8b0b763da139baf2281c094bb7de29ce7ab173b4cb6b23d4
+        checksum/config: 311cc7fed06976196a68558610cba2063057e5e322cdf22c5856761a579c75ef
+        checksum/secret: 6455d22ab91a87db3b74688480db2a71dbf41eccf64a994dd00089de61717512
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -471,7 +471,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -499,7 +499,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -798,7 +798,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -836,15 +836,15 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f69aa16f3ebb1668711f2c7047d1956c76968cfbc3695b9d299a285d4f512ab0
-        checksum/init-fs: f4a567fb81d64adbd040177f680b103194e9c8f5a5390f520bb8b8fb2256e0e5
-        checksum/config: aab3226572d2c46e769f2fa9bbd7ce9c3d5e72a3e18a1466e5f17aa1bba8821f
-        checksum/secret: 6c20945828d1c8e4800d0e6e38f8e449657cefbd228957d1e52a9686f30615b4
+        checksum/init-sysctl: b4915a51da32207c8b583375eedde7290a9624a2775fe61aa7bcafb269915734
+        checksum/init-fs: 1935120495ac375c4fb4e23a637827aee0f5bb62e891582f0a8d919efc728311
+        checksum/config: 311cc7fed06976196a68558610cba2063057e5e322cdf22c5856761a579c75ef
+        checksum/secret: 6455d22ab91a87db3b74688480db2a71dbf41eccf64a994dd00089de61717512
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -859,7 +859,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -895,7 +895,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -936,7 +936,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1094,14 +1094,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -401,9 +401,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 912086ad74bbbf47770a8835b7260090b1c9e65ee6924cd5a52e3e94f983c585
-        checksum/config: 0a432efa48f58af84180d12a536cf22a2bb64f004d11fbdc59abf5062928458c
-        checksum/secret: 3fbbbc9fda8881687f7ca34337e39a221391857755811932d31e46c75c99eec5
+        checksum/plugins: 263d2f13dd366a22f32385a8f840b1f9fd89da4796fa12d82745534de6c204b4
+        checksum/config: 50cc7ef8ea3348a6676357bfb11595c711a286b7f858bd6e693f1bcb3fddd99a
+        checksum/secret: 7a89ddde3ac52bba7ac690f39e23db2437814857736a355694ddeb8b662cd7a1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -769,10 +769,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 46b6c2bd58aed61306e4202f67fa0e3d0dff0be6bcdad37b0275396684615afe
-        checksum/init-fs: 3e1ec1f71dc7a59833dfbca2d1f7fde5cf0523845068b1182d5f076af821d86c
-        checksum/config: 0a432efa48f58af84180d12a536cf22a2bb64f004d11fbdc59abf5062928458c
-        checksum/secret: 3fbbbc9fda8881687f7ca34337e39a221391857755811932d31e46c75c99eec5
+        checksum/init-sysctl: dee064597f4505f3111ba0a61be4d1db61b15421aa061fcc6c589258b4f75bd3
+        checksum/init-fs: 833d9da4c8ce2d568417695005cb3d88ed7f29beeb1b45bf5d631af7df67e83d
+        checksum/config: 50cc7ef8ea3348a6676357bfb11595c711a286b7f858bd6e693f1bcb3fddd99a
+        checksum/secret: 7a89ddde3ac52bba7ac690f39e23db2437814857736a355694ddeb8b662cd7a1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -970,7 +970,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6b9b1b21a38d680290f14363defbe3e16ac2fb85026bb250e869020e590ce71b
-        checksum/config: 434ae34bd9a4aaa90a12fb352829ced32cdb1c1a2b3bf565e4df3071f1bfdfe6
-        checksum/secret: 0ac90c20694b1c023c1fcdabd9e73ce3f30f09158901eb1637194ab969d4607e
+        checksum/plugins: 1095e5c0abc879c3c796c61fff001980b18edf4dd95fdb2ca6bf3e695a1789ed
+        checksum/config: 3590ff241589d9d32888bd5e476beaa345c368575136676dcdb238a2a51153ab
+        checksum/secret: 58076bc557bf33099590c1fbb3906bb6ac791ace5ccebe48ab225a1b4f64b807
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d004b098fc02246b0b4c2c18e69a3c927e7d43894e8c2271ff04cdaa22c3bbe2
-        checksum/init-fs: 010cfaa508db24e17615ed2e34d2091a6e440b15fcf14fee10f6c52ecc4f1f69
-        checksum/config: 434ae34bd9a4aaa90a12fb352829ced32cdb1c1a2b3bf565e4df3071f1bfdfe6
-        checksum/secret: 0ac90c20694b1c023c1fcdabd9e73ce3f30f09158901eb1637194ab969d4607e
+        checksum/init-sysctl: 2d76b7bb982356b24289cdec81edd6d33f750b585fe82779962f22451af91370
+        checksum/init-fs: 1badacb250c55614ed6dec43094f2d538016d1798d1d72ea8f40d7be78360987
+        checksum/config: 3590ff241589d9d32888bd5e476beaa345c368575136676dcdb238a2a51153ab
+        checksum/secret: 58076bc557bf33099590c1fbb3906bb6ac791ace5ccebe48ab225a1b4f64b807
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -970,14 +970,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 427ba56b8e745beffb45e6e469aed783761809bd8068a7edee3888b39647dfad
-        checksum/config: 806c9c57b9f16bbc8d269bb2c232028b8c722b62abce6828bd11b659e6ab9004
-        checksum/secret: 62f3b1ede0b44a03f4e00dc5ebf8f575f4e25236cdb043524e13ba4acd4cdb2d
+        checksum/plugins: 75f64d741763f7c6e6cd1da2a377ee7124af937a5ade08aeecebe5b738084a58
+        checksum/config: 5761d4af3b8a31bc2f3609e9d51948bc2f552f83eabcf13762b8c754a02010a7
+        checksum/secret: 4dfeac8693d716e39b8eca510c1efd48f77d581100cd43e6c21b8de39b75d79a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: bbd68c7a6302680d0558d4f38b62e0f588690325690bbbf490dcd2ccab97ee91
-        checksum/init-fs: a66f1daf3cc64e73477677fed311ff974328febcf9793b49e2b778facbd76dec
-        checksum/config: 806c9c57b9f16bbc8d269bb2c232028b8c722b62abce6828bd11b659e6ab9004
-        checksum/secret: 62f3b1ede0b44a03f4e00dc5ebf8f575f4e25236cdb043524e13ba4acd4cdb2d
+        checksum/init-sysctl: 5b8397b72d99a2cd1f521738d139f635b64f2cbc63ce2de00fb70403e98631d1
+        checksum/init-fs: 459a20cae2f9032a7193380728d66d80189fa55971da4a128906d3e4393d4879
+        checksum/config: 5761d4af3b8a31bc2f3609e9d51948bc2f552f83eabcf13762b8c754a02010a7
+        checksum/secret: 4dfeac8693d716e39b8eca510c1efd48f77d581100cd43e6c21b8de39b75d79a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -970,14 +970,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: deprecation-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 37ea4c0b6584431cf4eb76a43fb6f9ed064c4b18c7c5a6bf7a7f180b6cccbbe4
-        checksum/config: fff39f4119dbcd6d36c4e83c36d0b73f588cfd52b9370d6db01715688d221dd6
-        checksum/secret: a18d45c66d2f23677305c5837f6f18d4ad148a4a04c74039dd53aee229cdc3f7
+        checksum/plugins: b433cded2e82274a7e1c64fdce0ec4b144dceca384a7ffeb30130183e6981eb2
+        checksum/config: 6bdc3cc934821b136c2e45fef7ee3c5336c7c218b2b32c57a5b2a260beadbef1
+        checksum/secret: df21eb2db994cbc26b35020892d98028d2df23705cb9348a1108b1d885c8ba4c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -462,7 +462,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -736,7 +736,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -745,7 +745,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -774,15 +774,15 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: de73c52f9475867932e0e95c1332a69e45478ea8d3b16a66266fd47545e475e3
-        checksum/init-fs: 85659b762c2e100fcba92107436071042b1024ddf9682ce6631bcd486b99503a
-        checksum/config: fff39f4119dbcd6d36c4e83c36d0b73f588cfd52b9370d6db01715688d221dd6
-        checksum/secret: a18d45c66d2f23677305c5837f6f18d4ad148a4a04c74039dd53aee229cdc3f7
+        checksum/init-sysctl: 2379342f5e60184a3eca108e168f848a4540890186304ce2db515661e2bae9cb
+        checksum/init-fs: 2fa224cbdc26f0bd966666edcb3e21bd78f84fd264fa2e24ac6bfe254670ff05
+        checksum/config: 6bdc3cc934821b136c2e45fef7ee3c5336c7c218b2b32c57a5b2a260beadbef1
+        checksum/secret: df21eb2db994cbc26b35020892d98028d2df23705cb9348a1108b1d885c8ba4c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -797,7 +797,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -838,7 +838,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -975,14 +975,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 70740447442154022453b8baa31c0ee6b1c92c0619e76c08d78315e0484447f9
-        checksum/config: f5c835ba99a070f4f6af7d54f15f8ea90ad6f1e4a31afb21e955b34223519f2c
-        checksum/secret: 85880d3160ff6533f86b10f01ac504562cf1eb10a5a705c1fc00e2f38f7f4b95
+        checksum/plugins: d496119da1e38d90993d9858252f557f2acffd7432f4432f43e312ed023588ef
+        checksum/config: faa43ef7f9f2647b0b22a6797c241044c0e17745f29f7ab2a7109198ecd4061e
+        checksum/secret: 874efe07909b05631c7beb1bd3cbd7ad03f95e45fe339f26dbf06717351988b1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -735,7 +735,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -744,7 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -773,15 +773,15 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 5465376ef33909a8984b6060e6387c207885512c1e777b7c01c6bd3477eb6873
-        checksum/init-fs: 9640d334eb7af9fefc42ad5608ca9e1064a321816248cc1cb36fd12c3d174c0f
-        checksum/config: f5c835ba99a070f4f6af7d54f15f8ea90ad6f1e4a31afb21e955b34223519f2c
-        checksum/secret: 85880d3160ff6533f86b10f01ac504562cf1eb10a5a705c1fc00e2f38f7f4b95
+        checksum/init-sysctl: d806baa4e4897185225a44ff13ede9a5acf3a5645dc24398d594029084c69b7a
+        checksum/init-fs: 65e83b3c5475ec09ffdca01218b5abcb43f22ea58efabfd494007039f1211f72
+        checksum/config: faa43ef7f9f2647b0b22a6797c241044c0e17745f29f7ab2a7109198ecd4061e
+        checksum/secret: 874efe07909b05631c7beb1bd3cbd7ad03f95e45fe339f26dbf06717351988b1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -796,7 +796,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -837,7 +837,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -979,14 +979,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -400,14 +400,14 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: dfc7e46b206eff4a5abdbbe419a873fc42d8d1f77868c0f96cd6b7825a21f422
-        checksum/config: c883fb8392d8589ea21d514a0fb4a10b3286419eb430f0ef6f3abd8b7b7e19a0
-        checksum/secret: 5a265d175f25bd677da337000b8800f5c3fb3e86bfe125f6b3cec8c0b09300c1
+        checksum/plugins: abb81f5d54a5398a9f8c9d891c9a5b9e6a3e405609d84dcb837f831e0d98dd82
+        checksum/config: 0f56ec09b40005688974debf695a4c5b0775a42c10f7f921d3ea7a78ebd11254
+        checksum/secret: b670aa63c9bda79684bd5b37dc6bc13da54b1f9d09743aa2604841a2c260e2de
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -765,7 +765,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -774,7 +774,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -803,15 +803,15 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9ef24055db389c012a4db9c6727e8ab8978068f3ecd9162d900495cfa55ab8d3
-        checksum/init-fs: adce2a2cabb989436d528d27a8971224a485f43fa44a1c462d85d47c7aa79a0b
-        checksum/config: c883fb8392d8589ea21d514a0fb4a10b3286419eb430f0ef6f3abd8b7b7e19a0
-        checksum/secret: 5a265d175f25bd677da337000b8800f5c3fb3e86bfe125f6b3cec8c0b09300c1
+        checksum/init-sysctl: 40bc8149120644563907a100e3902782731959ce7f733edf54de3102805036ed
+        checksum/init-fs: 890a94e10b851b8d122fb04822dd46a77b5a0f65ed0e126075eba320d8cbddd8
+        checksum/config: 0f56ec09b40005688974debf695a4c5b0775a42c10f7f921d3ea7a78ebd11254
+        checksum/secret: b670aa63c9bda79684bd5b37dc6bc13da54b1f9d09743aa2604841a2c260e2de
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -826,7 +826,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -867,7 +867,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1004,14 +1004,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: hpa-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f8648c5a37ac0ab26d0a357318a063dbf1f5e8313b0849b4b939201e9d3e15dc
-        checksum/config: 2b524b124a6c78bafe9236e6268fadd4bcb12ad615b64e51d8739947de99aea9
-        checksum/secret: e7289e78704301b02ab47ee0cfd21ace4de942378218fcb35a467f7cbe06f969
+        checksum/plugins: e73ebd2bc4c6fa4e175c2ab32d4baeabb398fc06151fb0079680ca1e78f0ffa4
+        checksum/config: 66ac5b4d93e53499637a106abf47695419b1478ceddf60244785c2d9c12f9127
+        checksum/secret: 3202d3cf9baa8ff29775e6213d5a0734e42200ef2353748bb4328f986b2b5fed
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 81d539a475b5209dff16a71f806356b6ef374d3cba0bb353d99b8064aa3b4826
-        checksum/init-fs: b443bed79a1466c5e16127e21d459cfa3af23a070d2838ff346a7096af2d5703
-        checksum/config: 2b524b124a6c78bafe9236e6268fadd4bcb12ad615b64e51d8739947de99aea9
-        checksum/secret: e7289e78704301b02ab47ee0cfd21ace4de942378218fcb35a467f7cbe06f969
+        checksum/init-sysctl: 1c2539f6a17dedfefd16d8b6dfe5f48647ebec59561a5d3fe512f01d5a562e91
+        checksum/init-fs: b8a978f7f0f48fcd0cdb49bcd9134cb8b0a0708559392b89a73f2773bb434469
+        checksum/config: 66ac5b4d93e53499637a106abf47695419b1478ceddf60244785c2d9c12f9127
+        checksum/secret: 3202d3cf9baa8ff29775e6213d5a0734e42200ef2353748bb4328f986b2b5fed
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -966,7 +966,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -995,14 +995,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2f72552e5c215978b6dbc3a4a52e47858807562cd646306c22eaaac7bcddfd92
-        checksum/config: fdb9b45538200ca22719875b93bb0e602128a1e4cb9303bc2041826cbce613b5
-        checksum/secret: ed0d2bf7c61c86f12fd847c699f8494ea85982cc730d0de0a940ea51705474ea
+        checksum/plugins: 6f2e2e924a329e5fa9ddd6e5b5ea4741b50737696768dbb6c71efe63a19985a2
+        checksum/config: bc68e59dbfb2c4fcd87193786fcec3b70a843249bb76265a86bee38a0feb418c
+        checksum/secret: 588eac8cb0a5e3e9599895e2759d34fc9277241c58c07fcb0114ea140892b112
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 58493d60d3f8620d3cdeb958de2c351eaeb2a5fca3876bfdedd822d809fbf303
-        checksum/init-fs: 788bd98f4e93d42084d56c4a497cf3eca66f6bb9602d151f39a1f22bc208c1e2
-        checksum/config: fdb9b45538200ca22719875b93bb0e602128a1e4cb9303bc2041826cbce613b5
-        checksum/secret: ed0d2bf7c61c86f12fd847c699f8494ea85982cc730d0de0a940ea51705474ea
+        checksum/init-sysctl: e395883966e76fd4d46733f2461959105428e571d8c3d3e946cc31eb29881cfb
+        checksum/init-fs: f70d256cf95f7882fb92d6abf9038708e2e7a87e3c8b8b4130a1375c694c4995
+        checksum/config: bc68e59dbfb2c4fcd87193786fcec3b70a843249bb76265a86bee38a0feb418c
+        checksum/secret: 588eac8cb0a5e3e9599895e2759d34fc9277241c58c07fcb0114ea140892b112
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -966,7 +966,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -995,14 +995,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 8c6c0ef37ba0fde070e1613d54bedc75189c1221bd1174b140fabccd00e6126c
-        checksum/config: 8a88b90fa86683b2f10d85d7d60984a33127bd49c12d3e4c19fe4507012af488
-        checksum/secret: e94f8fb39e2b2396970615d2190b5e19a64a4fc060f77346e127ee161130cd9c
+        checksum/plugins: dd879478f6272778f99b3aad9bbc077a364a12d0187456c67f4e8e30d56deacc
+        checksum/config: f149a2a5591e8afbcb55f71cf2bcbc9e3b292d7fbdc2babd32b572e6015adb09
+        checksum/secret: 6265f98857011310bee6d9512e08c06e9aba1b915e16f85791a150bb84f494ed
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b61881ab8f45d4172a9736afcf2dd8d751d9c3895bb7007ff49d0a068464d72b
-        checksum/init-fs: bd1e2eae16a18555c7b76a1f1bacdedb21f6c019ab9734336b27eaaeea6e57c0
-        checksum/config: 8a88b90fa86683b2f10d85d7d60984a33127bd49c12d3e4c19fe4507012af488
-        checksum/secret: e94f8fb39e2b2396970615d2190b5e19a64a4fc060f77346e127ee161130cd9c
+        checksum/init-sysctl: b7323861870ce1257aa2b3a818c9ce5284bcc907cc2bdf47a33d052a6e675129
+        checksum/init-fs: 0c5da838b8cb70f43be562f09b2ab1115df96c04686d94980ec1ca623402d26a
+        checksum/config: f149a2a5591e8afbcb55f71cf2bcbc9e3b292d7fbdc2babd32b572e6015adb09
+        checksum/secret: 6265f98857011310bee6d9512e08c06e9aba1b915e16f85791a150bb84f494ed
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -966,7 +966,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -1003,14 +1003,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -72,7 +72,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -87,7 +87,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -137,7 +137,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -163,7 +163,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -179,7 +179,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -226,7 +226,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -591,7 +591,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -613,7 +613,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -638,7 +638,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -664,7 +664,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -817,7 +817,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -826,7 +826,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -843,14 +843,14 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: fdc7f63410eb650d5ad55f6b31bf4d59a85de8d6bce52dbf2c19765878500960
-        checksum/config: 8704e154ed4d4b58fb8e6e818e8758418a4e1c8fa15564377887166239530bac
-        checksum/secret: c5fc09b5e2e09b3f74c720f5fb4c9b71fe99f9720c9a4d1044801c47a1513029
+        checksum/plugins: eeafaa35df4da10d65c0cdda50646b4cee7aed53d3f8251063daf5d0c11f5be3
+        checksum/config: 61bb1381e31405a779b62db94c51026fbc6ff194977cc366c0eac1182b0e9262
+        checksum/secret: d9a23e7db9183a64f2eed2ef1563f02fc634d3450a633a7d278495eda157d250
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -871,7 +871,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -899,7 +899,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -1173,7 +1173,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -1211,15 +1211,15 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9f947d2c8215edda059e7f2c0345ae9bba8b98374add9a6c139bdfb9c591ff80
-        checksum/init-fs: f9707d18aca0c50103ee5f66e22e05f85f746c574b6873dd9d7e056997ea8422
-        checksum/config: 8704e154ed4d4b58fb8e6e818e8758418a4e1c8fa15564377887166239530bac
-        checksum/secret: c5fc09b5e2e09b3f74c720f5fb4c9b71fe99f9720c9a4d1044801c47a1513029
+        checksum/init-sysctl: becad03ede95ff62d274801792d6505a05dfc0fb18664210973d25f4b210bece
+        checksum/init-fs: 2f88d71f62dbb35a093de15f0b69ec14f515c51608ec533b4cf94f96045e2c50
+        checksum/config: 61bb1381e31405a779b62db94c51026fbc6ff194977cc366c0eac1182b0e9262
+        checksum/secret: d9a23e7db9183a64f2eed2ef1563f02fc634d3450a633a7d278495eda157d250
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -1234,7 +1234,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1275,7 +1275,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1424,7 +1424,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1626,14 +1626,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -325,7 +325,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -378,7 +378,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -387,7 +387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -404,14 +404,14 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 8d06f6a5e91bf668b36f2d81bf878bb45641a57052e97b42ba74a22139bb85bb
-        checksum/config: f0fba291d94252f05f72b459662be7865c2cc2787ef43362888f3a467fd2486f
-        checksum/secret: 092db9c0f4e47fffe7932b2f642535c130a88b689f0f11aa18ab4a9c427a521d
+        checksum/plugins: 1cb8d94fb80170bf6f4c8f2dbbafb6ef7965b1ca370c210fe95a7c43fe8d6962
+        checksum/config: cccd8c0fbe86b81d970e77abf6d3481d9c190f190879f8409f6c5ccf682752be
+        checksum/secret: c192ceb4b2bb369a0caadec629845615614f19dc108a3ceb2d5e293cf88512b8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/install-plugins-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: install-plugins
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -473,7 +473,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -501,7 +501,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -778,7 +778,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -787,7 +787,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -816,15 +816,15 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b1665a1893cf25689ab4f86033ba62b92f557a0717df6b5aa60290fbb1ed1747
-        checksum/init-fs: f086261f868161e2f2669d9b3a45089325b0539c41fec1117d0ee52c6c76e371
-        checksum/config: f0fba291d94252f05f72b459662be7865c2cc2787ef43362888f3a467fd2486f
-        checksum/secret: 092db9c0f4e47fffe7932b2f642535c130a88b689f0f11aa18ab4a9c427a521d
+        checksum/init-sysctl: 86755bd1fbf6994288ad176364b136a562db3559606ea5011ea678c37b46ad3e
+        checksum/init-fs: bea44aafbdb5541da73536a6093d910193775bd521d60f39aa5eb1ef8a3dae02
+        checksum/config: cccd8c0fbe86b81d970e77abf6d3481d9c190f190879f8409f6c5ccf682752be
+        checksum/secret: c192ceb4b2bb369a0caadec629845615614f19dc108a3ceb2d5e293cf88512b8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -839,7 +839,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -880,7 +880,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1017,14 +1017,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5fad64ba0e535d89e6bbc54cf7d26b265c6d124d54582d4fc0fa7d41fd917f3d
-        checksum/config: 794a0e9db1927604a53eb38a00a028179dcda11550d67e5b2651864b7d455bd8
-        checksum/secret: 15ddf8c4c0ac7cbe081a4492ae1ce294681c78ee50328dd9d8570397071030e2
+        checksum/plugins: 0f0b1009468c284d74ed64c993b9855bb7ede32876a67d4d4d0fcebbc1850e10
+        checksum/config: e1c748b382cf6b50edc484d5a829894ae52765116d4027f3f617e13da296c659
+        checksum/secret: d2b9ccd34badcf9f13b4fa11157a17e1f2c2ee4d8f722a21c8ab8874db13eccc
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 7efa126a1dd46ec178fd8fb82914c19a8767fdc18adbf43a9fa56fa53514863a
-        checksum/init-fs: 23c1263b222f21660d0f5dca679995aeb0874fa9ffd64bf305c1fdeeb9bc36ba
-        checksum/config: 794a0e9db1927604a53eb38a00a028179dcda11550d67e5b2651864b7d455bd8
-        checksum/secret: 15ddf8c4c0ac7cbe081a4492ae1ce294681c78ee50328dd9d8570397071030e2
+        checksum/init-sysctl: 3cd0a71db3476a774e5c5d0fa229b6e8076f521e36dc35a1d15ec5e1c14bdb8b
+        checksum/init-fs: 91031b540104dc9ea261195be83f1a526a3748000d629da8808599406bb95ab0
+        checksum/config: e1c748b382cf6b50edc484d5a829894ae52765116d4027f3f617e13da296c659
+        checksum/secret: d2b9ccd34badcf9f13b4fa11157a17e1f2c2ee4d8f722a21c8ab8874db13eccc
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -970,14 +970,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -67,7 +67,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-database
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -159,7 +159,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -199,7 +199,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -249,7 +249,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -264,7 +264,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -279,7 +279,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -298,7 +298,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -311,7 +311,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -324,7 +324,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -340,7 +340,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -387,7 +387,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -400,7 +400,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -468,7 +468,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -490,7 +490,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -515,7 +515,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -541,7 +541,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -568,7 +568,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -594,14 +594,14 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6739cafa5661545792aaa01fdac7e8e051df2b68c140e899ec9b7bb601f4f10e
-        checksum/config: 504a03d52c7c0893ace105eb7e935d7341001da1a7bdd7123d09b5ac469ca7fc
-        checksum/secret: 751ec9449b04463c21c91a525e23d02d2514cf44b4026e1e799af53c7d738f4c
+        checksum/plugins: 34e279a688d2d7ee3cbb26a142bd880dd9a92176a34a12e500b72157cddbfb3e
+        checksum/config: 7bcc102cd389d4db3a5d77706a7a24c3ffb792f0e18f23632a62240ec6c025e2
+        checksum/secret: ad29619e2e324bc23a87e14fea2e01d1f72401c9ffc9ded189500271dae870b0
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -622,7 +622,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -650,7 +650,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -924,7 +924,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -933,7 +933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -962,15 +962,15 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b2cf66d82faecd0a7013e7be0f3d16f7ecfd11c8880337b6a42b174431fe1814
-        checksum/init-fs: bb5f41a505cf8391af82ec7f429bd6fd07b80484c0cfcbb2b8edcde255010e10
-        checksum/config: 504a03d52c7c0893ace105eb7e935d7341001da1a7bdd7123d09b5ac469ca7fc
-        checksum/secret: 751ec9449b04463c21c91a525e23d02d2514cf44b4026e1e799af53c7d738f4c
+        checksum/init-sysctl: f802bb799c150830952441a7e40b12a84273c235a33f936ff11480ed5b055705
+        checksum/init-fs: 9235100dba0ddda43815087a7af1eb5400566d411932f88e8f4a3d149b517271
+        checksum/config: 7bcc102cd389d4db3a5d77706a7a24c3ffb792f0e18f23632a62240ec6c025e2
+        checksum/secret: ad29619e2e324bc23a87e14fea2e01d1f72401c9ffc9ded189500271dae870b0
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -985,7 +985,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1026,7 +1026,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1163,14 +1163,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -67,7 +67,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-database
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -159,7 +159,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -199,7 +199,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -249,7 +249,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -264,7 +264,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -279,7 +279,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -298,7 +298,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -311,7 +311,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -324,7 +324,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -340,7 +340,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -387,7 +387,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -400,7 +400,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -468,7 +468,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -490,7 +490,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -515,7 +515,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -541,7 +541,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -568,7 +568,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -594,14 +594,14 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: bf21237258ab9df69e5f823f1e3f5afb43cc388ee837cfce293a83370b66f75b
-        checksum/config: 88394a571484e4a81d656749dc85b5aec30abc664d898ba26a98e3ed36607d4b
-        checksum/secret: 6d5115033c28966596c1f76d6fda15f1b9b4b3dfa999a14270ae0b0931a20250
+        checksum/plugins: 09754254503770830b7d3c0683d42e76dd1a3b8e58750b4e6260b8761d8b82a3
+        checksum/config: 792b41a9dea6536374250da50cd3e2ad7faf8994555c249c8b212b868b401df6
+        checksum/secret: f562e95fa5c018ecb60153d9e5b3efa35643b30dfe767b71bf8dd4f5b5ccb440
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -622,7 +622,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -650,7 +650,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -924,7 +924,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -933,7 +933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -962,15 +962,15 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f03fb6c30eb117a7b8ff363c6ce2ae1016eb599aea0951533ff73111f69290a7
-        checksum/init-fs: 8edb6d7d3aa69ed16bd5b13654bd01d3ff6830c8afe82d67637d32b077818991
-        checksum/config: 88394a571484e4a81d656749dc85b5aec30abc664d898ba26a98e3ed36607d4b
-        checksum/secret: 6d5115033c28966596c1f76d6fda15f1b9b4b3dfa999a14270ae0b0931a20250
+        checksum/init-sysctl: 82013e5017d3f5f67dd0a0bc1474520435db7512c4338bf7f1df3bfce21e54ca
+        checksum/init-fs: 98cd276cd3938af14d047cffa9d3cf2fee2c90a56a377cdb7d34fb12270c73c4
+        checksum/config: 792b41a9dea6536374250da50cd3e2ad7faf8994555c249c8b212b868b401df6
+        checksum/secret: f562e95fa5c018ecb60153d9e5b3efa35643b30dfe767b71bf8dd4f5b5ccb440
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -985,7 +985,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1026,7 +1026,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1163,14 +1163,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2a43c2ade78b2c27be7e164a762ba30171cde4b105c93f59925863f0160fd55b
-        checksum/config: dc6793dfde14b8755a3a722e9ee763bd4d481cffe4319e81254295bd099f9b85
-        checksum/secret: d4744ed49ee38e10a02b4c806ebc88a4724d1288952061efbd0359833803f784
+        checksum/plugins: e7f7b59818dbc3f6a93e068d7f03adac732b08edac3f65799d0ff180a6cd98fa
+        checksum/config: 14a1b352242e899cf4ea9799d30c393dc4bb16c20874971ff85d2f88cc47d360
+        checksum/secret: e22288735e50c5a68c64efd49f5b31377f8a7777e6acf691047022a948a582f2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -746,7 +746,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -784,15 +784,15 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a008ce7e8b7049b785180192500a9d993796d04e73cc649ca91fb011c917a295
-        checksum/init-fs: 3572d51698228393a73242da0a6b9b872011b70e41a691949b68e1b653f89cfa
-        checksum/config: dc6793dfde14b8755a3a722e9ee763bd4d481cffe4319e81254295bd099f9b85
-        checksum/secret: d4744ed49ee38e10a02b4c806ebc88a4724d1288952061efbd0359833803f784
+        checksum/init-sysctl: 88e498badf8795d36dc8e42d1f3ac5e44163b0c7e3eb5fe69199653fd6520b35
+        checksum/init-fs: d7061ddc09d691dccbaa2896540802b27bfe515f52e916d339ef5705eb503f21
+        checksum/config: 14a1b352242e899cf4ea9799d30c393dc4bb16c20874971ff85d2f88cc47d360
+        checksum/secret: e22288735e50c5a68c64efd49f5b31377f8a7777e6acf691047022a948a582f2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -807,7 +807,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -848,7 +848,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1000,14 +1000,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 97ad52429a4a3fa1df9d57da0c75671002117434bae0bbfe7513a9106a7cce02
-        checksum/config: 9f46b2d954057b89e41fc5e87864f7985312fc50975e3f8e141680576f24ae6a
-        checksum/secret: 26f34c6f5e18806b42be7fafe3306f227d432d6692932737dd5483949cdb30e4
+        checksum/plugins: 4c62337d61946257ada67b34b2ba6dbcb4238a2887e894e8cdc68d5ac312bffb
+        checksum/config: 703aafa84e935bf2727be7cad1e083702f4f09f3864cea97b258f8c00e057ca8
+        checksum/secret: f96ca53218b77594863b94db3d1263b96c681ba4d377e0494a8992c2e1ba1f4a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -746,7 +746,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -784,15 +784,15 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: acb1a11b6d29acf4f90b901c97d07e5b77e211705ef08cda944032c79b2442fc
-        checksum/init-fs: 90634795657c175c9161e12f26b9889b9ee47a177f6ecaa916d5bb428cf32c1d
-        checksum/config: 9f46b2d954057b89e41fc5e87864f7985312fc50975e3f8e141680576f24ae6a
-        checksum/secret: 26f34c6f5e18806b42be7fafe3306f227d432d6692932737dd5483949cdb30e4
+        checksum/init-sysctl: 74a5403a86b8665d8cd512a8bc0583e5bb2480fc550968de28d8bf9ab43f9b75
+        checksum/init-fs: b8734a321d9d33a62a3fc2df656a10947c2f66b5ce948982b507bf2510a9c20c
+        checksum/config: 703aafa84e935bf2727be7cad1e083702f4f09f3864cea97b258f8c00e057ca8
+        checksum/secret: f96ca53218b77594863b94db3d1263b96c681ba4d377e0494a8992c2e1ba1f4a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -807,7 +807,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -848,7 +848,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1000,14 +1000,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: node-topology-values.yml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -305,7 +305,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -352,7 +352,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -378,7 +378,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -405,7 +405,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -431,16 +431,16 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5b68380eb67ad9d8c4efd250c658c7856ad10f9dd8def4b9c186ee9d421996c8
-        checksum/config: 6f72ff6ea0587f9a5748e76757cd8c227b667b5a57452b57a2a15ade8fde5449
-        checksum/secret: d73f3407d39c5a99f52964f9baad62b9d281ea706d151cd3d722fe6451d2140e
-        checksum/prometheus-config: afa72a720253cb021d6ebca6730ecfdd98b3d8195f3b8866f1388ccce6af9e13
-        checksum/prometheus-ce-config: 3668e9f8fb7f81aa218ad34829722d88de89309699f854794c66f56689786500
+        checksum/plugins: 7e8c601842c9e1e7937fc218b4a1aa0995c2aa8786f418262899d4b9e48dd418
+        checksum/config: a7b518c532f088a30a56702d61f4afd6410581beeb03408dab3d5a678c6394ee
+        checksum/secret: f2d937fd99d24622a83d10167b0bcbd55cbbe082bec9be12093ad6eb6fa64a04
+        checksum/prometheus-config: c627a1ce9efa8aa201941c0ea36e879b6c5c6d04c54e044020baa096d53f3fd5
+        checksum/prometheus-ce-config: 1637010a2e93569d43e3b80fad27c83f44af44fa9f357fc291fd9cd8ff7ae080
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -458,7 +458,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/prometheus-monitoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -533,7 +533,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -825,7 +825,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -834,7 +834,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -863,15 +863,15 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 8b2d7abb9c3554449a7907f236d78de2fea5d34be0bdee447dfc9e4445561ea9
-        checksum/init-fs: 4e1c39b8dfc636d9a10b040ef977bb25bfe7ef214409710eaee3cf68e67a9434
-        checksum/config: 6f72ff6ea0587f9a5748e76757cd8c227b667b5a57452b57a2a15ade8fde5449
-        checksum/secret: d73f3407d39c5a99f52964f9baad62b9d281ea706d151cd3d722fe6451d2140e
+        checksum/init-sysctl: 0d64c180d1f486bd1b24062cb76e82f1c04440497ac241968f1b6e02b0a5a377
+        checksum/init-fs: 2a0e0f107a16dbd9849d6a5ff5e0637b83461287df16906a420a1d8f1169b9b4
+        checksum/config: a7b518c532f088a30a56702d61f4afd6410581beeb03408dab3d5a678c6394ee
+        checksum/secret: f2d937fd99d24622a83d10167b0bcbd55cbbe082bec9be12093ad6eb6fa64a04
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -886,7 +886,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -927,7 +927,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1101,14 +1101,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -325,7 +325,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -378,7 +378,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -387,7 +387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -404,14 +404,14 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 149e79f83e9b9128ab8077f618381172233ed4175ff79c8b9f39383181be488d
-        checksum/config: bf011f0cef46af2e10cf62b0a9314bab4881e1841f4298e62ecf8bc80b32c42a
-        checksum/secret: 4d2edc995f1feeeddd253fe620874c3ca0b096d1e78b81c42f779af46faffc6e
+        checksum/plugins: 123a46c1a844f9e6ed21ac1136d620374ca648c275b409c6e8b50bb7a47d81f7
+        checksum/config: c67ee686394af6d2759c8c2554584b6444c1859fd51bad2aa7efeb256f5a7faa
+        checksum/secret: 7a7a21c9edf162675b447c18d261343a36c483575d0dc32c940efce5c720ecf7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-secret-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: install-plugins
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -473,7 +473,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -501,7 +501,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -778,7 +778,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -787,7 +787,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -816,15 +816,15 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f1bf584cdf1f7a184ef129ba7e1377084710c23374cac1c624f08fc018592cf1
-        checksum/init-fs: f81296fdf4591adae8d529cdc413e2c8a06ee5624d8c7c3855d10e5696669d76
-        checksum/config: bf011f0cef46af2e10cf62b0a9314bab4881e1841f4298e62ecf8bc80b32c42a
-        checksum/secret: 4d2edc995f1feeeddd253fe620874c3ca0b096d1e78b81c42f779af46faffc6e
+        checksum/init-sysctl: 4723491d68120f17a85264f23cec694ae0f3af9fcf97552e5dba51f90d95db98
+        checksum/init-fs: bb914fca75a6780ea2facc4bfbe23cf4856cc616bf7c7a972a816eabc33e8e8a
+        checksum/config: c67ee686394af6d2759c8c2554584b6444c1859fd51bad2aa7efeb256f5a7faa
+        checksum/secret: 7a7a21c9edf162675b447c18d261343a36c483575d0dc32c940efce5c720ecf7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -839,7 +839,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -880,7 +880,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1017,14 +1017,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -308,7 +308,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 
@@ -330,7 +330,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 
@@ -355,7 +355,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 
@@ -381,7 +381,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 
@@ -408,7 +408,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -434,16 +434,16 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ca88559e256911e8470391e07b5e287efa9e9073d015f9431ae5068046982b19
-        checksum/config: f666ea56e545bbbdb3030ce80c4f81cbd9e8a1122cd912fc7aaabbfd6f084aa0
-        checksum/secret: 83881b27b0b54a46b973d164740c10dfe854e05e0eef293da02c60107ee0fcbd
-        checksum/prometheus-config: ac47f6687d71f3bf1d65ffb5883aeff53c07a409d7298b85a9edfd0aa5c2120d
-        checksum/prometheus-ce-config: eaa38e282cbaee3eb6766d616f5324bf5829ee884274274bca2d2e4ad22a5779
+        checksum/plugins: a5ed079a5e48d23184e0cb9cf72258a2c4fb51b1fc7bae413b31e42493170d53
+        checksum/config: fc82393d7fa53f42b3ab798f05b5b85a42a8fcb7820cf4917d5c456ebfaac7fb
+        checksum/secret: ea9ea0b1d81100ac29e1e2617b2ff0cb0a87cf81d20903952d78ecee75a647a7
+        checksum/prometheus-config: 5aac469459b3093ec08829cdd2bb3639f2f03de45e7ca3573e0e1c21976fca2c
+        checksum/prometheus-ce-config: 4153f58de91c3084467e1868faad7745addd147790bdd18d4ce72574439e1380
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -461,7 +461,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -543,7 +543,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -577,7 +577,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -872,7 +872,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -881,7 +881,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -910,15 +910,15 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0cb346639ada7b100ee92315ffe8aa6f47da6ac7aca645915ce1604985cffea5
-        checksum/init-fs: 17264b3f95d68def5ea8da61e32b16aba9bb86a202115303a42016c6af1d1dd9
-        checksum/config: f666ea56e545bbbdb3030ce80c4f81cbd9e8a1122cd912fc7aaabbfd6f084aa0
-        checksum/secret: 83881b27b0b54a46b973d164740c10dfe854e05e0eef293da02c60107ee0fcbd
+        checksum/init-sysctl: ea90fe55981488b56b0c36291b896a515db88b77d6ccfdae69380ba64a4bca85
+        checksum/init-fs: 53779af6be8b70155640410d41e3959c034d20ce7333cdddf7ad1ee49d1fb13c
+        checksum/config: fc82393d7fa53f42b3ab798f05b5b85a42a8fcb7820cf4917d5c456ebfaac7fb
+        checksum/secret: ea9ea0b1d81100ac29e1e2617b2ff0cb0a87cf81d20903952d78ecee75a647a7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -933,7 +933,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -974,7 +974,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1111,14 +1111,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 21187c521277fb647d34f6394bef4c3ffc55e83ec10c2887f57cc06383b2869a
-        checksum/config: e709c0ce0d3152c74e262e31e2f8bb6f4dc07a3bcb4fd94a5c6e9fa5b405f458
-        checksum/secret: 99900fe2408f78ee3ee0a17618b24b34526fa2718f387376f9a7e9a752b74af6
+        checksum/plugins: 7457a08f5c52a285aa549477d90f1eead201128079f4512db1e4c12a972c9354
+        checksum/config: e135ed5c17c00a1af0eba91bd423f47d82fb1c225bb9f91ff69044c70c6b5680
+        checksum/secret: 1b6bab9c07f09ee0b475b6fa3eb1ae6fd991170c0199f4ed613a435b4ad72a61
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -771,15 +771,15 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 11b8dec18b87cc56e6d6927fb6b39d7ad283fccf312b3f2b9b093af528c3f9d7
-        checksum/init-fs: a862960b57d0c1966e1e604e8459208a7e2ff8ecf57379737fff6a578093fd46
-        checksum/config: e709c0ce0d3152c74e262e31e2f8bb6f4dc07a3bcb4fd94a5c6e9fa5b405f458
-        checksum/secret: 99900fe2408f78ee3ee0a17618b24b34526fa2718f387376f9a7e9a752b74af6
+        checksum/init-sysctl: db39d6f8844fb5369c676b504303ade76d218cc3da5244805ef4ac445d5f8594
+        checksum/init-fs: b493618a8bee8dbfc671a7fab4073fcf7f9317c3972eec998bd365a89a058b16
+        checksum/config: e135ed5c17c00a1af0eba91bd423f47d82fb1c225bb9f91ff69044c70c6b5680
+        checksum/secret: 1b6bab9c07f09ee0b475b6fa3eb1ae6fd991170c0199f4ed613a435b4ad72a61
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -794,7 +794,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -835,7 +835,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -972,14 +972,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -204,7 +204,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -230,7 +230,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -283,9 +283,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2094f8860bcdb950b6505fc44b2919583a826514e2952a302544a5343e9862fd
-        checksum/config: fcd1541e97b6cc5dda806a53690aea7115a1214c44acf113438c52dc63e0b956
-        checksum/secret: b9c0a7087c8aa28b4f13b02dca3e37a2b4d285ccdc4bc91786a2b66ba30692fb
+        checksum/plugins: 0a132376347eb38f79c606af421de30b0dc40d02c4e700cd0fafae7bb20f77bb
+        checksum/config: e376eeab20ac09ae1d6ce4cbc8d1676641a174b48fcc6bd505614a23dcb1da3e
+        checksum/secret: 039aa9013a9e8ca19f3eea7e4103c6f09580768d97e6f159ca81e8bcdaee99b6
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -355,7 +355,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -480,7 +480,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -518,8 +518,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: fcd1541e97b6cc5dda806a53690aea7115a1214c44acf113438c52dc63e0b956
-        checksum/secret: b9c0a7087c8aa28b4f13b02dca3e37a2b4d285ccdc4bc91786a2b66ba30692fb
+        checksum/config: e376eeab20ac09ae1d6ce4cbc8d1676641a174b48fcc6bd505614a23dcb1da3e
+        checksum/secret: 039aa9013a9e8ca19f3eea7e4103c6f09580768d97e6f159ca81e8bcdaee99b6
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -692,7 +692,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: dc1d3d576cb90bad5ecb5fddf1ee441e1adf390294ffdf8cf72ffa98076f62fd
-        checksum/config: fca1cef597d8bb7625a2a821f91753c7805601da395ce9000c9d73c9558f0a10
-        checksum/secret: f0e8be06d3b10abbed7c025a40ec6cf78bf4db786c73255473bd623bed806a43
+        checksum/plugins: 355a81346a584ffc69f393d8f2d4aded8c837c2bd12e7fe90f967208b7e2a50f
+        checksum/config: fc3f19df24e5ec642cd7ac65931ff166bd524cd517f228c99a83c5355554da3b
+        checksum/secret: b63a5fbefd779930ebb5a9602858659ede6bd6cb1fe1fa66d3680c34d30b60ec
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 80f0fb2a465d7169fb66276f68e03a4cc0210bca937c99a15fba5aeeddc6fefe
-        checksum/init-fs: 58f820b65a2dd3d4bca8c5db59809ff0a6618301f3c78aa5b8cb3912f4e7828c
-        checksum/config: fca1cef597d8bb7625a2a821f91753c7805601da395ce9000c9d73c9558f0a10
-        checksum/secret: f0e8be06d3b10abbed7c025a40ec6cf78bf4db786c73255473bd623bed806a43
+        checksum/init-sysctl: 0df99b2e10081a79c53a0a5da0173e5afafa128b5da31f24d1806aedcf3e29af
+        checksum/init-fs: de1adbb830bd0bbd4cc6fd2c2d9af8c632d19a47a09d495e55c5d98dc41dae2c
+        checksum/config: fc3f19df24e5ec642cd7ac65931ff166bd524cd517f228c99a83c5355554da3b
+        checksum/secret: b63a5fbefd779930ebb5a9602858659ede6bd6cb1fe1fa66d3680c34d30b60ec
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -787,7 +787,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.6"
+    helm.sh/chart: "sonarqube-dce-2025.4.7"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -304,7 +304,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -333,7 +333,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -362,7 +362,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -393,7 +393,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -419,14 +419,14 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: addc75a02979ea3d29775512c33bb69909cdaaf46c943770b4b39727a28e46dd
-        checksum/config: b7c08ea122fcfcd11ca074caa622d52fd499d973955fb0f3c899100938d369cc
-        checksum/secret: 197689802d34cce214e1469e66d175b1bdf63af66a339269f00702fe9cf4642b
+        checksum/plugins: 4aea3f229823b6b5220505f7c9209ca5eb7679847c28a514856e0cc2c501bd53
+        checksum/config: da93a23bb71723cd93d5ff6e9faa9e25dd38cac84eeb154f1e7d4809e0e6551e
+        checksum/secret: 87acb1c0bfcc34c2b66ebbbda4ddb4b17d0732a45414a787baaef41214720639
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -447,7 +447,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -475,7 +475,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -749,7 +749,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -758,7 +758,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -787,15 +787,15 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: eab88a8dabd4f5b4011132624282c0b30ed8c308ace12d52f6e5e5fdfa32842f
-        checksum/init-fs: ddc2fc0c348efb7e1f60abfa0fea75176a2546bfd7af7af0e4e24a0181570e24
-        checksum/config: b7c08ea122fcfcd11ca074caa622d52fd499d973955fb0f3c899100938d369cc
-        checksum/secret: 197689802d34cce214e1469e66d175b1bdf63af66a339269f00702fe9cf4642b
+        checksum/init-sysctl: 09b259c1d93001adda64e7b8d1c55537be38954943c73e6062aafcd9029bdc68
+        checksum/init-fs: 940faf486e9f17b9d437fa32ae36a47aa03c991fc5e883f9222e4f41d70cf383
+        checksum/config: da93a23bb71723cd93d5ff6e9faa9e25dd38cac84eeb154f1e7d4809e0e6551e
+        checksum/secret: 87acb1c0bfcc34c2b66ebbbda4ddb4b17d0732a45414a787baaef41214720639
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -810,7 +810,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -851,7 +851,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -988,14 +988,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -65,7 +65,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -80,7 +80,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -95,7 +95,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -114,7 +114,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -140,7 +140,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -156,7 +156,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -203,7 +203,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -216,7 +216,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -284,7 +284,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -357,7 +357,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -384,7 +384,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -393,7 +393,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -410,14 +410,14 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: fb94e032b975499eb2795040e281f3e3ffd8f8acf57756cf6f843c695382b7ac
-        checksum/config: ca4a93c6b988bc819ac4c842a259caf99871b2f7a42c88b32e386a9432ba1e3e
-        checksum/secret: cf576cac902fa4a99d7b1f2d8d14f6feee59053398a873183c4424ee801c4e9d
+        checksum/plugins: e05b9e18c88e9b8a4794d1961aa6075a899f1cb8bbea01791e659d0c64121ae4
+        checksum/config: e442cb7abd8f3c4eaf6d60154a19763a079f08c964307d8b92e20b18172d38f3
+        checksum/secret: e594fd2c0792163661d6f5da0246b95339a057a61330ca141632d07efb3856d3
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -438,7 +438,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -466,7 +466,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -740,7 +740,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -749,7 +749,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -778,15 +778,15 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f42a93112c56433ad1c06386c8f07cfa97e260dd6314527c1cf018f6f8ed0afb
-        checksum/init-fs: 2fa8802ef659a8be7e4063a5f89ba65a5b69c527804244b7c706db31d3aec798
-        checksum/config: ca4a93c6b988bc819ac4c842a259caf99871b2f7a42c88b32e386a9432ba1e3e
-        checksum/secret: cf576cac902fa4a99d7b1f2d8d14f6feee59053398a873183c4424ee801c4e9d
+        checksum/init-sysctl: 351ca4a8ca9facd4b87834b98c3d77cfb0a421989134d1acb7689d49399f1ad8
+        checksum/init-fs: 61fdbcf89e53768e7932acfa5732a3d090f3c59b5e0997885de1413bd7701d6a
+        checksum/config: e442cb7abd8f3c4eaf6d60154a19763a079f08c964307d8b92e20b18172d38f3
+        checksum/secret: e594fd2c0792163661d6f5da0246b95339a057a61330ca141632d07efb3856d3
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -801,7 +801,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -842,7 +842,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -979,14 +979,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -209,7 +209,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -222,7 +222,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -290,7 +290,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -312,7 +312,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -337,7 +337,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -363,7 +363,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -390,7 +390,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -416,14 +416,14 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 8315a471083774bba10919e25bb55c8fac0dddcacce8c521c676e5609f03868c
-        checksum/config: 30c4a71735a19af7ec8c9b1ca51685ec09b97b2085dd3d27ad233cea8dc6e61a
-        checksum/secret: b0198e2fd574a5af308926d94fc62262819ac1af343cbd60cd2ddf4d04a776c4
+        checksum/plugins: 812a42ee51fad7fb5b918c3d221de6d8727be80d7ce54e7469e2123ff80ede8c
+        checksum/config: 71d71b29db0b6c073d8cef3f3a3c739aff277233981d49bfb4102c1c7807fedf
+        checksum/secret: 4b010797b3adc968dc618d688213e75e7601c0fbe408e5d13b1dd1b30c3f77e0
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -441,7 +441,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -480,7 +480,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -508,7 +508,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -794,7 +794,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -803,7 +803,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -832,15 +832,15 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 292c7d571c1cc6fa922dda097ecff5fb721637ee206fef5db6c92792ef909b72
-        checksum/init-fs: 058949661f36a758b64c59fdf9699a80affce52c4b55306ebb368979ac391f7d
-        checksum/config: 30c4a71735a19af7ec8c9b1ca51685ec09b97b2085dd3d27ad233cea8dc6e61a
-        checksum/secret: b0198e2fd574a5af308926d94fc62262819ac1af343cbd60cd2ddf4d04a776c4
+        checksum/init-sysctl: 0e0d4277ae8e0eb7415fa21b1176c5bd31de12cae166a58234529495a1d241ed
+        checksum/init-fs: a5ae3dfebbfaaec3386e047b66a74fbd0dc4d2738b359e60e50ffb551f61371c
+        checksum/config: 71d71b29db0b6c073d8cef3f3a3c739aff277233981d49bfb4102c1c7807fedf
+        checksum/secret: 4b010797b3adc968dc618d688213e75e7601c0fbe408e5d13b1dd1b30c3f77e0
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -855,7 +855,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -896,7 +896,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1029,7 +1029,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -1056,14 +1056,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1095,7 +1095,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.6"
+    helm.sh/chart: "sonarqube-dce-2025.4.7"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -1115,7 +1115,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2025.4.6-datacenter-app
+        image: sonarqube:2025.4.7-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -289,7 +289,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -311,7 +311,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -336,7 +336,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -362,7 +362,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -389,7 +389,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-app"
+    app.kubernetes.io/version: "2025.4.7-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -415,14 +415,14 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 301122867f2aeed46588ff053274c5664340f1b2673eede7132c775c8112f5a8
-        checksum/config: 4028571371da1e088a9048684dca85e22ea18518be119eec92a3ac1d3d6ed955
-        checksum/secret: e51cb7a2fb215ecc1c9f5beeec556be8b8cf11b397c9640cb535b411de69efb8
+        checksum/plugins: 9b3fa2f8430b6fa189b02fd30a67aaf28669d3638a4331c92e6cebac78d388b6
+        checksum/config: 601ce2567e1789e1606600e6f548ce2c4f97cc80ce2be6af5b045992872f98fa
+        checksum/secret: 85000bc13a49da2a6e6c3a92cba270241b45021117d773bafe8c4d0f6fbec5be
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -471,7 +471,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -745,7 +745,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -754,7 +754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.6-datacenter-search"
+    app.kubernetes.io/version: "2025.4.7-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -783,15 +783,15 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 6a40d593bad6044489e76c8c088dc92bfcc862de5d9ed949adc87d4b58d336b0
-        checksum/init-fs: 37de761002f80fae1c4fcbbc69f35879db043c94e04660af1b8d081c08646d88
-        checksum/config: 4028571371da1e088a9048684dca85e22ea18518be119eec92a3ac1d3d6ed955
-        checksum/secret: e51cb7a2fb215ecc1c9f5beeec556be8b8cf11b397c9640cb535b411de69efb8
+        checksum/init-sysctl: e1c85a61af2794d6c67e2f886a40c7925ed4524a14fd85621bb8ff39cf1c98bd
+        checksum/init-fs: 78c68e5b20a0a7aefeed2b22da5ad147244a5bbd5d9bd8ee657c2453f2bc8981
+        checksum/config: 601ce2567e1789e1606600e6f548ce2c4f97cc80ce2be6af5b045992872f98fa
+        checksum/secret: 85000bc13a49da2a6e6c3a92cba270241b45021117d773bafe8c4d0f6fbec5be
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -806,7 +806,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.6-datacenter-app
+          image: sonarqube:2025.4.7-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -847,7 +847,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.6-datacenter-search"
+          image: "sonarqube:2025.4.7-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -980,7 +980,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -1007,14 +1007,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.6
+    chart: sonarqube-dce-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-datacenter-app"
+      image: "sonarqube:2025.4.7-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1046,7 +1046,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.6"
+    helm.sh/chart: "sonarqube-dce-2025.4.7"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -1066,7 +1066,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2025.4.6-datacenter-app
+        image: sonarqube:2025.4.7-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -214,7 +214,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -396,7 +396,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -404,7 +404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -416,10 +416,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a6f83c66902ca6645b2032446f9900a7e7e309438b08169736ce5d79670ac273
-        checksum/init-sysctl: 4bcf74fde9e7fa6297fb96e831508cd13fa17f43da70007fe4b841b3a20e4944
-        checksum/plugins: 09116a57f3e0b0f7ea2f1e3c43020f37363d664073b7563ef27c3bde50e83914
-        checksum/secret: 346b604490cef73b5ee516d74bb68934db218864bfb1462ebb76b0bcc724f761
+        checksum/config: ad64bbcfcd2cbece3d7e3d796662bd6d190ff23920e82451841cd45faf3a3b62
+        checksum/init-sysctl: bc2c475fabd7ba9f1aab5e75320dfd7c8303f213e6dbbe879c24dc7a65873a53
+        checksum/plugins: bca48ab3d37318b1697bc148abf572bf745e10b6eb665501cd31e77520cb01ef
+        checksum/secret: b033c36a68955b35785da7421733d66e8de67065af869fc0fb9a7b87fd0df73c
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -445,7 +445,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-configmap.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -474,7 +474,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -492,7 +492,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -525,7 +525,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -542,7 +542,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -671,14 +671,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ba751328ed232f47c65ab252861c50cf8ca8a05141d908fd821f34a54e618fa2
-        checksum/init-sysctl: 70ca9461366dc8a693bfc2857453c7366bc1d41fc7d33157f484559ec366a6c9
-        checksum/plugins: df6eb75bdca8364dfebc59589916c109d295ff4d6593d478ce42296ede912ee5
-        checksum/secret: c8bfc471a27f49f6bac637d0881aaa0f2b12c2a478c297ac82d873556968541d
+        checksum/config: c5b21efd927c83a87e5d45449d7f44d229dc1866bc0cb49b56aab54ca84e1e5e
+        checksum/init-sysctl: 035efc7037eda484cc564ac775b6d52dac4f4fe52743a1350d9e06cc1785aa8c
+        checksum/plugins: 1ee91d69fdaa9ad72f74a7f215cd3bb44af0398f2e8447e63169daf75644f060
+        checksum/secret: 490140d1ff30ee70defe42da4d70b880ba5b40d010165723cb2e3c3d66c6b181
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-secret.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -477,7 +477,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -494,7 +494,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -606,14 +606,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: adf90387a687b04334bd6f1ce08c88e6189eeaf3037d9a4d6a56d59f2607e7a2
-        checksum/init-sysctl: e11d38631c2f117ad92b632dcd55915de7873edd751915643cec149c30b4dd7a
-        checksum/plugins: 0f54fe186b8c027fc7df7c23320097db1dc6817dfbd2ee48238d4174e07dd8a6
-        checksum/secret: cb4d0ac9b4198903115e40a1bd476887b9c92dee10d389c5fac9cd8e8a7073f3
+        checksum/config: 8d1ce5f907427b8c28e0ae1ab1f89930dea28e893580a796f8e7aba300a2a366
+        checksum/init-sysctl: 1543214d403d76adb8d8a60d0d4bb23c4c5ce3ae8ddd6fffcf86586a9507cb4b
+        checksum/plugins: 8762ae8e0b7078b57aff7a7ec8592160ea34ca95bca90f3b2ab2a482a5797097
+        checksum/secret: b2fbc4d7bf7ef8fd9f9620385ea7a14f09307f52897c14104484af17f34fcc0e
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/change-admin-password-hook-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -588,14 +588,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -625,7 +625,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -638,7 +638,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.6
+        chart: sonarqube-2025.4.7
         release: change-admin-password-hook-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 25d45397e33e103bb7d8e194015e67f444662bc888a901a4b73b0fa4eb8710cb
-        checksum/init-sysctl: 704d11be4b8bde59b7ad3e0df29420c0400f51e2b4663efcf406dedf9908db90
-        checksum/plugins: f818563e3be050897f303d6b681e6d54a9dabec0a6d69c50a5967837bd419841
-        checksum/secret: ee05f4394b6d69d0a4ac4b0a85a9386ddda7f2b2e43309ae2d5ad64bad0b2da3
+        checksum/config: ef22565fb4ef2f82547a1e1f9b02b53cec3e961bcea35833f10d3454602e1189
+        checksum/init-sysctl: f1fb4e5664f6b4627c7b18c1b67c6df494331ec403355fc0a5fbd5413cbeb685
+        checksum/plugins: 64e88dad04308e30a1d6fa0de8a3a8cde101437035d4e2b9e5da9ec99f32a9c5
+        checksum/secret: 5e59c614c53095fa81be2a1c5e9ef9a1a40468c0b2603e7f0d5e7b3a4d56a86d
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,7 +574,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -74,7 +74,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 data:
@@ -202,7 +202,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -384,7 +384,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -404,10 +404,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7d50ef09a8227620b33ac75b0cacc4e23e14774fa545a6b63885664ef1509c01
-        checksum/init-sysctl: 2d7a038bd17b48e9355bde343f0b815c39549f03e3abe2ae241aa22cfaa9ec52
-        checksum/plugins: 837efcfcf5d30d7d933b634b1f398002f8cb62600b3fab693e1ba45c62f537b6
-        checksum/secret: fc64a7571e3169a769be7a420f7049fd67d45ba57b319cb693ca087ab7e2688e
+        checksum/config: 361173a9b3bc608c7d8c68443e4058ec9e066d92c342cd843dbf44bac74f65d5
+        checksum/init-sysctl: 3b64ea1a53714b8b159e36854a9fa1adbbac3e79f73e00b70be4ba7ea320faea
+        checksum/plugins: 2b3c8b0d90dbb1db09a4e09337963c30b57ff2abba2e62de9da26cc42c681659
+        checksum/secret: 6d04ec676ec2676152bdea0d1b9e7a922372f3c47ce4876ed8f505b33a21c868
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -417,7 +417,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -433,7 +433,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -451,7 +451,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -496,7 +496,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -513,7 +513,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -652,14 +652,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1dedf7b9e1c61108fd62adb3ff9c19192fe5be5bde9f66bc856ce7a59a74e07e
-        checksum/init-sysctl: ec0bc3952ad92aa90947b4ead6711acb147163fa3f1f15f559c83e4c98c0fed7
-        checksum/plugins: 5bf4ca3858d2ca7ef8c1e97d5977dbb2a4b4d704df98beba42ba436277dab523
-        checksum/secret: 807bb28402788afbf7ed2850589599e1b813ff70292dcf03bba98d985f1597fb
+        checksum/config: 2ccae4a12f83c4f1a505baae2a2fcecd6e9f20ea2c1bbddf24e029efe74239c6
+        checksum/init-sysctl: 55995fac294489031b26c78276387da8f943db40cd6dd6e7296d64b881cbd3d2
+        checksum/plugins: 1e1e384293084f8f8237d17fcb944bc32ca36815322ab667556ccfc6b41b155f
+        checksum/secret: 047cf065a65b7e1ff6462d998f72f3bf4788580e1bb8831072d1e7c46e752c46
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,7 +574,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: default-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7a6c7ceffd6ccccb89366144202a465909c30675327eded1a436447693b3e228
-        checksum/init-sysctl: 3fe3ef1a03cadeb0adc33d9b248120863c31c1957121e8e8d6542ecb8ddb1d11
-        checksum/plugins: 964bf54990ea94188ce87c81043a02e47e024273f034086905a15d54affd65c0
-        checksum/secret: cbec0af9c2e8a04dbf846dd299c218a0fec379aab533318eff9b260bca85e6dc
+        checksum/config: e7c402d01e7abeb5a9d582a6696a92439e5e03f7c4c912ac8f0b00e9f1666145
+        checksum/init-sysctl: c8e3dade53dc234f6f5bd6b3fe3862416a55afd37cfa18fb44ccb914893837d4
+        checksum/plugins: 6bdd69da931fe6b317feb550626ae9ea972ca62858e113bd010a37224945996a
+        checksum/secret: 2537a33c02560b6b3b483bfd6f7e15f4c9171ed7bf27900c54564de2e962a651
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/default-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,14 +574,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -219,7 +219,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -240,10 +240,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3d91d77117957579798e8184775ecc6b9b37aa677ecdb01261b1fd6cdff1f5a1
-        checksum/init-sysctl: 3180d8c33a14f6bffd84c48f424be02e4040cbf6000b55e9546890bed26dc6ac
-        checksum/plugins: 3b0989c3007960607763f42be763833b44a519f191fc1df6c8f50a50ee5e4791
-        checksum/secret: f425d02cbe285a9c152662134418f9b65a19220379ef5fbcbcbc0cc76847494b
+        checksum/config: 740d832923e6240c26791bf5a3d67af2e58cbc4336e66e2e40444677086ac370
+        checksum/init-sysctl: b1f2b537a7a64fced9e5da9330184b6c3dcc8152421917cdeb7333ad66bfc2ac
+        checksum/plugins: 9609c92c0bb369c118efed4653e2a90d20ea7697434b7d048372e234b1d4fe46
+        checksum/secret: 0741ee59d658c64d811d06f56dd302d904b9ba1ab0c53294df9759c65ac24ab6
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -253,7 +253,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -269,7 +269,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/deployment-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -288,7 +288,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -305,7 +305,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -575,14 +575,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: deployment-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -228,7 +228,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -410,7 +410,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -418,7 +418,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -430,12 +430,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c996005f7ad918b0bbffaebdeb8b48233d5b2edd98fbe163061a02530f8d7ff7
-        checksum/init-sysctl: 2b06a0dfaaa03172b5890aa888b4585c9047e8df69ef8dda4f94e5bacb9ef0d0
-        checksum/plugins: 37add0efb1ff866719ee83a34585d56f216088eb1b6c6764bb5c69a681b8c0f6
-        checksum/secret: eac09e85edac6cd4d7a8480bddda172e0d0c911decb915e3a4db49cde4dd4022
-        checksum/prometheus-config: db219d31d59810faf2ee85e136921bc52f6d916bf7a99d5205e22e63d971fa45
-        checksum/prometheus-ce-config: 219594daacb7394971b9b984e45cf5b01c01fbd08d318adf931e8c6f017ed7ca
+        checksum/config: 41d720cf77ee7288d4b0fb5c81caa59a2cf6cc08dac53bc32ff8c4bb70f66418
+        checksum/init-sysctl: dd75628f7f2a0d302c0a747251a6a83316e48fd8926ed7e295f741a5172806d5
+        checksum/plugins: a6c0917bf839adfabb3bd863eec2dc871706d9df360e72993259516f35d8b2bd
+        checksum/secret: fc8611e58af4da75706a720e8f666296e1b6d87dd450412e8f1289997f0c21a2
+        checksum/prometheus-config: 772e7c47b2a9d605df4e2877cba3e199ca7037cddee78233d3cede60784b1f55
+        checksum/prometheus-ce-config: e417055110772705b6d948bf554146fb17a119770f0e306114bbfbe727db2723
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -445,7 +445,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -461,7 +461,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/duplicated-env-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -486,7 +486,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -536,7 +536,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -559,7 +559,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -693,14 +693,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -231,7 +231,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
     app.kubernetes.io/name: host-path-values.yaml
@@ -433,11 +433,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 399d5ca4f492413ee6365ba325c2914904d4777da7c9dfcd4b90529491aac412
-        checksum/init-fs: 50f83bf58ceaae740d68d876515eb394755e09072739dce6a45cb6e7fcf5ff5a
-        checksum/init-sysctl: 6c8ce36cd533bfc5e3a2fbd7d03c9e3cb4c2464de8b9d2802b1680c3d2771460
-        checksum/plugins: 4fc75f9937c7deea70ee9c78c3b400508c94813b175f9c59d6aaa1b88bc1ae54
-        checksum/secret: 036d9daa1f762632705d45d4de383452873486556fe12c55b37789d779ca7794
+        checksum/config: c1fbdd323f248af5f36a5aaca83457b26fd0f6690872e00ce28937e81fc18efd
+        checksum/init-fs: 15d322fe0b482cdd7dd5317b2ebec2776fbc169afdbbe683ff2548187dacb133
+        checksum/init-sysctl: d0adab53a061e898957a97960f7204512aeb7d77c0272eee28581f4ad3e0218c
+        checksum/plugins: 7c4584110adaa1c9c580fcad69c8c400d525f040db1d174cdd64cae82b787bb8
+        checksum/secret: 4c68af601e64b240db8c38ff1931d0184c1178a19a4cd8cb2992c6c34d8725f3
       labels:
         app: sonarqube
         release: host-path-values.yaml
@@ -533,7 +533,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -649,7 +649,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: host-path-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dd55e96848a6a3327cd566b69461a487cf4966fbb54d82d89ce1dfd82d7ac47b
-        checksum/init-sysctl: 663db35f9852f6b3099a62b9b91c145292b83a94b2c89191382640cc0b7269ec
-        checksum/plugins: 8ed9cbb88c801541b6cf32a9f6cd47491e3b73b2a2a46477f8cb148d2825565b
-        checksum/secret: 5b96f325354ffa16721a8a2b614acf7c4d6f750002104bad8a1d77fc39019446
+        checksum/config: db3e5cb04d0f67066f475163f075aab19bafd7b6af2f4c62eb2da857885f3193
+        checksum/init-sysctl: 4991ed46c30bc2a0fd9f36b48d4e00b1d6a3a793182c902d6e12434fe7728ef2
+        checksum/plugins: d4b0a43f9b3777295b5a4318521a31f5db938004c5752836dbc9d4426fa40156
+        checksum/secret: baa37409426f86d916025bb931636f46445cf21a3a2cec027295cf6d4f258a83
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/http-routes-default-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -599,14 +599,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 37bca1744ba2fd8ab3a40e2f8933d3bd89cde710d63d8e9dc5a7cba981d32423
-        checksum/init-sysctl: 8630638e1f313e8363a983d678d752eb1a0ce9a1cc6efb918d07c6da8548017d
-        checksum/plugins: f9a7d8fb9187df88d7b6b3f5486ee7c0cfb8299a77123a838acff0acca6611fa
-        checksum/secret: 339d59cd573acf232b6dbd9e7e0208b2dbc5ed5d260119ebde8e8a267121f7f3
+        checksum/config: c59b073e091fb142e8d7c19a5eb8725d6cd707c8ce4a1354770a0490eb77fa58
+        checksum/init-sysctl: ea02a58f2b6fcce2ba762638417ae5ff43924ed3f5af6a19ee45d69019fcd61a
+        checksum/plugins: 241904e580826c00cdad0fd3c82b357bb60e8e08d60fec03401638aab6c2f7ab
+        checksum/secret: 367538c3f4301b7366ae8ccae702f2e0b61259c6ef5186dd7f934653b1ad86e2
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/http-routes-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -599,14 +599,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2279a79dc136df8be662331704e6655c669475fda14a0c55477b2909e250c12d
-        checksum/init-sysctl: 9e08297b9e29e191e135dcba4f2b4c409a665c2a3fbef922fecd30604cd0fb53
-        checksum/plugins: f620a06300bb1e1f04569e54c6c2df32c7b89206aeaf5b070ca778d85115a2d9
-        checksum/secret: 780dcfbf45ecf4f49401e3a5362a9f1fe3f1a4164a2e3d075cb8338a04a802b8
+        checksum/config: d33c1a7a7b3c03cb89e7579d6b8676869ae27ae9d2055e2373a6bdba22db19a6
+        checksum/init-sysctl: 02f51cff6b5971ec80ad3497195829f11eb1f72a32a3bd8eb98e6ca2e2bdb1a0
+        checksum/plugins: 32864113c51fe83344eb7aa5df671568c64a61f31460590edda253d0f5ea0896
+        checksum/secret: f2e089ec56cc952b90da8bf567574a64ac55cd4cf87707a0cf7a948e15e9f16e
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ingress-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -607,14 +607,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -39,7 +39,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -149,7 +149,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -514,7 +514,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -822,7 +822,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -830,7 +830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -842,10 +842,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 91af6de6fc04826e66a6d707ba6563c584ace30beaaae360eabd6d9b98023b26
-        checksum/init-sysctl: 985036204ffec80e385b8a44d5446e5a5d338f2880a7227fdbf09376e512c729
-        checksum/plugins: 64842a1a816af1316f926bc5ec3fac95921d5e136fb587af1e735a33617c2a88
-        checksum/secret: 1f7a99196bae614f42eed7c543bfaf7330a3ff309be876935235d827352e97d0
+        checksum/config: 4e233b101e4a7b132211e2b3f1acfbd3bed93978e6747eb17c0c21a3a65222a3
+        checksum/init-sysctl: 9883debb421b83ea1cc8f4153d70d8684b26db4fa6a02d1dc877b423d42799f6
+        checksum/plugins: 78f91a1ced642ff29d7111a0f8ff0b644a775620f956f0236d3a0b1e89f1716c
+        checksum/secret: 2cb9399b713340a7cd747cfbea8758ad7c67368320a5f1ec2ffeebd89307ce3a
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -855,7 +855,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -871,7 +871,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ingress-with-controller.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -890,7 +890,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -907,7 +907,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -1028,7 +1028,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1230,14 +1230,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -201,7 +201,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -383,7 +383,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -391,7 +391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -403,10 +403,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 74b927d8f0c390323805e7db1d8381f463bfffed83d8088382db20017f633587
-        checksum/init-sysctl: 0c0331e3e6d4aa40b725f5787610e7567131a46729b08fd6a9e5038d1749177b
-        checksum/plugins: f10b4972b0ab85b878bbf70dff471c6de61074d636462f847d3ab0325f6a4182
-        checksum/secret: 301aa837b58aae94a1d5e0a1f634d83ab725e244da653aa058f0c6a0c5100e59
+        checksum/config: b78aba4b89250ba407310a3d205a9e119a10e9a16d14c90e2256f5316798e4fd
+        checksum/init-sysctl: 25ef500f0ff97d8d29dce37d5b808c5fc2815a13e92ee665e7a4f31dde85020f
+        checksum/plugins: 8c865355ee44f63e6aae92e128cbb3db2d5de8ff672d47d75666d017304a3b91
+        checksum/secret: 6615880f27f759d411087c1568257ecec3486462c58b7e4c6a0c6ccc03936ee6
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -416,7 +416,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/install-plugins-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -450,7 +450,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -494,7 +494,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -511,7 +511,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -626,14 +626,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c86fec345a4939522d9b17f00a9bcef6138389fea8dce32d537ef7f843eea0d3
-        checksum/init-sysctl: ff15d71048e6f4f5e6a4741baf8f8123a7f36d343187890848f4d6e3b097fea8
-        checksum/plugins: 3b1dbbd60eb50739732bd5b11721a63315e43ba24dfc08633a4c86bf16d1c589
-        checksum/secret: b317f2ecb970eb92fef0bbfbba0227a0b083cc1449dae21300b46d2ca67d762a
+        checksum/config: 706a04a6c87e8f57af43b7206d1e9e662c1c8a55c5f9c33da8eae7e5d3a1816c
+        checksum/init-sysctl: 2713a28ca85faf86f96387c081616b640b1105e1cd6dcf86d0ae6e98016d33aa
+        checksum/plugins: 69ea6b905c704a74980e7ea3c6baded7c8f0d07dd95f9f7fcfe9045cd553f0fd
+        checksum/secret: 18e7c3031540270050baf125ed959652e52fb9c9f79aa4739ff302f40bff9183
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/jdbc-config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,14 +574,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-database
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -145,7 +145,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -160,7 +160,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -252,7 +252,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -320,7 +320,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -502,7 +502,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -510,7 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -522,10 +522,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9b51de4d3e67e1f88941787801ab09ec000237a7d851001412d4d9c4b9b2e189
-        checksum/init-sysctl: 7ca039a1ab9b25a1c35b98511fc18c96da97f26e8fe24d1e998da730bc1a99fc
-        checksum/plugins: 8311d635dd9c043cd4f5bee692ee0b6cc512b7ffd1d79fc995dcb923eb8ae33e
-        checksum/secret: defabbd989b37c70561cc9ceb3f7d4b68189c004fbe303cef62300bb3c63dc79
+        checksum/config: 01160477170d1efd919e7d2bfdf28e7fe39ebde44f303655b3e37687dcc4a27f
+        checksum/init-sysctl: 6c0759aae9f11723a24756dea738b7143bde5ebf68ce5a8d98d34affad7ffb99
+        checksum/plugins: 35ad4a001d070a97d427e417c263eed867dc0d4443af06ecaed5b776baa5a336
+        checksum/secret: 230b63d2032ea9ff225f48f5030f41ceaf281d99389f98ab42a51a01b8968c5a
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -535,7 +535,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -551,7 +551,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/networkpolicy-new-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -587,7 +587,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -696,14 +696,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-database
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -145,7 +145,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -160,7 +160,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -252,7 +252,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -320,7 +320,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -502,7 +502,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -510,7 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -522,10 +522,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ee825483c1348ceb6dc69c81782204f7327aea6f5646c444f37f230117163433
-        checksum/init-sysctl: eac6c670a66624eaf8d554b3d5c1bee0ef19b101fc6f8d80eb992633bdf0ad14
-        checksum/plugins: 555c3d6a68bb2571227083045181e03d9edd749741360328047a50ae9a4f21ea
-        checksum/secret: 322e66767d9a3ce716681033e1beb043b5c1b871b97890ccf74e08492d9b10c6
+        checksum/config: 0b100c2c7f5b325d895b18380ffea270ce3e486ef25d97b0f614bb44254aa820
+        checksum/init-sysctl: c385692e3b833707440c29b3ebd3432a7fc7a0cc1577ff8aebc53f425c29ab49
+        checksum/plugins: a925b11d161430cbf8b977abf22dd9a2e4e9f40c68b34704a3e2367d967369e1
+        checksum/secret: b7ee86f5d5f46a258c4de5f0aaefb9ee3ffb595fd1387f42a907edee48d6767a
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -535,7 +535,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -551,7 +551,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/networkpolicy-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -587,7 +587,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -696,14 +696,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -245,7 +245,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -427,7 +427,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -435,7 +435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -447,12 +447,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: df2be82d560b9d2296b1ef7e32941ccad595adcfb4c019fd6dec9ec93ac65316
-        checksum/init-sysctl: 7cf08a0c31b8135ca49674145656d78789f6582fd4540a9c89c9053897c42f36
-        checksum/plugins: 5b29a502e4c1f1b40919ff6cea4680b7e6054a8552080aad6d7f52d11c8d6017
-        checksum/secret: 040167674919cb06a1ad74688019f27aa88a0353e652bea0214ff39bdf7f697f
-        checksum/prometheus-config: 530b71cef3f304c992302910d40d3f9ab82de36d78c35cb53a6ff7da0ab0fc12
-        checksum/prometheus-ce-config: 529470ed66b3decf6f7191c2be5392c5f0b50a4e02cb203485c8483c7d3cbc68
+        checksum/config: 004f8223ec9cdad53b36a54841a3719c6a41b0faffd00c713bf73258168fe1bc
+        checksum/init-sysctl: 90e62916255a9c30b46da039c1c3e349d81237babf577e59c7c1d5622c1896ea
+        checksum/plugins: 36fe7ba95cd72fd58b3c7b655341b81f660b35f596b2e02b5ace5e421a09a700
+        checksum/secret: 71aaad325cf03bacd343f09c6bb6b0ccc127ed61d68c029a43e91add37dc6ec2
+        checksum/prometheus-config: 99b56534349126d3843f009c65d2121c7c78a261ec3bbf42a533f1e27fcee63f
+        checksum/prometheus-ce-config: 36f8e3412afb0bce086c87023ff7e48bbd0bfb8393f87ca8119e409d3fe17446
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -462,7 +462,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -478,7 +478,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/non-default-security-context-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -496,7 +496,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -538,7 +538,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -582,7 +582,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -605,7 +605,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -738,14 +738,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -775,7 +775,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -788,7 +788,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.6
+        chart: sonarqube-2025.4.7
         release: non-default-security-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -83,7 +83,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -151,7 +151,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -333,7 +333,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -353,9 +353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a0c473c92d46df562517323313e148dc04c0ace49f806ab62e0a7e0320714ccd
-        checksum/plugins: ff55de862304033db32abf42d3fcdb22004d5974e37de3c79a3c11aee4661e92
-        checksum/secret: 164af5f4b3b7609e87af30128d0bdac73e0699c91fc6924b6ef613949706620d
+        checksum/config: e3733c0cee02a60e3207051c9c701b57984fd34e92393677fa10a5baf7ea6f83
+        checksum/plugins: a1beb6f674f548434f170ab0985ae4bd9611426da59901f4ef77982fe60d39e5
+        checksum/secret: f3f78da1e40c10ad7c2a7be67dc497d0127601a801d64c4daa1b3f2b78b1c98c
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -365,7 +365,7 @@ spec:
         {}
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -380,7 +380,7 @@ spec:
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/openshift-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -397,7 +397,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_JDBC_PASSWORD
@@ -496,7 +496,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -522,14 +522,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: openshift-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ffe6889724ffef4c35679498feaa788a88f8338c59f75a2bb1277b39fa950311
-        checksum/init-sysctl: 1d7ec7bf1a40106369a77ff4ff9e05e55914b975373ff594d7f71e89eb359588
-        checksum/plugins: a22e0fd56b6c34be7308fc9a4384b934e68963d431683117eeadbfc97c35aebb
-        checksum/secret: 82216d1f60d0fd36e72cdf419ac2e86bc831c7b7ff9a20f3bf26287347ed8344
+        checksum/config: 2e56ef253452ef542cd83be02ed7a64771e50db97295c0cc303d062030b34a66
+        checksum/init-sysctl: 1074f090bec05f8f4913e8eaa5422398b4a74b969f7342bf23cf70cf8c010570
+        checksum/plugins: c44809e1997ce1f45a4f1c2bc9bf72b5ed9c9ee7a76c60d67937f44b99b54e42
+        checksum/secret: eb4134a38d9bff32ad89adccc0409acc0324e84eae995a6966d199c88cec2378
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/prometheus-monitoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -601,14 +601,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -201,7 +201,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -383,7 +383,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -391,7 +391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -403,10 +403,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f59ab934532a8f43271240a8e5986184c82b65e9be805f89298266c3f4468b7c
-        checksum/init-sysctl: 8bdc88d9bc067bad3f0b84f4f6a83a27ca5ff4a2791e06115bb2d2e11483d79a
-        checksum/plugins: 3622c5678f728978c111daede41df5423377f37e8ab87efcc6aba964243faf17
-        checksum/secret: b5a5c7aafffa8c9da374e084756e8cc44a8072829a57b19e0ddc9d1c27d9de18
+        checksum/config: 0171e8b43a516e79254efca7860b35f833dadbb5c6c9c7db2c5ed1cd0f3537d3
+        checksum/init-sysctl: ae9a6baf9216f753c59a220b405256ff6a3e17289a677b7f55c06b0b478d519b
+        checksum/plugins: c2689ec13b563bb62b1454900dec8278f02fb2c6e34f1ba037d9d95326e033df
+        checksum/secret: e0116efa8f5f3d4b24abd2576bb58a2f037b2d2ca233504c8fae9c9cd463bca3
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -416,7 +416,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-secret-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -450,7 +450,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -494,7 +494,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -511,7 +511,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -626,14 +626,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -231,7 +231,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -421,7 +421,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -433,12 +433,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d56220acbcfa08b4de22a0634c96ae6f94292202cc00663f2836638b64a2f975
-        checksum/init-sysctl: b115322a89c63f74a886c9a7be6450c1c7a98652a65fffacc5f6f3e8a104692b
-        checksum/plugins: f72983dbedaa7b59003b04cd1b8aed1a8091bdf1d59f190e974e015ff2cd3680
-        checksum/secret: ccad759423b5b65f2892c1e875a780947f9eb7c3bddc6a2e62e01d28f47fd2c9
-        checksum/prometheus-config: 7adfed99ef9cf3350abbab5484268655d90b176a366ae43b29a1da419cbdd933
-        checksum/prometheus-ce-config: 2e7854029a262a9dc41ca9d116dceae7d786cb1a9288e1655047bd771c9c2abe
+        checksum/config: 7544e0956136c1ad117f6d5930779d024d2f71d8909a67c6db3f29d915ab5bf4
+        checksum/init-sysctl: e0c471ebf035b53692029042f57b7da2c6b4ba20804e69671c10d18b0e502c11
+        checksum/plugins: a97c5dece92d4c25ece80a2601b7c681714cedc2e744d9610e442a0a49b19e49
+        checksum/secret: b18633e1a52ee790ec399eb7f4c05f7090530419195cb170e00637457d5b5be2
+        checksum/prometheus-config: e36369c70fa1ea0a289270e086117a93c58e8f92d53882ca223a0f68268c6e70
+        checksum/prometheus-ce-config: 301cca8e1456f81fbe51c5d6600e26fd8f943cfe19b9a3519ce5029d60833fdd
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -448,7 +448,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -464,7 +464,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -482,7 +482,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -524,7 +524,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -568,7 +568,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -591,7 +591,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -724,14 +724,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -233,7 +233,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -415,7 +415,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -423,7 +423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -435,11 +435,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d7fd5e3989d3c69850d894953c4a284c7dd4dc1be8c3a3509133f92060a1696
-        checksum/init-fs: abe02e6bec4dbfa29cbc9819d4e1f8f2f0ddc444adc17c349f65701a4a527f32
-        checksum/init-sysctl: 59419f4d9de6ce06962a6cb4611f6b537bd0bde6eab94f1e97efcf22b3f63bdc
-        checksum/plugins: f8db45cecb26b8b59e8fb8beaa7e31be46845ebb2ec627b2c3144ea205a0cec7
-        checksum/secret: 28cb666c964c8ef317bf666a987c6d0a4c3a5524b792da3fbb0d848b11da0b06
+        checksum/config: e81a34a0bbd0833a79f5443e405262013642e3763310aceed245846df28b9f86
+        checksum/init-fs: dfb1aae90a5630230a0145ca41492bba6b75eb6e553b1c0bcceacac445cbaafc
+        checksum/init-sysctl: 6e050e7f33e8aa560fcd0b42343361cf2b91ab2dc21e9b0143db34cbb5e75d93
+        checksum/plugins: ee3eb0a9a234d6be76254473e578a95def8e4200d604fb2dda5cca95284ce20b
+        checksum/secret: 2c0ddb08b0d2ace2e84be760122b17ea4da3fd4e831861d51abd080bacce51f8
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -449,7 +449,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -465,7 +465,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/pvc-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -483,7 +483,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -518,7 +518,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -535,7 +535,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -650,14 +650,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -34,7 +34,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -49,7 +49,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -81,7 +81,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: secret-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -155,7 +155,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -176,7 +176,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -196,10 +196,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47cf820e9f5e35f083277972d167858403b7e6a5c5274e7f7b4a9aad1f087d02
-        checksum/init-sysctl: b374e264dbe715abb830e39d61f603d06717f78f773ced7f4d2a0e830f0a5a8f
-        checksum/plugins: db095ac601c8f1d3c94e476db821ae70f782c956fc2347f2814c5867d40c0e1e
-        checksum/secret: 1959685a0618bae261edb942720614795a4d7883afd7168f36b5f565f8d572af
+        checksum/config: 722f42e09bf5df0f4b8afa2f9fdc55c88d896fa355b8993db4d9057aa275b9f3
+        checksum/init-sysctl: 634b86b2609d8e39c7784719f83eff812ba4561005c1458037119f2a644c2334
+        checksum/plugins: 29db22c35b35e67e27d31f7267a77bdbcc946d73399b713515f51c3b09374cf9
+        checksum/secret: 93eeb4b460d14436afa450d2c0f73bbe49e32c3ecb45b40c871a4ad06adf5b11
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -209,7 +209,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -228,7 +228,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -245,7 +245,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -354,14 +354,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -391,7 +391,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -404,7 +404,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.6
+        chart: sonarqube-2025.4.7
         release: secret-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: service-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -387,7 +387,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -395,7 +395,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -407,10 +407,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7565b54df634eb9901faea3b5b39e9ef480db40d98c9a38095725a41cceff087
-        checksum/init-sysctl: ae41aab43e1727584b3f4720c5f119facbf544ace0028218d5ab82dc6d0fe2e9
-        checksum/plugins: 0ad52b252b5303c7ae4653c0930da44c4d08657266d63cee338acd27e20d4716
-        checksum/secret: e714167687b5d827d0006bb8dacf754ea0048896aa1ae540a394ea728ddc8c7c
+        checksum/config: 8eeac47c9da8b9ef2c09f866d92b3dff6cc289c4eed2d0956f604c7303653f39
+        checksum/init-sysctl: 96ec3148b35cf380caa7b77e966c423f1a7930671f42fb0a58d971992f50fd89
+        checksum/plugins: 13bc4bb3f0cff72a9b5a15369305d4bc4182678f904fc76c7ca3295606edced3
+        checksum/secret: 3aab1441a5bbb94d9b269ea8d4b1740bd499414328b9d319ab809dab2966bb68
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -420,7 +420,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -436,7 +436,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/service-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -455,7 +455,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -472,7 +472,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -581,14 +581,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -37,7 +37,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 42954077ed0dcdc9d514a40f84285d72a58d0b18defacb461c6c15dfae8a3566
-        checksum/init-sysctl: 16859040e13be4166c2cb91f9a0bc7369faabadd9041f3d0979b42200a1ce75d
-        checksum/plugins: 8410d6fe92c8dad3e884b4e3a99ac901d5e13d1b917c6337631fea17b72cc174
-        checksum/secret: 2e7c7d7b7d82879e5ce7597c98fb6b82eb916619d58dc9e90ab1f9bf30d9ba1c
+        checksum/config: df8452d74bd2e5c4dd4e3c9eea63dd7665ddebe2d2e80eb2592c789a62680aa8
+        checksum/init-sysctl: 0080366cbf2c1221b2e17e75b8b84e0ed59f6210f9dae05a65cc2dec4bd22656
+        checksum/plugins: 5e1c212671ee26fd6387ece37414c73f66fb43a8def003366ff5b27310d168c8
+        checksum/secret: 547007bb80547e9a0b2c35d953935b0a2c0a7da695c5b6109389118c74a4de68
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/serviceaccount-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -588,14 +588,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -241,7 +241,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -254,10 +254,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 45609855b179967bb1c2641e9c4e9a7f7b503dfd344dc6c3156cdc8b9d43abf0
-        checksum/init-sysctl: a32f0c8fa84f985722bddb1dc71b573e8da8838413995afba72ae50cb63baef1
-        checksum/plugins: 71f57c6f608a2ef5f47123b4b62ceb2cb143883a98ce696ea44ce50e195606cc
-        checksum/secret: d97232052b64119ea4aed14478b6044a68e5538a296551ab88acb67807e193c5
+        checksum/config: 98bbe708c327183d2b3b9166eb6b64a53a387ed034793520c94fc51c57ec486d
+        checksum/init-sysctl: a0b5ffbe4e8a34de1d666b67e3a636f4ceb347658d9a1c3daf0616a886e3bcf8
+        checksum/plugins: 746ac4e518eb54b21a1dc9045390da698fa5b2ffeb7b87e598bef1c89feadfbe
+        checksum/secret: 836b2faeb78526ad01882c91841a792dd02180343514da6858dee413fdd456b6
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -267,7 +267,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -283,7 +283,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-deployment-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -302,7 +302,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -319,7 +319,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -585,7 +585,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -612,14 +612,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -649,7 +649,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -661,7 +661,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.6
+        chart: sonarqube-2025.4.7
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -672,7 +672,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.4.6-enterprise
+        image: sonarqube:2025.4.7-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e612b0f5e7dad2c1192a63bae74695b91fda50682d91eb1a5dc62f77b571051
-        checksum/init-sysctl: 7a35a251abd8b9fa3e0b5346504e97c579c6bf76733f868f396c23e94b0816bc
-        checksum/plugins: 2e87a330842166f71a6e21a525c502f8500cc264c6cac09b8fdb60b138bf34fc
-        checksum/secret: efe660cf8218e25cf62f1991471476ef8025d60a914756bd9509744ba0f58d76
+        checksum/config: 63ee0c5cbe10eae4317741a6065d65ca389f501d23618b5daa0277b01622195b
+        checksum/init-sysctl: e1b4d7b7baed853b0571fe378e65874fac383b47834426412a0f1c6790f130e6
+        checksum/plugins: e4918951471a8182b81a0f86ff414adac3ce4804c45f04c2849561f8a0d63ed8
+        checksum/secret: f7e7a92d7409b1974467621dd0bb5024803aa77c1a42ba3497a690d25b84490a
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-sts-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -584,7 +584,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -611,14 +611,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -648,7 +648,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -660,7 +660,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.6
+        chart: sonarqube-2025.4.7
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -671,7 +671,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.4.6-enterprise
+        image: sonarqube:2025.4.7-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5b9cfe3b0be9b26d42260f956af62932483eac24d0b8962d97561c16d8fe48f0
-        checksum/init-sysctl: 5c1226e47d7c5e2e5511d87f2c0e015fe1c3ad2f9fb3c3b34669f700daa78e24
-        checksum/plugins: 09c81aca87692f388a8dea030e34f144425a23e3e50d8a6223e0deb480ec282f
-        checksum/secret: cb2329d7e9e34987dee99c85ae2bb0d547d3b63392f06c81e096bdccdba72088
+        checksum/config: d86bc13b5c9b36edf6b910f14cdb9e38f638ff78f8d899e62ca68ab85f140b23
+        checksum/init-sysctl: b86757d9ae01944d25de194622f4d4ff5bcab481e5c1319547b467a7cf7639f6
+        checksum/plugins: bbf07535ee03b40ea37b6517ceaad192fcc37463f2d57f03b37fa8c8511d640f
+        checksum/secret: 557990b9bfadf12a3ec6c7b32620824d08942e4e2900b9a5c99185751b15b6e2
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -584,7 +584,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -611,14 +611,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -648,7 +648,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -660,7 +660,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.6
+        chart: sonarqube-2025.4.7
         release: sonar-web-context-values.yaml
         heritage: Helm
       annotations:
@@ -671,7 +671,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.4.6-enterprise
+        image: sonarqube:2025.4.7-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -231,7 +231,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -421,7 +421,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.6-enterprise"
+    app.kubernetes.io/version: "2025.4.7-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -433,11 +433,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5eb98631feba4e3607c1d4d540cd26aa1fa09f5e881d70b56ca6435354ae2a01
-        checksum/init-fs: daf0b413ce7c0b84da56822f12c93c2e83603be2fd8e64df9ef3a2586a58dc77
-        checksum/init-sysctl: 372b6b60e51edee8c388bd8988fdfcbdea655c04141ade621d41b3d2532ce8d7
-        checksum/plugins: 92d8f0ed9b4920cace990cf581e8d0d7cf5f091633e9fed6a52de36b6fa10d06
-        checksum/secret: 4ea5b13c056f826ab5b692f73ad4238b2afc835c547f786d1447cb66272833b2
+        checksum/config: 52c373fb88ee03029f466a871c32600377d4c86037dd67e535bbffcbdfa329d5
+        checksum/init-fs: bef4dbd75e2173dba4baf51e565838c16cf2e1c8fbc0fb1162286f41a013d0a5
+        checksum/init-sysctl: 01ca0a2d6d63bcb588553e7c75f93825a1f5aaa78fa0dc6a616702d9d64c89e4
+        checksum/plugins: 3e4a804821474a127069b8d0df150cf13e9de700d5922a7a22b03217dbf6942b
+        checksum/secret: 97ee9bbc43c6dfe7e8deedc33ede02c2741760740cef9292487143881a173655
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -448,7 +448,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -468,7 +468,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/template-refactoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -490,7 +490,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -529,7 +529,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.6-enterprise
+          image: sonarqube:2025.4.7-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -546,7 +546,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.6
+              value: 2025.4.7
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -661,14 +661,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.6
+    chart: sonarqube-2025.4.7
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2025.4.6-enterprise"
+      image: "sonarqube:2025.4.7-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -133,7 +133,7 @@ func TestShouldUseImageTag(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2025.4.6-enterprise"
+	expectedContainerImage := "sonarqube:2025.4.7-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -219,7 +219,7 @@ func TestDeveloperEdition(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2025.4.6-developer"
+	expectedContainerImage := "sonarqube:2025.4.7-developer"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2025.4.6-enterprise
+  tag: 2025.4.7-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Version upgrade:**
  - Bumped SonarQube chart and application versions to `2025.4.7` across `sonarqube` and `sonarqube-dce` charts.
  - Updated image tags to `2025.4.7` and recalculated helm `checksum` annotations in unit test fixtures.

<sub>This will update automatically on new commits.</sub>