### PR TITLE
REL-4645 Release SonarQube Server 2026.3.1

### DIFF
--- a/.github/workflows/azure-marketplace.yml
+++ b/.github/workflows/azure-marketplace.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  SQ_VERSION: 2026.3.0
-  SQ_IMAGE_VERSION: 2026.3.0
+  SQ_VERSION: 2026.3.1
+  SQ_IMAGE_VERSION: 2026.3.1
 
 jobs:
   build-azure-staging-app:

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2026.3.0 # Update this value to the desired version
+  GCLOUD_TAG: 2026.3.1 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/azure-marketplace-k8s-app/manifest.yaml
+++ b/azure-marketplace-k8s-app/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: sonarqube
 publisher: "SonarSource"
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
-version: 2026.3.0
+version: 2026.3.1
 helmChart: "./sonarqube-azure"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"

--- a/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2 # Or v1 depending on your Helm version
 name: sonarqube-azure
-version: 2026.3.0
-appVersion: 2026.3.0
+version: 2026.3.1
+appVersion: 2026.3.1
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
 type: application
 dependencies:
   - name: sonarqube 
-    version: 2026.3.0
+    version: 2026.3.1
     repository: "file://../../charts/sonarqube" # Reference to the local SonarQube chart

--- a/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
@@ -22,4 +22,4 @@ global:
       sonarqube:
         registry: __ACR_REGISTRY_PLACEHOLDER__
         image: sonarqube
-        tag: 2026.3.0-enterprise
+        tag: 2026.3.1-enterprise

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.3.1]
+* Upgrade Chart's version to 2026.3.1
+* Upgrade SonarQube Server to 2026.3.1
+
 ## [2026.3.0]
 * Upgrade Chart's version to 2026.3.0
 * Upgrade SonarQube Server to 2026.3.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.3.0
-appVersion: 2026.3.0
+version: 2026.3.1
+appVersion: 2026.3.1
 keywords:
   - coverage
   - security
@@ -36,17 +36,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.3.0"
+      description: "Upgrade Chart's version to 2026.3.1"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.3.0"
-    - kind: added
-      description: "Add applicationNodes.topologySpreadConstraints and searchNodes.topologySpreadConstraints to support spreading pods across topology domains"
-    - kind: added
-      description: "Add MCP (Model Context Protocol) server support via mcp.enabled"
-    - kind: fixed
-      description: "Fix MCP init container and SONARQUBE_URL to respect sonarWebContext when non-root"
-    - kind: changed
-      description: "Update MCP image to sonarsource/sonarqube-mcp:1.18.1.2664"
+      description: "Upgrade SonarQube Server to 2026.3.1"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/
@@ -55,9 +47,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2026.3.0-datacenter-app
+      image: sonarqube:2026.3.1-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2026.3.0-datacenter-search
+      image: sonarqube:2026.3.1-datacenter-search
     - name: sonarqube-mcp
       image: sonarsource/sonarqube-mcp:1.18.1.2664
   charts.openshift.io/name: sonarqube-dce

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2026.3.0`
+Compatible SonarQube Version: `2026.3.1`
 
 Supported Kubernetes Versions: From `1.32` to `1.35`
 Supported Openshift Versions: From `4.17` to `4.20`
@@ -549,7 +549,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.3.0-datacenter-search`                                             |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.3.1-datacenter-search`                                             |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -606,7 +606,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.3.0-datacenter-app`                                                |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.3.1-datacenter-app`                                                |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/ci-values.yaml
+++ b/charts/sonarqube-dce/ci/ci-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 3
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.0-master-datacenter-search"
+    tag: "2026.3.1-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.0-master-datacenter-app"
+    tag: "2026.3.1-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
   webPort: 4023

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -7,7 +7,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.0-master-datacenter-search"
+    tag: "2026.3.1-master-datacenter-search"
     pullPolicy: Always
     pullSecrets:
       - name: pullsecret
@@ -17,7 +17,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.0-master-datacenter-app"
+    tag: "2026.3.1-master-datacenter-app"
     pullPolicy: Always
     pullSecrets:
       - name: pullsecret

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2026.3.0-datacenter-search
+    tag: 2026.3.1-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -156,7 +156,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2026.3.0-datacenter-app
+    tag: 2026.3.1-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.3.1]
+* Upgrade Chart's version to 2026.3.1
+* Upgrade SonarQube Server to 2026.3.1
+
 ## [2026.3.0]
 * Upgrade Chart's version to 2026.3.0
 * Upgrade SonarQube Server to 2026.3.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.3.0
-appVersion: 2026.3.0
+version: 2026.3.1
+appVersion: 2026.3.1
 keywords:
   - coverage
   - security
@@ -41,25 +41,17 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.3.0"
+      description: "Upgrade Chart's version to 2026.3.1"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.3.0"
-    - kind: changed
-      description: "Upgrade SonarQube Community build to 26.5.0.122743"
-    - kind: added
-      description: "Add MCP (Model Context Protocol) server support via mcp.enabled"
-    - kind: fixed
-      description: "Fix MCP init container and SONARQUBE_URL to respect sonarWebContext when non-root"
-    - kind: changed
-      description: "Update MCP image to sonarsource/sonarqube-mcp:1.18.1.2664"
+      description: "Upgrade SonarQube Server to 2026.3.1"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community
       image: sonarqube:26.5.0.122743-community
     - name: sonarqube-developer
-      image: sonarqube:2026.3.0-developer
+      image: sonarqube:2026.3.1-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2026.3.0-enterprise
+      image: sonarqube:2026.3.1-enterprise
     - name: sonarqube-mcp
       image: sonarsource/sonarqube-mcp:1.18.1.2664
   charts.openshift.io/name: sonarqube

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Default Versions
 
-SonarQube Server Version: `2026.3.0`
+SonarQube Server Version: `2026.3.1`
 
 SonarQube Community Build: `26.5.0.122743`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2026.3.0
+export TAG=2026.3.1
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -304,7 +304,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-static-hazelcast-values.yaml
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -357,14 +357,14 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 3c0b2e90ebc44be988d5de9a7db9aea3cdeb2cb9a14a8e0a77cdcd86624e9e35
-        checksum/config: 8965c422513d7bca25aab594ca0fcf92126e13c60590f2fd1ee2fe5df807846a
-        checksum/secret: d739d76d9ae5937ffc8032c8156de57b13117d779fca1b35873833fbedb07df6
+        checksum/plugins: f31636ff454668595b8674a934fcada9f9ff7b3240f9dc8c6cf74cdf91c3fe94
+        checksum/config: 42ffc54e217de96f4cf96d6cb8aca737b411ae5dd029b8735efcd8143dd9d015
+        checksum/secret: 143d11603aab996c88905044b3bcf34e517f90f959fe070d669cf624b450d716
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -403,7 +403,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -437,7 +437,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-static-hazelcast-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-static-hazelcast-values.yaml"
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -600,15 +600,15 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2d44ed1629c99eb98a71de120e9a07c2835c67b7e49336c354d4fbc436c0aae0
-        checksum/init-fs: 945e004393d4ed1dbf98204e7ba468758d71eede96545834db977d45b7180bd8
-        checksum/config: 8965c422513d7bca25aab594ca0fcf92126e13c60590f2fd1ee2fe5df807846a
-        checksum/secret: d739d76d9ae5937ffc8032c8156de57b13117d779fca1b35873833fbedb07df6
+        checksum/init-sysctl: df2f3912f8c47fbba48334006843f53372863c4ffd0470266d00753d1562d80a
+        checksum/init-fs: 05fcea32e4326ff31601325de6baf8d599369856c17bad13f8f89ea5107689db
+        checksum/config: 42ffc54e217de96f4cf96d6cb8aca737b411ae5dd029b8735efcd8143dd9d015
+        checksum/secret: 143d11603aab996c88905044b3bcf34e517f90f959fe070d669cf624b450d716
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -623,7 +623,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -664,7 +664,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -801,14 +801,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-static-hazelcast-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 1a8ace6325ef294e364bb279bd40631838e8d85169391e4e3eb88c27451077f6
-        checksum/config: 642bb1410e4662a547a5ddb07a3fa9313448cdef57988e587daebf3d42812304
-        checksum/secret: c47ce67ba4eec3c976ed574babc21a76bf1816f1ec020a9f9f220c0df9e56a38
+        checksum/plugins: 28e5b4ced71ccc2806f62c9bd3be043ed859af6b32cffef5435bccd59e28d5d4
+        checksum/config: 5f5e3f40caeca3fc7a8d78b539a2bbdfa62d6e327dccb797987dda410cc009d5
+        checksum/secret: c471a16d4690466eedd9d242b6879a8931ce33e1eda9a1d61dc678517a891261
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d7de2501959574712469dc0bb65ba4ccbb7f3ade1d113c07d7454f55311a7179
-        checksum/init-fs: bdb34c2a8a54fb9145a8e34c999cd4eeda6b27731436660d0fce03a77d334371
-        checksum/config: 642bb1410e4662a547a5ddb07a3fa9313448cdef57988e587daebf3d42812304
-        checksum/secret: c47ce67ba4eec3c976ed574babc21a76bf1816f1ec020a9f9f220c0df9e56a38
+        checksum/init-sysctl: e5ba026c69e6b49c760bc44502142d6e961c9a9058b488a76bc04b1d0acd1786
+        checksum/init-fs: af6f6c689600e50fe7a1fc0582809ee01300370b7af177d7db50d3fc859adc10
+        checksum/config: 5f5e3f40caeca3fc7a8d78b539a2bbdfa62d6e327dccb797987dda410cc009d5
+        checksum/secret: c471a16d4690466eedd9d242b6879a8931ce33e1eda9a1d61dc678517a891261
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -739,7 +739,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2026.3.0-datacenter-app"
+    version: "2026.3.1-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -793,14 +793,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: application-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -235,7 +235,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -282,7 +282,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -308,7 +308,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -344,7 +344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -361,14 +361,14 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 1c087afd7bf97c4556e403aee1c447cb40eb722033acc00c9f24cb1622aa78e7
-        checksum/config: db0abaed24dea6e0d49588e692e2e43884aced40ddd745c4c1e1386ed526304c
-        checksum/secret: 738d4242255e13fd0e103505b578c3120f84013512c83f0841f5d670b166f9cf
+        checksum/plugins: 306dbe8ed39704d70af1b92318bf12e34b5e3819d17276d6164dd74503099c95
+        checksum/config: 3b083a44b24e2d8c0d75b703cf596869b3a90b2eef9f45aaa7a1735b52cad50f
+        checksum/secret: c03730026f28f87c31a04c06cc268ffe0b03091fdf9498de75668f25fd26b685
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -392,7 +392,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -420,7 +420,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -448,7 +448,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -584,7 +584,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -593,7 +593,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -622,15 +622,15 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 86ce77e4e19ddc40fbf441a48477ff2d73daa93eaac8d4754627885cea61b3bd
-        checksum/init-fs: 17036366531f1f6b207bb1c2faeccde92d5dcc3632062a7f30607852eda62ac3
-        checksum/config: db0abaed24dea6e0d49588e692e2e43884aced40ddd745c4c1e1386ed526304c
-        checksum/secret: 738d4242255e13fd0e103505b578c3120f84013512c83f0841f5d670b166f9cf
+        checksum/init-sysctl: 792eafd5d9f331926bf6ce2b911a1be46dcaa6a1a26bcf55b787ec7f6277b2d2
+        checksum/init-fs: e6b6531033ab8b9ad2e44525808780aef02cdd61682fc61e00c28534fe214a54
+        checksum/config: 3b083a44b24e2d8c0d75b703cf596869b3a90b2eef9f45aaa7a1735b52cad50f
+        checksum/secret: c03730026f28f87c31a04c06cc268ffe0b03091fdf9498de75668f25fd26b685
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -645,7 +645,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -669,7 +669,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -710,7 +710,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -852,14 +852,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -241,7 +241,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -266,7 +266,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -319,7 +319,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -345,14 +345,14 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 1647c5210fb1b6ec69ccd8f5b3a9a62ca6391bb212de82595e51c3a11534f995
-        checksum/config: 3e392b435c48e259054cf0659cdf6a89096200221ec2b82b2667c3e510ec04bc
-        checksum/secret: 6b53b015700dd9d49f4f5b7a51d694723973da37adf7e38fdee8d43f7139e939
+        checksum/plugins: 9dcc6ae75ec4371587aed60f5e72dfb4a86d9e2e38dc02268cf96d4a6b81b9df
+        checksum/config: adc3cbe9c23b191b990e5ede7af6e83e33cf10bbc48193876f2f0cd8ee3f0880
+        checksum/secret: b028169a2b33e515dcbe9f20ce540b04809101a8e79751fdfb77770b23b1fe4e
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -379,7 +379,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -407,7 +407,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -523,7 +523,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -561,15 +561,15 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f52cb07fc9cededd378e8786cfbe6f08b5cd44db7cc13ea12ecdc7de94216069
-        checksum/init-fs: 89bbbb67fbca3d6ea81cb29abb3faa007c89dd5264937a4b7660001391013013
-        checksum/config: 3e392b435c48e259054cf0659cdf6a89096200221ec2b82b2667c3e510ec04bc
-        checksum/secret: 6b53b015700dd9d49f4f5b7a51d694723973da37adf7e38fdee8d43f7139e939
+        checksum/init-sysctl: 1496761c57f9e4ac50f1ec52aad0f025595718c2edef1602edd3c7edca5960f9
+        checksum/init-fs: a8d7e40b0149186d4a88413b5a00d9d2c691421e73e69a8eec2d83203ba98cbf
+        checksum/config: adc3cbe9c23b191b990e5ede7af6e83e33cf10bbc48193876f2f0cd8ee3f0880
+        checksum/secret: b028169a2b33e515dcbe9f20ce540b04809101a8e79751fdfb77770b23b1fe4e
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -584,7 +584,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -608,7 +608,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -649,7 +649,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -786,14 +786,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f3e16fb75fdcea0077eb18449bbb0934147bb8154eb66ba91bf6c3c1bafeb99f
-        checksum/config: 2521375d9449b8c56b48fc5a3f22712447b427e13a6a2cef4684fccd0db0fb11
-        checksum/secret: 3d4f2f28a56748e4e138aa0c39e42271fddc0b67f81c1220d725376ded5c95e8
+        checksum/plugins: c82d2374f9628b3a4abd05a53b2ba59a7f092ab1807614b05b0a759fd031496e
+        checksum/config: 49e47dbf759615ac2f1013db43294e05be5f2236d648d07ef2f6d006cd0aaef1
+        checksum/secret: 93cfbeba0b2a5598a6052a8e39edab63d552352586f6181705e8d842895b5bc6
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 29a7d783cf644b17e328a78925ddcebaa84a2f4451170d0db7c1e69f1a985481
-        checksum/init-fs: e69878f0b607c200dff9ae3919f8f6feee48efcf44840c1ea43c44d6a777f26d
-        checksum/config: 2521375d9449b8c56b48fc5a3f22712447b427e13a6a2cef4684fccd0db0fb11
-        checksum/secret: 3d4f2f28a56748e4e138aa0c39e42271fddc0b67f81c1220d725376ded5c95e8
+        checksum/init-sysctl: 9b622a236b24c1c4ff2735a909eff743bc74b4491e42230d96b578581839db77
+        checksum/init-fs: c4c830cf6c451265d2ced2819fd1e0752f26f24a27cc362cf903720d8b2b8ed5
+        checksum/config: 49e47dbf759615ac2f1013db43294e05be5f2236d648d07ef2f6d006cd0aaef1
+        checksum/secret: 93cfbeba0b2a5598a6052a8e39edab63d552352586f6181705e8d842895b5bc6
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -789,7 +789,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.0"
+    helm.sh/chart: "sonarqube-dce-2026.3.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 
@@ -246,7 +246,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 
@@ -271,7 +271,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -350,14 +350,14 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5b7c1a30de4f1ee70af8327198eb8411756a7b0743774599d65ca4ae04287e77
-        checksum/config: e6165fd6cbbe46f6971955c77c960cbfa2114a3c2aad9971dc567d3c8ba31593
-        checksum/secret: 1709c88912ccd3052cf16c83c4fef293742f0515b6ae6b62a73ef7dfef99c767
+        checksum/plugins: c27580a68179f955218fa7de062e20098b12fb7242287cfbe4fd9beb64cf48c6
+        checksum/config: 40846996fddae2cb4b10d97cf6a22edeb836c7aad97696409ac6a809b6c9301b
+        checksum/secret: c6c12de657f83d2a313297cd1d79d6b51e02fea6b725355a2dbe16579c52edcc
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -396,7 +396,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -424,7 +424,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -600,15 +600,15 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d38dc2faba2d2e539ff285623665f1ee7515558d4c6d6ec7f3cfc563e0dc7c68
-        checksum/init-fs: df13808e84a0b3d1fed90e181a9bf7a4df20e7fff24eea1f3dbf17d72fca0232
-        checksum/config: e6165fd6cbbe46f6971955c77c960cbfa2114a3c2aad9971dc567d3c8ba31593
-        checksum/secret: 1709c88912ccd3052cf16c83c4fef293742f0515b6ae6b62a73ef7dfef99c767
+        checksum/init-sysctl: d97a7379c7f016db8808419cf4c242d7b572d7decfa42ad51b126cac90363801
+        checksum/init-fs: d68a60c8710170787dc865e8c104c5678815ff6c705551efa1bcb37554802712
+        checksum/config: 40846996fddae2cb4b10d97cf6a22edeb836c7aad97696409ac6a809b6c9301b
+        checksum/secret: c6c12de657f83d2a313297cd1d79d6b51e02fea6b725355a2dbe16579c52edcc
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -623,7 +623,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -659,7 +659,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -700,7 +700,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -858,14 +858,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 619161a855123d174a6c837273a90aa9d7d38e0c0b0d15c488d7a692a8417220
-        checksum/config: 07d1aa88ebfce34107f4ba9c1b2464a793c4bc4fa272ff27f0c72089844089d3
-        checksum/secret: 500336daa12758bb94d32d79c63b2f8426617f6a5ea03696f2e60532fa039549
+        checksum/plugins: 283bc04ceba3f0ab6963b697f4b39a3a181033c63f3bc98775604754165073a9
+        checksum/config: 726fdbeeaedbf8e9061d012e8eafadb16709e13b951bafeb4a815eb365ae1020
+        checksum/secret: b5329ebf7bae4d960b470bb7f6f2f8805841b210858c4c4cc45463b79c7bd30f
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: c9071886114d6f9d74d5415c8809288aca81f05bca166aa6acaf72959038efb3
-        checksum/init-fs: 47eec2e410a99ee50ba697b92b0ab5b922cdeda4d6ea266fac46f4b4f373fcae
-        checksum/config: 07d1aa88ebfce34107f4ba9c1b2464a793c4bc4fa272ff27f0c72089844089d3
-        checksum/secret: 500336daa12758bb94d32d79c63b2f8426617f6a5ea03696f2e60532fa039549
+        checksum/init-sysctl: 59f8c3150d4b8b96689e3a61160b5bb8cd05a1df5d40a43b08010c106fc797e6
+        checksum/init-fs: 24dff34d541fea82048f15fc2f3a5c47454fbfe4be3c473b7c557f4d4d90153f
+        checksum/config: 726fdbeeaedbf8e9061d012e8eafadb16709e13b951bafeb4a815eb365ae1020
+        checksum/secret: b5329ebf7bae4d960b470bb7f6f2f8805841b210858c4c4cc45463b79c7bd30f
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -734,7 +734,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 391dcc5d4f28ff3ab11c3f22a90d48603c92d3017d45605e4ff56dc07a7f1ef8
-        checksum/config: 1818b671126d04ae58cfcb02709d7b1593b90a3ac0887ecd77c0000d4f47e16f
-        checksum/secret: 4d43d75bd92ad1a961cb3ede662df4c8b869bac725c858fc36ed80338335b5d5
+        checksum/plugins: dc7b74a71b55c59eefd203aaece3b2a0ab2f7bc0cb9f27bc41c7f1c56f565536
+        checksum/config: 6e0186abbc9692d7d6ce3fe59ca6270cef7af63ccc53d820b757dda34b3ad3e0
+        checksum/secret: 4295207ffbe26692137cb4c64c97edcdc522068f5d7ef1f372fa85975df9fba3
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 68eda211e6e1ad781b6044cbb826d908f78c5935f127da0c9b9a347a41c43368
-        checksum/init-fs: c164a0c853233d41e32bb4eaa246714445cd2887a52598362323ee9eb1b7277c
-        checksum/config: 1818b671126d04ae58cfcb02709d7b1593b90a3ac0887ecd77c0000d4f47e16f
-        checksum/secret: 4d43d75bd92ad1a961cb3ede662df4c8b869bac725c858fc36ed80338335b5d5
+        checksum/init-sysctl: 03a499c6b114feb4219fcb9f78ba1128ad7d6d64443fcf2c14fa5226a2d8b9e3
+        checksum/init-fs: f21bb830a145f6915489907491fccbde0dd44773829322cae6bb81a761898df8
+        checksum/config: 6e0186abbc9692d7d6ce3fe59ca6270cef7af63ccc53d820b757dda34b3ad3e0
+        checksum/secret: 4295207ffbe26692137cb4c64c97edcdc522068f5d7ef1f372fa85975df9fba3
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -734,14 +734,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 3c6ffa82b15eed5205ffea863c2ec83c74cbb7b777bb6c10b5c5c858646a9419
-        checksum/config: c3245410fe6ec5c9a7c4756ed16dd7fa97d601e36cc41a17689866992e9a1d2c
-        checksum/secret: 307de3947585fbe51fd8b2176f4cf44065a04ff74f7f9c16ffed01773aea5681
+        checksum/plugins: 92ee4c33dbf9eecde927af559f8c8a66d367c3ecc8a70adc8110786457024903
+        checksum/config: ee0c5e9c5bac26d75d8ca8c475f6c1753b8b1f88504dab23d96d7fd1839f82ea
+        checksum/secret: 3b328d3d25b9ece11a209d035d66058b1174c96786dca372dc3de96bd50d7e6b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f20db0b048343a4b4a4d3a896236a81eda8dc335a71aaf0993086cba8e484c28
-        checksum/init-fs: 2be5721ce43b92a3c09f438afc1bac4003ecdcb4872a44a8d5aca19f8499b795
-        checksum/config: c3245410fe6ec5c9a7c4756ed16dd7fa97d601e36cc41a17689866992e9a1d2c
-        checksum/secret: 307de3947585fbe51fd8b2176f4cf44065a04ff74f7f9c16ffed01773aea5681
+        checksum/init-sysctl: ac4492f57d99891a964306d974dbec6f715be48e1cce6ca5cd84a47814204a94
+        checksum/init-fs: 1a14f183184e72df76543175af2b5f859c1bcc4d6780a23b15a087468d506c13
+        checksum/config: ee0c5e9c5bac26d75d8ca8c475f6c1753b8b1f88504dab23d96d7fd1839f82ea
+        checksum/secret: 3b328d3d25b9ece11a209d035d66058b1174c96786dca372dc3de96bd50d7e6b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -734,14 +734,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: deprecation-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9885cc825ba07a61a3982430d634a5266efb7b76d29efc1f2f9a9ddb876bd02b
-        checksum/config: 74203398a743313c15ee905c5ccfa924ac65396c9d1e40a0908b84074f677950
-        checksum/secret: 96662b40852fc39757189a4976cffd8ecc624ddb11bb1c8827198380feb39b54
+        checksum/plugins: a2720076d5306240986b258634977fbc486c722b52275c3c2ce5e5fa2321a79d
+        checksum/config: 35364b1ccf81af82fb55cf46b7b42829674e4a6cec9b6165e83e9f385b9df420
+        checksum/secret: 9efe073cf6cf1287359578b05f159311a465ff1963a50ee5cd301e23336ad070
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -387,7 +387,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -500,7 +500,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -538,15 +538,15 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 042269646127cfcc85017d9a3a7b895c731784c540806f2b746a1f94c385c1ff
-        checksum/init-fs: 2ca8410b32be4894a73af514bad5a591213b4b8f6c967f564dec078163ba26da
-        checksum/config: 74203398a743313c15ee905c5ccfa924ac65396c9d1e40a0908b84074f677950
-        checksum/secret: 96662b40852fc39757189a4976cffd8ecc624ddb11bb1c8827198380feb39b54
+        checksum/init-sysctl: c242a5999873b7b291f22f21d5bad15482e93543ffdde527bfc35b4328bad490
+        checksum/init-fs: 7214842aa9331ea477e38af40d2dc1962861b85591e69fa2bb655b8d0b28b5b5
+        checksum/config: 35364b1ccf81af82fb55cf46b7b42829674e4a6cec9b6165e83e9f385b9df420
+        checksum/secret: 9efe073cf6cf1287359578b05f159311a465ff1963a50ee5cd301e23336ad070
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -561,7 +561,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -602,7 +602,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -739,14 +739,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 40734f5599d8b25f553e782a47433486b64240b5798fa01d145f5a3f47142e5d
-        checksum/config: 6fdbf2a331ef5a4b7040a8e398fc77dba020d39517e102583590a026d650da58
-        checksum/secret: f6b11c6e3e900384c85594e75ef6fb3112d721e5a3b423046f47e20724c845ef
+        checksum/plugins: 9e4ede51cae7c22d1cd2204946fb24fe19802a514bb59b99aac8ceffc7fa8e37
+        checksum/config: 514354160e02076b5fb9bc6f5dc5a2db910cfb5badc07d0956055f1c0322af96
+        checksum/secret: e31c2e7862bf0ba64ee8ec7a3fbf99ff1836d6a31081992fb9f76a29b4866da5
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -499,7 +499,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -537,15 +537,15 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 48c679b04f77c659e0615bee5b9dbb7a06168837c4354728f019890b4a288ecd
-        checksum/init-fs: b50422349bf6a2dfc2ffdf88c61e09d88b041a0b38c9d0f8798cd0eda4505033
-        checksum/config: 6fdbf2a331ef5a4b7040a8e398fc77dba020d39517e102583590a026d650da58
-        checksum/secret: f6b11c6e3e900384c85594e75ef6fb3112d721e5a3b423046f47e20724c845ef
+        checksum/init-sysctl: c0b829263294f76fce22b32a0acdfdca936e8b20cb03099f3b12e409baaa71de
+        checksum/init-fs: c82e189116e6e053beb845d1b447e62b7d12daf5af8197cb563afa4dd4aa0f7c
+        checksum/config: 514354160e02076b5fb9bc6f5dc5a2db910cfb5badc07d0956055f1c0322af96
+        checksum/secret: e31c2e7862bf0ba64ee8ec7a3fbf99ff1836d6a31081992fb9f76a29b4866da5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -560,7 +560,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -601,7 +601,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -743,14 +743,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -343,9 +343,9 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: df8a42463ca1077538babbbe9e61c066bb19a3d977bb457066a5bb9c605283f3
-        checksum/config: a14a2cb17cb23a334192c354d09ec7cef9d2300de384e8fd23565dd905a07115
-        checksum/secret: f930f6e60ba0f5b9d300e91745b3741fb1ebb90b64f6fb9f8fde7754ecd7b09b
+        checksum/plugins: d7c8674c8269a03d94101923934df7e0ffc7ece74ca99bb08c530cedd07a859e
+        checksum/config: a8ae91092e260b5f70772fb85ce5fd932461ed30d2b3c4e7279a9c4c3bd0dd18
+        checksum/secret: 0171727b4d30a83214b23e1131443d72cf4fb9bb969864d04f60e26a03e17816
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -353,7 +353,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -381,7 +381,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -529,7 +529,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -567,15 +567,15 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b55c6638d165ab0108047fb09debf98c2b3c983365a7ac23e82538de4e7e1886
-        checksum/init-fs: a37629364b3f6ebc393a0c9b2294881e4555162f377e19658f4ca64a4f602934
-        checksum/config: a14a2cb17cb23a334192c354d09ec7cef9d2300de384e8fd23565dd905a07115
-        checksum/secret: f930f6e60ba0f5b9d300e91745b3741fb1ebb90b64f6fb9f8fde7754ecd7b09b
+        checksum/init-sysctl: 02fca2701f9f5c95d99d4b60489e159ce75ad2bbc5e69f5fbc8bc3206b9075e8
+        checksum/init-fs: 39e14507e918ed8803c77c8ab6f5df0b14979207d8eb45654bfa4e2525e58e58
+        checksum/config: a8ae91092e260b5f70772fb85ce5fd932461ed30d2b3c4e7279a9c4c3bd0dd18
+        checksum/secret: 0171727b4d30a83214b23e1131443d72cf4fb9bb969864d04f60e26a03e17816
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -590,7 +590,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -631,7 +631,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -768,14 +768,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: hpa-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d04ebe500da0888d5eb475477a49c307de8d96fdce964a8378b3a765375d37b9
-        checksum/config: 04262f465bd5d7630de9385dcef8391fe99b3d73a4510d01a4cc437f19ffdbd0
-        checksum/secret: 25ed745d8979d337e5624cf03f34a5ad25f1224e16c521d65922c3bf3cec73fb
+        checksum/plugins: b87b5662c6d0bcbe43770c7453066bc22b9c6048b82e6734f5b54fc11c6cc474
+        checksum/config: cf80e57e6a18abc93cfb425afdee6bf2646a3cea2ae558e322a29aa78994ac67
+        checksum/secret: 68ad6b63805818f7078a5f1543909ab546e3a53fe0529debf5f17266b6c3904c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 34e47d5d470c1dae2e513fae6d9cf7ca98a0a9d1046790589a908a8b9d33c163
-        checksum/init-fs: 6c681a283b0aa5abebf310f41d8568243a9b93bc08a23f6c1cac602632a1d92e
-        checksum/config: 04262f465bd5d7630de9385dcef8391fe99b3d73a4510d01a4cc437f19ffdbd0
-        checksum/secret: 25ed745d8979d337e5624cf03f34a5ad25f1224e16c521d65922c3bf3cec73fb
+        checksum/init-sysctl: b4351926cb1507ef811be13cede9bd1312756b9fef89c3180c1666a975d75b74
+        checksum/init-fs: 1f45ba04739e0e17660e61348e721595e479575fd1bc850f747d1adf45979820
+        checksum/config: cf80e57e6a18abc93cfb425afdee6bf2646a3cea2ae558e322a29aa78994ac67
+        checksum/secret: 68ad6b63805818f7078a5f1543909ab546e3a53fe0529debf5f17266b6c3904c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -759,14 +759,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ca828c602250e13b6b510ddf315585d7f720c1f829891d73129f5d4624614619
-        checksum/config: 98f2eb99e8e0c6a893fa35c1dca43a132c299dd0111ff6b8ee4082e145d51524
-        checksum/secret: fa43e269ea6e749da770180ebbc2046d1824922a432b7e34ae529cef88b7223d
+        checksum/plugins: ea44473d35e4fef9760800154585a43ca2726f5f9742fbc2bb0698ea3662911f
+        checksum/config: b75bde5826a1b5c7be95eb3288d546bafd8de1dd6a4873843b2f3a8bf2da3c47
+        checksum/secret: 2acca3a21f59d15ffbf239019baffe11f9d6c078b81d1a63509b84933653d55a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 46b64dadede22dba1b11c02ddb3d4d83274491430a0d4b9b00763d79d0074f1c
-        checksum/init-fs: 96c8cc0a154e2beb8bc987da87750d46d2488f7b729ac75c7cfbe4e8c47e2409
-        checksum/config: 98f2eb99e8e0c6a893fa35c1dca43a132c299dd0111ff6b8ee4082e145d51524
-        checksum/secret: fa43e269ea6e749da770180ebbc2046d1824922a432b7e34ae529cef88b7223d
+        checksum/init-sysctl: a9ccca68d18a96dee2b4cde5a100ebbfa897219b9a26cd46689fb08706a262d9
+        checksum/init-fs: a3a528859ca50b95c7e97203556d889a54ef8299d01bf998f9bd3b12f203ead8
+        checksum/config: b75bde5826a1b5c7be95eb3288d546bafd8de1dd6a4873843b2f3a8bf2da3c47
+        checksum/secret: 2acca3a21f59d15ffbf239019baffe11f9d6c078b81d1a63509b84933653d55a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -760,14 +760,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4266d48d0b4b5ac716f3b6687de3427011962446910350f84fbcb7968e9c3890
-        checksum/config: 9d3ddfd6265f1b4941371d9415049bc6ff25a685c2c5c5659639e317089e228f
-        checksum/secret: 63bc967ccd641ffeb785257be9719d9067825ff3a559a6a313f4fd85fa2bc416
+        checksum/plugins: 18beed5eb0e399338c97fc8ef58a7319df5747ac77da3580de340d3f2b607a8a
+        checksum/config: eb6808df24099f897ffed5c3f697e688da50cc1d24234d3b1cf0a7c2b5c5851f
+        checksum/secret: 750e676755f73854c435daafc0686bd44a6acd95b72ca01c70058351c4307aae
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9dde3353b45205680eac63aadc4831a30596852c458448f9e727044bc2d22311
-        checksum/init-fs: 98e785f8c9a54d3249e906781ae5c191421958750b910f58203c3a49504fd2ae
-        checksum/config: 9d3ddfd6265f1b4941371d9415049bc6ff25a685c2c5c5659639e317089e228f
-        checksum/secret: 63bc967ccd641ffeb785257be9719d9067825ff3a559a6a313f4fd85fa2bc416
+        checksum/init-sysctl: 9b22cf69910432bcb8f024fd2fd8dc7cdf93fefeb98d427ac090f763caaefd70
+        checksum/init-fs: 47099013da0247de8e9ccc2f28575f5913284d54e615309d14a16a9d48b8f115
+        checksum/config: eb6808df24099f897ffed5c3f697e688da50cc1d24234d3b1cf0a7c2b5c5851f
+        checksum/secret: 750e676755f73854c435daafc0686bd44a6acd95b72ca01c70058351c4307aae
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -767,14 +767,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -84,7 +84,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -99,7 +99,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -134,7 +134,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -223,7 +223,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -534,7 +534,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -556,7 +556,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -581,7 +581,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -607,7 +607,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -769,7 +769,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -786,9 +786,9 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: afb6073a50670bb7a665484d2626670803367af721bb28fd2b5af8d49edfe47b
-        checksum/config: 34fdb6da877b543a9e980a5ee826691cda4551cb0a8a7c87b81019d598d96f0f
-        checksum/secret: 1b6c829b2974df537ea39bb6740ed6ca8a6f7126957bcfe5bb68a2ec502d8c50
+        checksum/plugins: baf10f53ff043fba61eadb888d757050b0c556b624ca5350ba07169b428e79e0
+        checksum/config: c9fbae5cdffed455ad07c917c898ff6bc041e93fb89c8dc41b9cf71a54be7927
+        checksum/secret: 0fdb613c052f23ea3c5b8560e8c30c04eecb2e8b87edbef27645cd798534422f
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -796,7 +796,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -824,7 +824,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -937,7 +937,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -946,7 +946,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -975,15 +975,15 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: dd8864e21c96a5290205b6913909ee0901de9833debdf640dbaaee410febc089
-        checksum/init-fs: 2266f831cacdbce042cf194d8d3e30eb43d8b173fb90d2ca24e68ad948ee3359
-        checksum/config: 34fdb6da877b543a9e980a5ee826691cda4551cb0a8a7c87b81019d598d96f0f
-        checksum/secret: 1b6c829b2974df537ea39bb6740ed6ca8a6f7126957bcfe5bb68a2ec502d8c50
+        checksum/init-sysctl: 9440e9dd2ad4d6d9c390c3686083a0750f6af685cf9e215603f99d514a01008b
+        checksum/init-fs: 40e3ce817d3c1a4b87309852fc0638ebf98336e5ee4d6d8f7c70f3e87bd05613
+        checksum/config: c9fbae5cdffed455ad07c917c898ff6bc041e93fb89c8dc41b9cf71a54be7927
+        checksum/secret: 0fdb613c052f23ea3c5b8560e8c30c04eecb2e8b87edbef27645cd798534422f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -998,7 +998,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1039,7 +1039,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1188,7 +1188,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1390,14 +1390,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f0191153821712f85ee079e7531fe3f6120e48dbef34cdbcf5c895f68c9a2a09
-        checksum/config: 6a13fe9af2ab5f626c1d393045f13ac86b60c13d5193ce36358da3b832a94c10
-        checksum/secret: b4d05d994940c865a12cfd0875e245024693b5235aa93f52f57d254384688915
+        checksum/plugins: dfb9b91fae1365830ae8a15a1dc3faadfac7b782602e24613ee9678fdf75d5c7
+        checksum/config: 448caeeffaebd8ac550bae0c883f74841fad46a1fa3e42666f5ea6859c812875
+        checksum/secret: c91ee9b263390cd2ff5e8d508e4040e66c7235bbee236758a403e0dbbade9b19
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -580,15 +580,15 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 7c2e03def77ce6f4f762dfb999cd784475ae374e06c35b3f6997c691b9a304b6
-        checksum/init-fs: da7d38aac9703b1fe0ba9f2ea9d494dd8402d9d554435fec33b62e1800ce6bdf
-        checksum/config: 6a13fe9af2ab5f626c1d393045f13ac86b60c13d5193ce36358da3b832a94c10
-        checksum/secret: b4d05d994940c865a12cfd0875e245024693b5235aa93f52f57d254384688915
+        checksum/init-sysctl: b5076be011319263021e164e7ad86687fc472e43abe2221ea700ce3559dd0fde
+        checksum/init-fs: 949ae44cf86146b99c4456dac502cff37621dce7c98356f3cd24ccb57903b3da
+        checksum/config: 448caeeffaebd8ac550bae0c883f74841fad46a1fa3e42666f5ea6859c812875
+        checksum/secret: c91ee9b263390cd2ff5e8d508e4040e66c7235bbee236758a403e0dbbade9b19
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -603,7 +603,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -644,7 +644,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -781,14 +781,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -178,7 +178,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -227,7 +227,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -252,7 +252,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -314,7 +314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -331,9 +331,9 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 827ae763b21dcf35c72e6c053c7e85947df0eeb6851d66843d1f6eb8de0c7f2b
-        checksum/config: d7dfe38076ded703486ab9d9f4a566d9fc2740b72f9533cfa40269f309325f8a
-        checksum/secret: 9e61e6c01c4033cc74a27deef5953fe685bf74ffa3e6d68151e5ede568523158
+        checksum/plugins: 2dedec287c6bbac89397715c80417b3e27f9eff0e42ae65e0b05fe65a6e27586
+        checksum/config: b5d2f98dc13b596bc21e0e650dc10e00bf0dc802a99b1552feb37fc45446ab59
+        checksum/secret: a975e751a7643c17ad4d6c258028a87dab778e761ad67ad7042f0f0c1f071ccd
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -341,7 +341,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -369,7 +369,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -482,7 +482,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -491,7 +491,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -520,15 +520,15 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b6ed189305dcf116cbdfa254b791c8299c28f02f896cca664071aa4a296db0bb
-        checksum/init-fs: b32cc02b317ac54d1fe111c0e596b401a8b61a833659feeb7b0db75d40c7cc3e
-        checksum/config: d7dfe38076ded703486ab9d9f4a566d9fc2740b72f9533cfa40269f309325f8a
-        checksum/secret: 9e61e6c01c4033cc74a27deef5953fe685bf74ffa3e6d68151e5ede568523158
+        checksum/init-sysctl: 10ff6c9dd8a3fa1e2ccd93e12b5cb15a933d0cb4c3914b5808f19d66d09624b8
+        checksum/init-fs: 91b8aeafe6dd6b0d509caba9030c6b6b28c0c23dd1ab6d09a8ba4664f6b4c660
+        checksum/config: b5d2f98dc13b596bc21e0e650dc10e00bf0dc802a99b1552feb37fc45446ab59
+        checksum/secret: a975e751a7643c17ad4d6c258028a87dab778e761ad67ad7042f0f0c1f071ccd
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -543,7 +543,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -584,7 +584,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -721,14 +721,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -240,7 +240,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -262,7 +262,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -287,7 +287,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -313,7 +313,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -340,7 +340,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -358,7 +358,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -445,7 +445,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-tls-values.yaml
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -471,9 +471,9 @@ spec:
         release: mcp-tls-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 3b2a38c9be19817cafc6b8c84aeff24949cf60dec2651d226c19b15767e18b5e
-        checksum/config: fad4723890d9637e7a0875233cd502ef6f853abcef95216531d186407cdd3df7
-        checksum/secret: c194e0e48506bbbddb150374a322d27e53615004d6cfbe2337baf9c70c7d989b
+        checksum/plugins: de58234c2e9995c30068e168db82895de77caf6ed1e155344865d600b58ea972
+        checksum/config: c8be6a560209546ecd137eb7534c466282935f6debd79b5557a6e4c8be2b7e1f
+        checksum/secret: e7e909d43524531c2daf86b48608b685c3249eaa5a76e23e3d612f8440840f99
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -481,7 +481,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -509,7 +509,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-tls-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -626,7 +626,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-tls-values.yaml"
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -664,15 +664,15 @@ spec:
         release: mcp-tls-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: c325436b0117f38945c4a178bc019ad6c0de34b17247f7716d0e714679d08352
-        checksum/init-fs: 1f98a38d7c3472ee869c690f1a5c29437f42342f605b7ee81dcd68e886e955b1
-        checksum/config: fad4723890d9637e7a0875233cd502ef6f853abcef95216531d186407cdd3df7
-        checksum/secret: c194e0e48506bbbddb150374a322d27e53615004d6cfbe2337baf9c70c7d989b
+        checksum/init-sysctl: 66004d733f5980b010f675fa6c036c9816ca0967228c5a8f29b20fd89d10694b
+        checksum/init-fs: c375ac42c28cc1f47d57775212de0c0e14f9140b512288d3c88087f910bfb567
+        checksum/config: c8be6a560209546ecd137eb7534c466282935f6debd79b5557a6e4c8be2b7e1f
+        checksum/secret: e7e909d43524531c2daf86b48608b685c3249eaa5a76e23e3d612f8440840f99
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -687,7 +687,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -728,7 +728,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -865,14 +865,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-tls-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -236,7 +236,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -258,7 +258,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -358,7 +358,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -376,7 +376,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -449,7 +449,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-values.yaml
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -475,9 +475,9 @@ spec:
         release: mcp-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 41e6c887125a70e0a66b6c822112c12062e15bc7b80b7d551f6940a73e862a73
-        checksum/config: 346c1f8b9dca79aef58d687bac73f60f06fbf78f2b4debf3fc80760114e6553e
-        checksum/secret: 1cd34946b66f26aaca7526e926b77a5d1147effc65e0b81b55c1df652b6e8b7e
+        checksum/plugins: e1773c04f446fc914c708b01ed3d2619f8f688f356f31d608c9563707d9e6eea
+        checksum/config: 0665c88f1dee8d54149a7e360ad33ca88e76dab2a9b96873cdcc19043ecefbee
+        checksum/secret: bb629b3aa9f657d48c2932c6fc5af585535ab8d0bf61b65216075c272106c4eb
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -485,7 +485,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -513,7 +513,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -632,7 +632,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-values.yaml"
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -670,15 +670,15 @@ spec:
         release: mcp-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 631723b5204cb0d86f9d3848026760f26f70f7725447e29f983da8dee58a4825
-        checksum/init-fs: 924bd070743b0369447704156f1ef2c5be7d2d6231b9b6ba497571d4a9666c07
-        checksum/config: 346c1f8b9dca79aef58d687bac73f60f06fbf78f2b4debf3fc80760114e6553e
-        checksum/secret: 1cd34946b66f26aaca7526e926b77a5d1147effc65e0b81b55c1df652b6e8b7e
+        checksum/init-sysctl: 1d7e84757431475e86f29d34e41c9b476b576a8e0f1c0a3a5c0e170ba2b0fb70
+        checksum/init-fs: 78f7a0d27467b2c45b789037cb272a4cce1b49536e30a3d1e74bc609b4ef08e8
+        checksum/config: 0665c88f1dee8d54149a7e360ad33ca88e76dab2a9b96873cdcc19043ecefbee
+        checksum/secret: bb629b3aa9f657d48c2932c6fc5af585535ab8d0bf61b65216075c272106c4eb
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -693,7 +693,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -734,7 +734,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -871,14 +871,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -236,7 +236,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -258,7 +258,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -358,7 +358,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -376,7 +376,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -449,7 +449,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-web-context-values.yaml
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -475,9 +475,9 @@ spec:
         release: mcp-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6c150410ac9b45dabef947fa81a7f22bbae6a6d59cb90f8e2f02e5cfe4ace3c3
-        checksum/config: 2b5f123416452fd3d17d421380c8a9f68a397a9d1cff147762b4360eac00ca27
-        checksum/secret: 83ce67ba6b2cb426929b679a576c6d41d1c18d24556887973e23c6c9c74c8691
+        checksum/plugins: eedbab29d8821ed2f27c0d77059bf1ccdaba7ef7df5e65998f967d665a28d41f
+        checksum/config: b225963c0b84fce3f05e16ce8082bf79bdf89707dcf19af656de12d635cded8f
+        checksum/secret: 391cbef6801476efd35aba60ccd0049010ee126ba19aaeab7ce2cce55c1afef0
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -485,7 +485,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -513,7 +513,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -630,7 +630,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-web-context-values.yaml"
@@ -639,7 +639,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -668,15 +668,15 @@ spec:
         release: mcp-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 8180f528405fd3135137649a208c6db34da051fd273e1738740e07422e058509
-        checksum/init-fs: d6a8054332664f9f71b1241b703dd42232d4914d3b5fa856887adc1908479499
-        checksum/config: 2b5f123416452fd3d17d421380c8a9f68a397a9d1cff147762b4360eac00ca27
-        checksum/secret: 83ce67ba6b2cb426929b679a576c6d41d1c18d24556887973e23c6c9c74c8691
+        checksum/init-sysctl: f203e844ed8627572aa4d60945cca8235bfa196586591f38e588d624e54e19c7
+        checksum/init-fs: 487ca7f5a8c6276e87abfd6a8edb52a373acc81a92a5c59e1ddcc7ffa5b60063
+        checksum/config: b225963c0b84fce3f05e16ce8082bf79bdf89707dcf19af656de12d635cded8f
+        checksum/secret: 391cbef6801476efd35aba60ccd0049010ee126ba19aaeab7ce2cce55c1afef0
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -691,7 +691,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -732,7 +732,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -869,14 +869,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 8ce9212c045a90ee25d2c859e8e31272710ca5496e1a729e3fd65ea721508225
-        checksum/config: 29829a0c5cc0321f08b20af903207af0b62c51471dd8608d341b14824c0ebae0
-        checksum/secret: 1d81174e41688751ae3fcde2c66129170d2959315a65714e902089b9e1322ad6
+        checksum/plugins: e6cd08e6685aaffeabb4db5349bc16436e5c10ce9c3fade7a6e830c6e73f720b
+        checksum/config: f5229ebb9801bef959e26c370ed3674ee8712eb293b8ce3744b9963abdc3493e
+        checksum/secret: be836c2e3093fad3b6b476d541f9a65d58416df120e001ffdf94c6fe9416cf5b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -502,7 +502,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -681,15 +681,15 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0cf056b2a2b3f9b0fee54694f1db2c1b9ff5920609c69c772bbb801355d8465c
-        checksum/init-fs: 1debffd13ba06e4507b20dbd4c76a695d37137158fb9a17a0bf23eb0f71900a4
-        checksum/config: 29829a0c5cc0321f08b20af903207af0b62c51471dd8608d341b14824c0ebae0
-        checksum/secret: 1d81174e41688751ae3fcde2c66129170d2959315a65714e902089b9e1322ad6
+        checksum/init-sysctl: 2d132b07cc529baac59fae0c3d79bf587585eaa24a0c2d7eb2a3ade13a1af53d
+        checksum/init-fs: 260681bdf1796a9aac4b3999612d3a0c38db0e2e81088b5df6cdb73d86105775
+        checksum/config: f5229ebb9801bef959e26c370ed3674ee8712eb293b8ce3744b9963abdc3493e
+        checksum/secret: be836c2e3093fad3b6b476d541f9a65d58416df120e001ffdf94c6fe9416cf5b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -704,7 +704,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -745,7 +745,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -882,14 +882,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 53d00fc404b104cc58d1bbe4d3844dba6b5e003ba9df05929b453b011be0e7cc
-        checksum/config: 399a021277f58a6fca600c88b6479a0e2897efaf8299a2d4b2c88e109620cf73
-        checksum/secret: 446470f074d987a10ad0b8dacd426dde025e17d7fe655973feb7545b37294338
+        checksum/plugins: ea390d22770d724123c24ddc203a47338fd34c956b69eb0f39a4d538de5a48a2
+        checksum/config: 1fb40bc48169bd826fbf58da0473d78c6655b72b7c727ddd39e17a97310e87e4
+        checksum/secret: 4a9d50ab5a5fa025119f820b7a1643bfb14818ee3e61b3edb72cdacbb317d7c2
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -502,7 +502,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -681,15 +681,15 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 5314c22b95b4e5fda89a634862bb385d3ad062833b81434c80c3a91b3eedc826
-        checksum/init-fs: dca2a1b05dcebb1808bd92838f14ed32824a256ecd89a0cc8ac7e906aba22450
-        checksum/config: 399a021277f58a6fca600c88b6479a0e2897efaf8299a2d4b2c88e109620cf73
-        checksum/secret: 446470f074d987a10ad0b8dacd426dde025e17d7fe655973feb7545b37294338
+        checksum/init-sysctl: 0aad2c276c9f851ae532e7d69ef144be9ed06e2112800c8af45957268530fdca
+        checksum/init-fs: 6f407902d7728ae5c804d51014d7832795c7ac75591450cc5eda17289df5637d
+        checksum/config: 1fb40bc48169bd826fbf58da0473d78c6655b72b7c727ddd39e17a97310e87e4
+        checksum/secret: 4a9d50ab5a5fa025119f820b7a1643bfb14818ee3e61b3edb72cdacbb317d7c2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -704,7 +704,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -745,7 +745,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -882,14 +882,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c90bc709cd0bf6767d07fa36cd2bacbe6fb72e554304c59a5733d3f886c322f5
-        checksum/config: c8b63aac6ad0b7a37cdb54d79dffeb0b1b852a4acbbdc41df67e0ece4a5c7f4d
-        checksum/secret: deb863cd15df2d7dbe2cc486a3cec789f6d084502ec2bb972a01aa7fc4e3612a
+        checksum/plugins: 37686937453d51a7513ea2615129940016e9f031df0faa073aedfde811503f54
+        checksum/config: 8d57b3a7800fa7fefbfad971965f0b3246103d0644591a49f7d1e11d24f0f20e
+        checksum/secret: fc9ab5b57e26475af8fac70f0444df9824a7486c6687ddc67de67a39d4d5f91a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -519,7 +519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -548,15 +548,15 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 7c614235d24d1fe63301dbf249cc76983bfcf8a96e70f946fa8914960279a96d
-        checksum/init-fs: b52db05e291fa282539b2d3ce8aaf7c7b8236f618669e17f0cb20e1645f0cf05
-        checksum/config: c8b63aac6ad0b7a37cdb54d79dffeb0b1b852a4acbbdc41df67e0ece4a5c7f4d
-        checksum/secret: deb863cd15df2d7dbe2cc486a3cec789f6d084502ec2bb972a01aa7fc4e3612a
+        checksum/init-sysctl: 20a4f415ebeb6887a8b9c84daf9a43d0dba3db44e72db99b77c33df4c8229670
+        checksum/init-fs: 6fe993ef9b4ebf08f2cf70734e9b5f887acb4240f50bdb65fe33e7b416c9f827
+        checksum/config: 8d57b3a7800fa7fefbfad971965f0b3246103d0644591a49f7d1e11d24f0f20e
+        checksum/secret: fc9ab5b57e26475af8fac70f0444df9824a7486c6687ddc67de67a39d4d5f91a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -571,7 +571,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -612,7 +612,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -764,14 +764,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6faf994abdbd862840705aaaacdc384ae423dfea4d65a8f14d2cc2f32e89cd23
-        checksum/config: 2fc0e9a3c141fdfbc21f448a65a5f0d00362f219e64bb5c96a6d0bc62ef661c9
-        checksum/secret: 9264ccebf13a4302046e2db76b49e9d2d085137a60a2b5af3ed21f97c008a190
+        checksum/plugins: eb230315ead764fc3afeb2cc8479a87cda4883593354b6fc8fd3b878e1e405b1
+        checksum/config: 03096787b74765c8ec7186387761be8c345acf003e9ad684d6725fd40cb9fc95
+        checksum/secret: 34067745ed4abc2db2d202173f40a536b90ca9d0600e743299e0ec4d4eeb762d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -519,7 +519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -548,15 +548,15 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: ab599c6f96df8bfc73ea6fa68c82f5cdf604cb1f88284e6b9e43e70e3439604d
-        checksum/init-fs: d2185ed925d73f2544161fa5090644cd9c7346960d8f17d91f36c0291a93c731
-        checksum/config: 2fc0e9a3c141fdfbc21f448a65a5f0d00362f219e64bb5c96a6d0bc62ef661c9
-        checksum/secret: 9264ccebf13a4302046e2db76b49e9d2d085137a60a2b5af3ed21f97c008a190
+        checksum/init-sysctl: 7042f4e86a32443052aafed8d324c0484a2b9b7f2bf21903a4d57ac30bed9c2e
+        checksum/init-fs: 19f145ae076d21e7dcca0622ee347cfcb266feb4e3f82573661c231307cc25d0
+        checksum/config: 03096787b74765c8ec7186387761be8c345acf003e9ad684d6725fd40cb9fc95
+        checksum/secret: 34067745ed4abc2db2d202173f40a536b90ca9d0600e743299e0ec4d4eeb762d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -571,7 +571,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -612,7 +612,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -764,14 +764,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: node-topology-values.yml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -248,7 +248,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -270,7 +270,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -295,7 +295,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -357,7 +357,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -374,16 +374,16 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: def3b384f744ef25ed9d8e560630d3a1146a6973cfce0010d1713a81f998e79a
-        checksum/config: a27834ffa222111dc9a22a860304131d80d5ce057a7ab92689b56ef8a48bca26
-        checksum/secret: 010a81889954d6d962421dfda161cdbe0f091fcb3926c6a7c866a5fb2ca41d4f
-        checksum/prometheus-config: a610ab1c89930873198ff776ac1848dd078ee19e4f366be6188838cc29b216c3
-        checksum/prometheus-ce-config: 9e44137ee43433089d565ecba8636c2f6863b200ea02c841abe0f9bbb38c6c55
+        checksum/plugins: 5133700ae6d6484935650cd101a9c4bf56f9e56c9000ee2a1a9d1a51079e7b85
+        checksum/config: ab475399ae6096853d3234b0c8d006d4a05fc54335a4bc4c741eb2921b0c872d
+        checksum/secret: 0f8bd8af0b8149254c9df544153171a9aa58a38e67029d39595b9c0aff217218
+        checksum/prometheus-config: c1a857f8b6d2af478d799a39b8a087b523fb09a5cfc590f67282726c8a9f672b
+        checksum/prometheus-ce-config: 8f36c6882a457145b2c9f8a3dd0dfce3404a944052efdca685223737b024e245
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -589,7 +589,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -598,7 +598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -627,15 +627,15 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b6e4fd451abb27b8e9452ca8a33b2bb17ec28fccb702e867910dd7fe39a64f27
-        checksum/init-fs: a687fb438a8b61e0012985b31d0854361b8902e52c6f60455b3f33578d8f9929
-        checksum/config: a27834ffa222111dc9a22a860304131d80d5ce057a7ab92689b56ef8a48bca26
-        checksum/secret: 010a81889954d6d962421dfda161cdbe0f091fcb3926c6a7c866a5fb2ca41d4f
+        checksum/init-sysctl: 63e731d23475f2529bc1551c53f2a5578e851c18549fd5bd2e31258aee20f933
+        checksum/init-fs: a51efb422e81180b49386c66b951c1815fd70c1b4a07887b053bed5513d0affc
+        checksum/config: ab475399ae6096853d3234b0c8d006d4a05fc54335a4bc4c741eb2921b0c872d
+        checksum/secret: 0f8bd8af0b8149254c9df544153171a9aa58a38e67029d39595b9c0aff217218
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -650,7 +650,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -691,7 +691,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -865,14 +865,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0d265b55c894157158ef82ec58072f5a5c39fc9256c818892d4c60b667c97995
-        checksum/config: 52e4ccbf6c33b0d8bcab076814584084b106ac16c3762bcf0d2f040b1686622b
-        checksum/secret: e885ea20f04b4fbc3cb329bd972540d309c9e161ced5d236a5a36c8940e48e3e
+        checksum/plugins: 756b4e54881da7cfc66949c5d147df4a18b83181fe5912cff5de667534e7e969
+        checksum/config: f03a1307aa1c549530bf290fd99232bfeef70a9a4b42a93067c9e5b8d0bf07e7
+        checksum/secret: 1e7ffaf81a69695b2254b4beb290e6e9729ca99cb404d4ca7c364a465c38192e
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -580,15 +580,15 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 628902fdd7bd14177388120620b9e2d894bd0cd23c224408fc086537d1a1e7cf
-        checksum/init-fs: 60200991411fe50b91feb0a754accda55c3b48df4082d51a046ff9b28ef9b958
-        checksum/config: 52e4ccbf6c33b0d8bcab076814584084b106ac16c3762bcf0d2f040b1686622b
-        checksum/secret: e885ea20f04b4fbc3cb329bd972540d309c9e161ced5d236a5a36c8940e48e3e
+        checksum/init-sysctl: 442ac48d4f54c147ef66f6119b949eaf44c5533f439ca3369593bcc9e84121bf
+        checksum/init-fs: 108a018264cac458276d1548aa26cd8f06b3a91720dd55eb7a2fb30befd427dd
+        checksum/config: f03a1307aa1c549530bf290fd99232bfeef70a9a4b42a93067c9e5b8d0bf07e7
+        checksum/secret: 1e7ffaf81a69695b2254b4beb290e6e9729ca99cb404d4ca7c364a465c38192e
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -603,7 +603,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -644,7 +644,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -781,14 +781,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -251,7 +251,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -273,7 +273,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -360,7 +360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -377,16 +377,16 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b307aa7af91ebdc04754494939bf89fbcfbb6a78d9cdd1482727677670533461
-        checksum/config: 7f15f72f1fd45b58b03766a37642352b3b9e74ef7bb50065f6ac4a6d15e1f48b
-        checksum/secret: 510eb34822132839fbc23f4ba9ef008364ced5969270d4ae7b8ba94d40145790
-        checksum/prometheus-config: d5764a15b2ee2aed8ab7b23c166c3a277b5accbbee9e1700cadf7fb8c67ca4f6
-        checksum/prometheus-ce-config: 15e01b3438f028f6daaf8feb57cf68262c23794032207aee5252e6d819326a4f
+        checksum/plugins: 36693ca127cede63a959e83c249ba8f0c7363073c9239db4201ffe7d6d4acc74
+        checksum/config: ab4752105af970d276c9e90ae5ae2bc870ef73669c171b13e91f69ba395efbf0
+        checksum/secret: cb74396ff2c974ea1dbb8895c59d42fed9c3e706effe9e321e341cb76fd19e23
+        checksum/prometheus-config: 01aac62b4bf12611035ab342f7f817291ee03f86a6e3a088df8e82799c5c12cd
+        checksum/prometheus-ce-config: 2fa5bf97f1d35de12c12d385ab44cc8e6ebada71a4623726948d923368fd5f12
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -468,7 +468,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -502,7 +502,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -636,7 +636,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -645,7 +645,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -674,15 +674,15 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: dd806fa967ab47f72ab8648bee253aaa281a710e4a5cc8cfbd62750419c7fab9
-        checksum/init-fs: c9d64d8b5b8781d28806be2f6ef140502026e83d5d8e2a08dd9b471673be61e6
-        checksum/config: 7f15f72f1fd45b58b03766a37642352b3b9e74ef7bb50065f6ac4a6d15e1f48b
-        checksum/secret: 510eb34822132839fbc23f4ba9ef008364ced5969270d4ae7b8ba94d40145790
+        checksum/init-sysctl: 81a72da4a9876d25d3b314f508ad8a528698b40ee710a68f7595c40f667c46d7
+        checksum/init-fs: 45cb301ccd1b5d90446d9edb2ff99cabbd264dad2548b4bd8e2d5723b152497a
+        checksum/config: ab4752105af970d276c9e90ae5ae2bc870ef73669c171b13e91f69ba395efbf0
+        checksum/secret: cb74396ff2c974ea1dbb8895c59d42fed9c3e706effe9e321e341cb76fd19e23
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -697,7 +697,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -738,7 +738,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -875,14 +875,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a1da78874bbd4486492e99ec70e44beec9e78b4b84a84dd92dcd9116c29b68f6
-        checksum/config: 8a36be389e5e76f027610e1391707fd3b627801328fddf7f7275968d4ba7075b
-        checksum/secret: 22230af9dd082522353e20bd36baa10a1880dbda8196eddeebc3d1173cecdee7
+        checksum/plugins: b80d87afb2264f4e30c8e1632856f5d38e488ffe6fa4bb55f0f8f339c81dd6b6
+        checksum/config: a1ddd5824e4d02f59f9fb7e41640bc53148b9558ad67e6b0a26f36811caca8f2
+        checksum/secret: 2b89fe88d72ca98103f947553fb8301740314e9a87c759e8505b092593abb914
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -535,15 +535,15 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: adc5962572ea357eb601537582d9018729a34bb01b41e555258ff0ac951732f4
-        checksum/init-fs: 89687ed6bde37ab3f1f7f4d8b0a52086e670808854d30b2786c3c75970319c8f
-        checksum/config: 8a36be389e5e76f027610e1391707fd3b627801328fddf7f7275968d4ba7075b
-        checksum/secret: 22230af9dd082522353e20bd36baa10a1880dbda8196eddeebc3d1173cecdee7
+        checksum/init-sysctl: 2a768dfd1465510a0a7d640975e78df50c912a74a7474485ccca1570053a192b
+        checksum/init-fs: 1d26d1f403336d36bdf235c1709812335040e02588b5ddd39e031fa502e800a5
+        checksum/config: a1ddd5824e4d02f59f9fb7e41640bc53148b9558ad67e6b0a26f36811caca8f2
+        checksum/secret: 2b89fe88d72ca98103f947553fb8301740314e9a87c759e8505b092593abb914
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -558,7 +558,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -599,7 +599,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -736,14 +736,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -204,7 +204,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -230,7 +230,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -283,9 +283,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: bdc82519a98e7f4dba3e860b07abf03db2c98f8cee4fb66bd7aa0c11026e0da9
-        checksum/config: ecf530c3c835ecfb03eb46147bd0a1febcfe2888c7fef4ef0cc883715149a831
-        checksum/secret: 5d9b9c0b0f3e155b60c3dd9be55fbf01dc0f972aa1b405730b83e12746ad8a3a
+        checksum/plugins: b77e78cf67938c37422c53df36cdc73f4372587cfa42d64daa1141e2b03b7aa3
+        checksum/config: 30ed5083e24c629dc9fa9925ee8a7a682662f494bdb418a69184f446c4731d45
+        checksum/secret: 012b3a6b96771ff0bf062ce0d73389bb2e4bf99d431f580f466e3433e1c67c20
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -355,7 +355,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -480,7 +480,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -518,8 +518,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: ecf530c3c835ecfb03eb46147bd0a1febcfe2888c7fef4ef0cc883715149a831
-        checksum/secret: 5d9b9c0b0f3e155b60c3dd9be55fbf01dc0f972aa1b405730b83e12746ad8a3a
+        checksum/config: 30ed5083e24c629dc9fa9925ee8a7a682662f494bdb418a69184f446c4731d45
+        checksum/secret: 012b3a6b96771ff0bf062ce0d73389bb2e4bf99d431f580f466e3433e1c67c20
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -692,7 +692,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 231b133fb8b02b110f9c5accc76441227d6ae710b047e684c599608c78019a4f
-        checksum/config: 11a804711e4e050038e29f07758daf497f96571034555919638c0b60b5648064
-        checksum/secret: 245aa21f4e1a77aa68f8b8f0798885a572d329c42e9f160024d7a463ef9512d9
+        checksum/plugins: 1372eebba6c22f3466843a203054b57247593a6e5160248e0af2041bdab85514
+        checksum/config: c94f08b93c0700fb133dc8eb622df311f76655a38be7c9e8393200c15f90eed4
+        checksum/secret: ea8a9df96097e952b092f4a189d63fd3e0552059c1d1f02641af93b1e95616e5
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 73cd15a8d6f2eabc2ed7db3320ae2ea55a5a567262c26e73b0205317c9cb9560
-        checksum/init-fs: 2d16596e644978a5644d0632f89cb8edf62d5154930ece6988429facaa5f63b0
-        checksum/config: 11a804711e4e050038e29f07758daf497f96571034555919638c0b60b5648064
-        checksum/secret: 245aa21f4e1a77aa68f8b8f0798885a572d329c42e9f160024d7a463ef9512d9
+        checksum/init-sysctl: 6362763f083d420960ba1e9995aae2ba30e5ec22dd2a692e9771482d0729d02f
+        checksum/init-fs: 121fb9a13827715ac9eb901d6a4b1bf935f1ae3edd42d52e36061c09026d3e62
+        checksum/config: c94f08b93c0700fb133dc8eb622df311f76655a38be7c9e8393200c15f90eed4
+        checksum/secret: ea8a9df96097e952b092f4a189d63fd3e0552059c1d1f02641af93b1e95616e5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -789,7 +789,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.0"
+    helm.sh/chart: "sonarqube-dce-2026.3.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -247,7 +247,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -276,7 +276,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -305,7 +305,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -336,7 +336,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -345,7 +345,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -362,9 +362,9 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f0e37536865d3ae654bc86aab8021b93a6e5817427948fbb9f114277e1348721
-        checksum/config: 89d398eeed9c0a487fcaf5e9477fb2428c83e4a8baa89456525d9345bbd3c101
-        checksum/secret: 53c776fa485124acf835be4b131bf28e1f14a9de73053e929ba7acb387ca55be
+        checksum/plugins: c91982da5d708e2028b391a221cb669067aa9203c051798c178e180dbcac516c
+        checksum/config: 44aaab6115409aeb7c18f178f12a7db49d10fb58ee311937b8a883f3f5e6193e
+        checksum/secret: 93048e60d71aedd044a82850729cbe0afac173a727961f2206b1295032e0cd17
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -372,7 +372,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -400,7 +400,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -513,7 +513,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -522,7 +522,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -551,15 +551,15 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 82f5f3d9001f210a0122371bc3a34f0792f0823f088db633a5f38a42065eed15
-        checksum/init-fs: bec266cba60fdfd46ee6e84d4fedbb208ceaf416dc53d4a3e85c234b7a53c352
-        checksum/config: 89d398eeed9c0a487fcaf5e9477fb2428c83e4a8baa89456525d9345bbd3c101
-        checksum/secret: 53c776fa485124acf835be4b131bf28e1f14a9de73053e929ba7acb387ca55be
+        checksum/init-sysctl: edf799638b1bde3ef82c3d395952a45890ee684ed9f54f7c039c1899735bc451
+        checksum/init-fs: d8590afbaf1b7ceda4bff518aced878e306e9415121564464c86a16f8cdee09c
+        checksum/config: 44aaab6115409aeb7c18f178f12a7db49d10fb58ee311937b8a883f3f5e6193e
+        checksum/secret: 93048e60d71aedd044a82850729cbe0afac173a727961f2206b1295032e0cd17
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -574,7 +574,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -615,7 +615,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -752,14 +752,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -49,7 +49,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -63,7 +63,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -77,7 +77,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -92,7 +92,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -111,7 +111,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -124,7 +124,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -227,7 +227,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -249,7 +249,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -274,7 +274,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -336,7 +336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -353,9 +353,9 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 98926c8e40b22a22522445a104d2531837bca94c7ec23827ba6a7f6335c8a6d0
-        checksum/config: 8628742f89a065b67ab2fc901577f640c4402e8e7f4a137a0b789cd5460fc558
-        checksum/secret: 27d609b410f0c63b654a689744330c950316e605ad37e931b242e2320b49fd8f
+        checksum/plugins: 2b67f271fd7a0b087ca435cb64e2d1502eb44f2a7b7cce0335733d3c7eb6ba46
+        checksum/config: 6bb1fdd4d290c887815d8884462d62ce935af377e96e88ef5db52017aff5d2cd
+        checksum/secret: e1f8e90987009bc1c32f652630c77e4dee75e10b36f574b9bce1cde4d5905493
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -363,7 +363,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -391,7 +391,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -504,7 +504,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -513,7 +513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -542,15 +542,15 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3f01600dabdf1ad74e7a2c8332ea7c3e659a8ab81d4c07810d1233d94046ac4b
-        checksum/init-fs: 6086a5741cf136d29e5fa6a0f9a99b296b45ced73acc0c14bda17c49e7a528a4
-        checksum/config: 8628742f89a065b67ab2fc901577f640c4402e8e7f4a137a0b789cd5460fc558
-        checksum/secret: 27d609b410f0c63b654a689744330c950316e605ad37e931b242e2320b49fd8f
+        checksum/init-sysctl: b8fb8feecfffbeda5bff1d6c9b48cd3c79645f7dafe40b2d999a86152fe93963
+        checksum/init-fs: 4c05e112b021bb0788c8f9f3fdaa178b61fe8bb6fc2ca8d895e3275316068362
+        checksum/config: 6bb1fdd4d290c887815d8884462d62ce935af377e96e88ef5db52017aff5d2cd
+        checksum/secret: e1f8e90987009bc1c32f652630c77e4dee75e10b36f574b9bce1cde4d5905493
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -565,7 +565,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -606,7 +606,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -743,14 +743,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -206,7 +206,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -255,7 +255,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -333,7 +333,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -359,14 +359,14 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a1ce45c0783173778e46e84f5ddf227fca4daaf22c0687b6fa169cdc559ebf92
-        checksum/config: 1d05235b7d23bed73f87930595eac53bb04b27d6eca0b5cff2e4df6825592fe4
-        checksum/secret: d84c588881701b614a35bdbccfd6c6af712b3c0280060a992186b484c1cc8b80
+        checksum/plugins: 9f40804cf6414c41287a1fdb86838f1c8ac548329fafa9fd4964485d37f52ea2
+        checksum/config: 47cf3fca18348887dde22f1058a915b1294ce3b428b266d9a6ab8f0b908dc98c
+        checksum/secret: 5e3acadb1f27e04c31bfe40a7fd626c001b1b683fe4ac62a8fcf4cf11fad1446
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -405,7 +405,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -433,7 +433,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -558,7 +558,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -567,7 +567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -596,15 +596,15 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 629b6199748ca89c63ca6aaed4a0b9fe3a3e4e317b1eb9139016b198e084b9d2
-        checksum/init-fs: bb79d707082cce9ae13f8dda562e14aa977896ae280349509fe7b6c00447b45d
-        checksum/config: 1d05235b7d23bed73f87930595eac53bb04b27d6eca0b5cff2e4df6825592fe4
-        checksum/secret: d84c588881701b614a35bdbccfd6c6af712b3c0280060a992186b484c1cc8b80
+        checksum/init-sysctl: bddf2a83da4b91c1554c84ffb7dc4932cc2bb18259f0a019624c018c6500e8dd
+        checksum/init-fs: 86a37754d3aba193e382a18c0b9cf4b775c09445a2699a2dd0d771019bfea8db
+        checksum/config: 47cf3fca18348887dde22f1058a915b1294ce3b428b266d9a6ab8f0b908dc98c
+        checksum/secret: 5e3acadb1f27e04c31bfe40a7fd626c001b1b683fe4ac62a8fcf4cf11fad1446
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -619,7 +619,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -660,7 +660,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -793,7 +793,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -820,14 +820,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -861,7 +861,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.0"
+    helm.sh/chart: "sonarqube-dce-2026.3.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -881,7 +881,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.3.0-datacenter-app
+        image: sonarqube:2026.3.1-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d254af7b86f2dda97d6f2a3062f0eed54001d46770676998f430de64073c43f8
-        checksum/config: 4eb313c735c058f748475692d0d8b16c56ae6a716c885c245b1014bc5782802b
-        checksum/secret: d85907a7e4cbbc90f37a66bf149696c3427e1d8b48ae4a96b4c9821f1c8f0cd2
+        checksum/plugins: 56b2a2acec99e507bf04867153bc6983291c8168eb44ae24f3e4c832eeac6072
+        checksum/config: 339acbb1eb874da02606f31ab38f3155c0e6da1e91130161d0ce515cfe8970cf
+        checksum/secret: 9f6faeab26acb9d702b9e17c9143c0549d5c119042a18c4b37cc729c42957343
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 286459a80f574bc5b3f288b5b39cf8feb1bd66830271bd065bb958b55c07309e
-        checksum/init-fs: 99d73a2b8692348ae8c3c476f59f2bccb45fea7db3f6fc5ba4cf4441d676c9e9
-        checksum/config: 4eb313c735c058f748475692d0d8b16c56ae6a716c885c245b1014bc5782802b
-        checksum/secret: d85907a7e4cbbc90f37a66bf149696c3427e1d8b48ae4a96b4c9821f1c8f0cd2
+        checksum/init-sysctl: e3cc43f355a919f47e6f93c43fba4a9ff56200fb88d89ec54f1ab6b2bd9f2588
+        checksum/init-fs: a50771bed8b8584da796f0dacbb3967ad8a12c5610bd8b282f9a4a865ba31fbf
+        checksum/config: 339acbb1eb874da02606f31ab38f3155c0e6da1e91130161d0ce515cfe8970cf
+        checksum/secret: 9f6faeab26acb9d702b9e17c9143c0549d5c119042a18c4b37cc729c42957343
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -744,7 +744,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -771,14 +771,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -812,7 +812,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.0"
+    helm.sh/chart: "sonarqube-dce-2026.3.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -832,7 +832,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.3.0-datacenter-app
+        image: sonarqube:2026.3.1-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
     app.kubernetes.io/name: topology-spread-constraints-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: topology-spread-constraints-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-app"
+    app.kubernetes.io/version: "2026.3.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: topology-spread-constraints-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 60b5d41d3a1d3c021104a0e5d1880a4418c28b8a230d568b30fb93a0b11c3285
-        checksum/config: 5837383d7c20a0837107a4aa46e302506dc460b528525b677fffa94dca510282
-        checksum/secret: 3569a493250fd0d2862b8d2c416cec6f49d9fcf60f8460484f7fd5c2e01f599e
+        checksum/plugins: c071f141dde7666dfee290e384bb6d137d46414349d7aa8c5903b7704a44977a
+        checksum/config: d4101c93433ad42aeedcb126e19deb994f5a3ae2e468e01061d3320c51f17f03
+        checksum/secret: 4575f20bcd6dba4e8fcf175cfaa79dfb3444d9e8043c7cdfd202c4cf76fa2905
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "topology-spread-constraints-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "topology-spread-constraints-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: topology-spread-constraints-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.0-datacenter-search"
+    app.kubernetes.io/version: "2026.3.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -541,15 +541,15 @@ spec:
         release: topology-spread-constraints-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 33ad3f3b00794814d5ad9de855469a2220d3f78cdf6aa5196713ccc72c016432
-        checksum/init-fs: f871867958c358ede50e84ebb06c5edcb2ab1b33b4a6fec497cb5f91783da3bc
-        checksum/config: 5837383d7c20a0837107a4aa46e302506dc460b528525b677fffa94dca510282
-        checksum/secret: 3569a493250fd0d2862b8d2c416cec6f49d9fcf60f8460484f7fd5c2e01f599e
+        checksum/init-sysctl: ccd8ae42d653da541b1c6fa15298e25ccf739411f41eeac953df27d50812a0c4
+        checksum/init-fs: ce5df7acee6f0b84a084492acb375090c686532e76c46812a1acba095d75ca4f
+        checksum/config: d4101c93433ad42aeedcb126e19deb994f5a3ae2e468e01061d3320c51f17f03
+        checksum/secret: 4575f20bcd6dba4e8fcf175cfaa79dfb3444d9e8043c7cdfd202c4cf76fa2905
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.0-datacenter-app
+          image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.0-datacenter-search"
+          image: "sonarqube:2026.3.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -750,14 +750,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.0
+    chart: sonarqube-dce-2026.3.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: topology-spread-constraints-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-datacenter-app"
+      image: "sonarqube:2026.3.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -151,7 +151,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -159,7 +159,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -171,10 +171,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ecc612e59a228efa8f7261c263ace0b9c850fe1c1b3a1b181829f3702db9da8c
-        checksum/init-sysctl: 62f5f8852c57bf60b0651279e09bf6de384ef194db1b107194016cb8ff7c9fb8
-        checksum/plugins: 89e697ee4eccf8862a1b3edb98fc1b32ecc5333b3d536abe92e7778e33728e94
-        checksum/secret: bf8f0af8d45b01f42dbbb90ed5ae85e9cb132cc481c9ef03ed2cdb0c30a9d362
+        checksum/config: 8c3968bd3aea8e5b7b0d37573b84fa4a85495d3d635a7844e2b2de2e322961b7
+        checksum/init-sysctl: 63d9c0156ae478217e3b8347c41f50f0bef02fb10c22421b318d4f39d169ff56
+        checksum/plugins: 2610c9a8f14fea09dd6a261eea63bcf47148026f61ef029ad50862cd967b9393
+        checksum/secret: 3a8b484d4212e53ccc81155eab1e45fffcd3d3eedf06f54a1d2f908f23efba42
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -184,7 +184,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -213,7 +213,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -231,7 +231,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -264,7 +264,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -403,14 +403,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e63820212cfb92d8728eaf7ffec97408ad9028ed34d25c5b972e9e59e9f52536
-        checksum/init-sysctl: 038a09204ffeff1a83dc071c8173047ee4a8ce7bda0ffbbd667e5c822e9cb7a0
-        checksum/plugins: 9e61dd92cdd625035184139b251ae8a4bf97eacbf6d2deee5ad9f36e3d424fff
-        checksum/secret: 753337b70061325fea011fcf1578b771565725f421d7793dae1a36076aec3fac
+        checksum/config: a94adc47fb8ef925220c47c9573d6d62a0236aa55a0ecaf3573aa0559e609f8d
+        checksum/init-sysctl: 98c93bd4052d1b83f1675eb1d211b6e01eb98f26b48c708d7dbd8b6f0db23d90
+        checksum/plugins: 11dbad3f5ebde2745999aa018dc8c76bd310a401bd4c4c52a001b0a5d553afa5
+        checksum/secret: c6fbdfa6794ee1c798f4981b31e71fed3200705a14a6c8a17eae6de32b828f61
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -197,7 +197,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -216,7 +216,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -233,7 +233,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -338,14 +338,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47bb15cb120516becb95800f8e709fc1643c3eb3ae2c9d3164e1301b799f16b3
-        checksum/init-sysctl: 9c1f6c32b36739c71112b497d31a6992a1c40e56b1e48bfcc025dc1c2de9f481
-        checksum/plugins: f4ef824b864fb444d577a141125c089b16d2f700dbdf934a5316345f94ce1e39
-        checksum/secret: 9279babb4fffd49b4a1935e9a6fd764b405ff536e6a989a18508d5d01d105df7
+        checksum/config: 9bfaf06015ae84dbe90c4964230ad27c22ac6c4f1020a446e23ca5bf371b93cb
+        checksum/init-sysctl: 63deea3e23c68715cfdc2f5765d10c7a0482e5d947bb2b5fad9299525ca0c5d0
+        checksum/plugins: d8fa89cd7c853853f927ac1e82477fa56dcdaf3899fa25ff9105fddcd95850e0
+        checksum/secret: ad4ac2a81cf51b61c786c9fd77681f7533218e8b063467cfb8176942a681d038
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -359,7 +359,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -372,7 +372,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.0
+        chart: sonarqube-2026.3.1
         release: change-admin-password-hook-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f9468d3329f902b8180c8ebbed88432bb5bc72c12110a7ca595d231d362fa895
-        checksum/init-sysctl: ad038d552dfad5b7943514853531b859da2e412c1c05669745faec9724156033
-        checksum/plugins: 217736592233330efe57de3ca6286a92a2d3fb8d214047c918e934180fdfd6f8
-        checksum/secret: 0f29d71aa368f9b456d62d191f0759d606eb2c86ce82f6480cc5f27482a0a82b
+        checksum/config: 2d2489b345b1a7736347072d73bc5c65f68ae1e613a51a37daf54626d6a3864d
+        checksum/init-sysctl: 20ad3d580496a40153ebf968b95ddab399d04c9eee6d4fd566d5240326be56ff
+        checksum/plugins: 85ab978a814970bf6c4260a962c0be6805dcdb5c38a0eae0769ddf82deaad6ba
+        checksum/secret: 9230f4bdaad4fc7173b66b6d6d8111bba8fb95c29c20d0f58b1dc784260420ae
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -58,7 +58,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -139,7 +139,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -159,10 +159,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ba61d58e4f57f32d078f27c3ba22cd699cc87d459761dc98f81a86d1a4539e1b
-        checksum/init-sysctl: c1cd1e90f9c5d4eb394a8b402b145c0275b494250b1634d8d054a59e523016bc
-        checksum/plugins: 4760da43237d1023b7e0599dd54b425a93386b09895a2fc3106251af01305f6c
-        checksum/secret: 9a04fb7a24fadcd052d13e8a804051d933ed1373149d84b1448d0d72130f45c8
+        checksum/config: 8df1f4a64c412f2c0c2126d9c845e5d4b8a93d9bd6d089753d679c912a4933aa
+        checksum/init-sysctl: bdc05c762f3ec69076b4e37b85d3bbe85afa860e78cb3504d51d39a1f4adf969
+        checksum/plugins: 933c30d875d4557651383434c54d70612b9d89f92b790dc2ace050041011445e
+        checksum/secret: eef1cd2f04af4f298a931e52e9d010b035459ca35123f122697bb5c3db210323
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -172,7 +172,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -190,7 +190,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -235,7 +235,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -252,7 +252,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -384,14 +384,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c1632ab3ebacb15eddfb7b39562ed6a7948563e291e1d96e5c00fa4d0e7cdb88
-        checksum/init-sysctl: 33ea765e777b8a9e81161f44e7dff1fbce3eb6f761b032f9962b038d1842befa
-        checksum/plugins: 1baa9a0a3893d834a3e23925c9347febc5239c4319406dbcf11684cf5a0c9d33
-        checksum/secret: 4deb9f8cc0b80dc98b452c61d7f4df3a5c961597a48b50773e8c3eb3fc74568d
+        checksum/config: 1b37cb258a04b6c316845f6604394aff3f31efdb2a4027a8995d036c1c5df975
+        checksum/init-sysctl: 010c92993b89ee3c1990822ad7236fffdba3cf26610b860ed182eb82228bcc94
+        checksum/plugins: 98f344d008a160487a54d1da19795686fb15c672a2d0d94624f5c54722d67e78
+        checksum/secret: af0e5074c066ffd36b9037dd9b1f5912bac8b7e80ea1a613a72b7f941cbe8909
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0af5acd6220ca36c71464441e1bd12c2ce2f7553ab6433bf4d5d5b82aed2100a
-        checksum/init-sysctl: 42a650bc8a4f27172cbbfe6723532faddc594cca8756af47e75db538897064f2
-        checksum/plugins: 1ea2298aba84a4d9e6617568d0bc80c0aca683c6713ca632d939cb9d9879e903
-        checksum/secret: e9a6e2761e5cacfe94d985edf39fad22ceb0b6811e35c3e044a3aa8dc072f850
+        checksum/config: a1e9c51ca00ffb85f89e9eae98e50d7ceecb81a2eadb99dcd1da75dcee2d7421
+        checksum/init-sysctl: 1db4a548219720c0c7bec1dd1099a700a401619bedaf9415ba85ef0c33e39981
+        checksum/plugins: 5a0946c58a79904d12324dbeaa9722d5fa65a311aa03040c0f3a3469d362c7f7
+        checksum/secret: 3993321fef4507a09c8d04ef2474e878c5d65929a80b1f67495c956c5e63710b
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,14 +306,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -156,10 +156,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1c09bf00a689cbc884e497fa64541bad31917d90d625918e5681bcd6a48bcb59
-        checksum/init-sysctl: d2e2fa316009a5a58626b62bfb83397192ab37d0a3e07a9f3d6e76b6d51c0020
-        checksum/plugins: 8467428a550316d5289487c34db176a4e34a831f259d7da440d92bc03a9fb8b6
-        checksum/secret: 6430a4c12450e90f4051885b0933b36284f3a94f1cd4a050c2bc496caf681a25
+        checksum/config: 279d4e29a04af9a533555aebb8acea7d3064cd55ece8c554d5a11def1d1576f0
+        checksum/init-sysctl: d107c3a5acf6a0ba715790f5039e5e195a0a2dc4b565e0af9b2c6d161f2b914c
+        checksum/plugins: d7dae62654c8788c6a81f3ffe4b3bb8fcd2f5e123df852f0bb9fc8c83918e1aa
+        checksum/secret: f7e1878f2a4f401ecb0efc5aae4592bd67dbd65f4650b13e0a2a5d61a9f02525
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -169,7 +169,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -188,7 +188,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -205,7 +205,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -307,14 +307,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: deployment-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -165,7 +165,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -173,7 +173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -185,12 +185,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6b6ba4ace13924c65dd1a943807c08c8422096672411aa57eb0b731a576ad5cb
-        checksum/init-sysctl: 1eff116b21724059cd27c9858d743101a211f65503f9abdf49ced4571f86a58f
-        checksum/plugins: f530d4f053fb803a326222fa0a604f7e1d49f9fdb570234ce5036232f2e3ce51
-        checksum/secret: be115aeb9fa230f7a955ce69c268adbe870aaf36f4d317c8c5a5a046bea92394
-        checksum/prometheus-config: ab0fe9bd5e54d0d368e16a8867961bbc00047f324a605ea29901e419eb899db2
-        checksum/prometheus-ce-config: dfaee48a5f78fb1cccbd26199a8d02d2fe57b37a2a118f2d4bfae5d6ef95c305
+        checksum/config: d56cbbadf7d73bfc69241f1b15ffd3818c0b18100dc9ace6b122a88b27fae206
+        checksum/init-sysctl: e8254b05929a6beaab1a0778f30659c044cf4a46e123cbb565d25857c5d1e58f
+        checksum/plugins: edd4c48968937c034393d16f1e18e81ef268390c3128cd4061b60b01f02d803f
+        checksum/secret: 4126acfbf409df2bc105b06192272bdba551a006e3f1ea2eea1717845abd24f0
+        checksum/prometheus-config: 9cc9ddb2e3c8a6876e20501015d52204b6dd9c2f61d2684387595751f5c59d45
+        checksum/prometheus-ce-config: b2dc89f61d9c38d3cd1c43d3a2d1e404a45d8b9ab6824fad12f244f9188e39ab
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -200,7 +200,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -275,7 +275,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -298,7 +298,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -425,14 +425,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
     app.kubernetes.io/name: host-path-values.yaml
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0d4c6cee184d4a50339e30f5442fd6b1868be940ff95f57ba79a9bc78e8242a4
-        checksum/init-fs: 7beccb6cf08b5d08c7c1dbbb2c319494eaf9e27c9989d828a42b7052a43b765f
-        checksum/init-sysctl: c9fa27efdf1aad5088f40f47318108f4e18200161107202fdaea6d4f3789d0c1
-        checksum/plugins: 56b1ee6086185e44c2533e933a6966d7efe077e1ee0e19f7d40ad5a579b9faa3
-        checksum/secret: 7f770378925c8f152627b6af5815c32df93f6b1497d5099297fed9bafca37d45
+        checksum/config: 664739f3c5feb42e566bde92450121e729f9fb80a5a608cfdd2a23964b5a1396
+        checksum/init-fs: 1bb14f9582d0937846df852e3f24b9e84568c10efd1625cab36e9eee64d2844b
+        checksum/init-sysctl: c2bfc31fc03e35948b6dcddc4a2ffafd797e05a77ac8dd0bd3fcfe7a4728c526
+        checksum/plugins: 6001f9436fa1e68cd960783d85de12d51ed618e319088b1a542b7b53068cefd9
+        checksum/secret: 7f51561785cb18b2d390d2838d61528e1b38323be4028f1207e018463c7504c4
       labels:
         app: sonarqube
         release: host-path-values.yaml
@@ -272,7 +272,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -381,7 +381,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: host-path-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bcbd0e21e0708fd990fd8b5a7e7875c7a152cf2bde35d5897d6bd86504bd3772
-        checksum/init-sysctl: 14994fa68e103730dc34171a772194c8d91d1551c49bd3d4dc9a87f5bd9be94c
-        checksum/plugins: 4c1718412a1f81928338a142983b86db89407b43a61c25341936298c2b51b4aa
-        checksum/secret: 96f61c7cfdedd4ef1d3d65f8d22ca84834e8a1d8980da82d5f68b96a38f8c6e1
+        checksum/config: 1a2e782cfaefd08edc83943a7f9854812fe09a70c3b8bf5c04a93efa1b5348b1
+        checksum/init-sysctl: d40f7e21bf7c4d9d94a9b85cfa72703749d6c2a6e4ae2bd09e87f551f866f74f
+        checksum/plugins: 24caebccc2d75db1a09bd94cf73f50cb3ef24bc1abaf266ac6d254c72e48f228
+        checksum/secret: 1b68fde4912d88ff76b56471b2c4a62ed5fff7733c2a5e476a1212c0d17714fd
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -331,14 +331,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 74b193855258a99b4283bea8b570a0dfbd9b0abe7358303098decc74504fd737
-        checksum/init-sysctl: 3d4b1534893b9115ae381148c9d17a54c6c0f53455f23edefbcf811f27e725ac
-        checksum/plugins: 045d9a196d6b43da330d65e925ecf5708922ac6ea9c18d945b0a34045d679ff4
-        checksum/secret: 3b72ca4071f2e746ed24dbe974f532cdb1747f042a4475f5465028e4a51ffc3c
+        checksum/config: ec66b61660de8f5cef6e5115befb8558d5398c74b2d79c402e289a7346d8cc39
+        checksum/init-sysctl: 4d7639ef3ce5859aa2ade5883482cff4cf5850cf9e181be3e0445fcc10405389
+        checksum/plugins: 77683b6c73c557ebe601b0c7b58103eaf3a9e876ba14c25d4ce90ff672797269
+        checksum/secret: 196258937c3904dfea206d6a699ca2344dac430b580ce4c55e94280703c39cf6
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -332,14 +332,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ce69670092c4d5a8dd316de9e9681a57500db44ed95a21d714b2ee3638f837c
-        checksum/init-sysctl: c5b0483412ea90a251ecb9e0e85b79c4bffd9044cc84358f5eb3a828d6581847
-        checksum/plugins: 6a436eb5dfcbc246293e240867d1a8097d1b65177214c29b4b623afbbd8fca91
-        checksum/secret: 3125391bafd02515eb28df93dcbd1a8c56b078db69929f4614670290feade3a4
+        checksum/config: 2206c9836bd213ecf42687fd32c83f7083fd52d4e2d6fc8afe04600af1a879f1
+        checksum/init-sysctl: 0a8abfd3db223684fab0bc0fe1fe9f939db2588990ca35051e6534d1ba4ea2d5
+        checksum/plugins: ab43faf087f5b9a77c9d40c9c4349af82853243a7707c492bd91fc1b8ddf636a
+        checksum/secret: 1e584e25a432a868aed8f1f7b173574112c7b8557addbf57d3a3204d58880353
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -339,14 +339,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -73,7 +73,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -430,7 +430,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -577,7 +577,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -597,10 +597,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c3b0c04792472cea821277e66315276100e4a420ff46145c486af269df4d65ab
-        checksum/init-sysctl: f41f0f9e858015b2a55ba1f4cf8e6bf753ea754a1f85edae538d88f65b75ff45
-        checksum/plugins: 9ad315704ee3c1e0867fd5edd4999977dd4784cedf262354b662c2228932a1ce
-        checksum/secret: 75488e7972ab9c5c4375ed22f8c34416f24c973422acc23b3a91a6dd473d00c4
+        checksum/config: 622af5e3ba616bcbe6f86d1462fada778fc7b7e159681b810e2742bfa8384188
+        checksum/init-sysctl: 21bee56527e146cb882395d5941d683e804bd31feb64f9751932fa063a0b4465
+        checksum/plugins: bd00805e7a34dc0272942d22acfbde1c91e56fa62babc8c16e971a639becfb63
+        checksum/secret: 83f0ef7ce8385ec9e1e08547369e12f45de2aa6ae07f8a7b249658629c5ef2ac
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -629,7 +629,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -646,7 +646,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -962,14 +962,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d66232a91a960841b4cc5fdd6be91b087162ed63299b1c615cbe5d09e6ff32b8
-        checksum/init-sysctl: dbb09caec7739b4e78c94236ee1414a5b24bdd0fca302787189a4ac2f6e198ed
-        checksum/plugins: 02c0e65e1831677c00a75954dfcf7437444930ecf0fc823654b8e3d312b5ba93
-        checksum/secret: b1f1b964343d31411c96ff3941a54cd05eb47931230c3a02f15bd13644067718
+        checksum/config: 17bc84577c4b93ae15bfdea8c5158348c69b18ccd1558a088d3b6714f12c5067
+        checksum/init-sysctl: ea1eccb35bab5e1f9c8d421904bde50061819bbc1fef30ca8e8f6369d72bc713
+        checksum/plugins: fb5df28d02e18a49e66c68cbe60e0bc504338ee02f7cfec45ee554208d652e22
+        checksum/secret: adb750489a26ad062b3278072f0e55270cafc255fa8da61ddbd6fadee73f707a
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -35,7 +35,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -162,7 +162,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -170,7 +170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,10 +182,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c4ed6c426c74f6367f3e7e04e4f0b7bd138b7e9207753cd2116e3805435618e7
-        checksum/init-sysctl: 221124d7259b8365a5c59ba74ec7c4fc9be9467e61ea840be8b7096e2d0d0d9f
-        checksum/plugins: 7b10b382ca6fb1ea13cb5d69915fc6d751ba2b1bdc4f92dbb5fe4db6b75c7fa2
-        checksum/secret: 4ce4d14a6221076f20cc7bf605d91b95373d70b7775d9ba14d42d285026d1eea
+        checksum/config: 45f2e44cea7c59d6d754f627f7fc400e75c3cd4071f6b38dd4a459406f30d237
+        checksum/init-sysctl: 26ba80aeb8ee0b0418fd2ccb78344a506a3c1841e6991c2089ee699cc952c938
+        checksum/plugins: 348a3cedace93e2fb351359fc36fe0516d10e3ae2dc9529c393ca4a885a43bd6
+        checksum/secret: 803711b9627fe9a7c48391436ddd621c3c83ac9b12ff1b1c9d715319a4f26c2e
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -195,7 +195,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -214,7 +214,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -231,7 +231,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -340,14 +340,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -136,7 +136,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -157,7 +157,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -175,7 +175,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -262,7 +262,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-tls-values.yaml
@@ -270,7 +270,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -282,10 +282,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cb8942ecd25681f3bedb2a240bc56ea13e69c787dd52eeb3aded5f8d9fa34440
-        checksum/init-sysctl: 73ae901854e1010667ac827d88f7bca7f264c29c53a586d348ee982c6d760be5
-        checksum/plugins: 2fcac6c9106b1d1e50712de947dabb27e3367a79621a6ccc5ad6872b316bac0f
-        checksum/secret: afb617ffd0a70d2f4bc8240381ef4c8d9c4003e37f942e47c45f6801f5d14f65
+        checksum/config: ed0b6533b39cdf805d831d83159716edea686eb738cd9ddd692f1fee8ae12dab
+        checksum/init-sysctl: 056c849623c16889959d19cfb34485b49d60c9f47bd2e5a46ed63197dbbee914
+        checksum/plugins: 7c457c72526f29c748043036e2a2fd1cc806535f1d83caf71945b442cfe1adc4
+        checksum/secret: 22df7594c2c96bc223681bfb775f8eea26f196fc8073b3206fa37ab407e82d3c
       labels:
         app: sonarqube
         release: mcp-tls-values.yaml
@@ -295,7 +295,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -314,7 +314,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -331,7 +331,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -437,14 +437,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-tls-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -132,7 +132,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -154,7 +154,7 @@ metadata:
   name: mcp-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -193,7 +193,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -266,7 +266,7 @@ metadata:
   name: mcp-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-values.yaml
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -286,10 +286,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6ca94996c703a808ca15e5c2c72b7830e050c4b18a38aad083905415cbb4a717
-        checksum/init-sysctl: 925f584404d2259994507019a04b374a0a56e62a8369e806ae68259abef6bf71
-        checksum/plugins: 1583426050a83b8770321e9e6cbc752e02e756624e5f8fd3758608fe91cd7817
-        checksum/secret: 61729849b8ff2829fc4daec19b9759f42bdcaae06da1353632bc90308895d3d5
+        checksum/config: f1493982c7840b35b726bcb538ee522daaec5739ac5aecc7344b786bfd69038a
+        checksum/init-sysctl: 51e163c5f58cf66b1e035cc5f0463251fd943d8badd53a0df58af386d3d4a2a3
+        checksum/plugins: fbc2972cf825735e13baf75ad34424495b080c9af89e8546fe472056dfc1f3e3
+        checksum/secret: f43e391bc212f95e2d1142e087f3394d22098fafa89c15a220552c51b3c815de
       labels:
         app: sonarqube
         release: mcp-values.yaml
@@ -299,7 +299,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -318,7 +318,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -335,7 +335,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -443,14 +443,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -132,7 +132,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -154,7 +154,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -193,7 +193,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -266,7 +266,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-web-context-values.yaml
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -286,10 +286,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e6a43247e33b665e1912996ffe87acb18212f7f77fc2c400acd0fdbd89b2663e
-        checksum/init-sysctl: 4b08e8811aa86fefd6c372c930531ff1416b7547ba99944f21490d16911619a2
-        checksum/plugins: 5e993323231464b9b5edf5b5b8db87f21d68865e42c44d543caf82a04da1d4ed
-        checksum/secret: 87a0c78a641d5eafd1b4be808cb50ec5bb1ac4b41e7acd327b78263e238c33fa
+        checksum/config: 5ed27d905d8db1c0c51e8c21851d784c46684697a24cfb1915334b8c16adabc8
+        checksum/init-sysctl: 36ec73060ec362e1d8a13e3d0de8d596f49450ccdfa30828fc012186c684ea6c
+        checksum/plugins: cd3c8c0a5a2310625e95c59676a726b1279c90d1bb4f5015f1484d856f07c313
+        checksum/secret: e95f44415404697227d735f66afde30b4962572926d47dd8bd3dd7dd00a974c0
       labels:
         app: sonarqube
         release: mcp-web-context-values.yaml
@@ -299,7 +299,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -318,7 +318,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -335,7 +335,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -441,14 +441,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 734035cec9a85d6fc844772ebdb1cf40675a6a4ef30795420d1e47ff2de2e097
-        checksum/init-sysctl: d51f5c0bbfdb05fe33a29fea382470a6b103e736b2a484682300ae457077d741
-        checksum/plugins: e8b7e49983d7bb23907c2dcbb1c2c1a8f2481491f7deaaffd1b74132a22a1950
-        checksum/secret: a6010c38ec29b411b1772c3532c3e2dc3cf96b60b2f12ebde53caeb771504b2d
+        checksum/config: 2a6126851f3817fb554978da8f9b36d8deb063f7221e42fba262c61fc94dc6de
+        checksum/init-sysctl: b28cd1bcbdbac730e1c3a1ab87675604a6314f201f4565a8925612713675a702
+        checksum/plugins: c61af4c081abe17af75bb8d18d175562fa1bc25b45b6a259e107d3e9a56cc8c0
+        checksum/secret: de2c4915b3fa878fadaca666ef1c607df38ba0ed89fecdef40ad09137de925ca
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -249,7 +249,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -268,7 +268,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,14 +387,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9973ee44af9fe731cd41192882e77e8569a52c2e6016fec681ec3535ff9b2933
-        checksum/init-sysctl: 5e57c9d5a08d450ce4cfea40d961d67a93bab17f4cec69e62d0df418bee9bb4f
-        checksum/plugins: 7963aa489e6c819fd4d87531e00ea5e2ec7e133ab3c1ca16118b9d8603d0fe27
-        checksum/secret: e049a306d825974ea0f4cf7cf9ea8dbbc108b4d050e007a203181f6a451dbe21
+        checksum/config: 02a637760a13292533e723a778d141d31df102634ad74b037089b3fa9bb51ae5
+        checksum/init-sysctl: 06f69ce467032cd14218cac9ba29f72b341539dd2eacd21c89a68eb2607f42a9
+        checksum/plugins: 9bba3d5ef5eba49e3626d834632b29c2b70270b766205d397bc49c4a06d0d428
+        checksum/secret: 82867d0326a7a391bcd0ab88c69bf0b9e0e2e636cefa3644ddd151e71abb1c7b
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -249,7 +249,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -268,7 +268,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,14 +387,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -182,7 +182,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -190,7 +190,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -202,12 +202,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c7d9e2a0910ade6bada30e1bad33cc386dc55c56ee44beecaff94d0758ac019
-        checksum/init-sysctl: df2622588950ab0194b5096728409281377c0809e81f3dfb7f69bfcfa553ec92
-        checksum/plugins: 86ae04ae6617a2d264d2d3686fa909f5622f706c993821182c9a59edfa8d6296
-        checksum/secret: 6ee0372a2ed02d02e880d98bdc741acc5764bb30b9664a349804ad12232a3434
-        checksum/prometheus-config: 0b1b073ef2868b029d7fbad2b17b3d2dff4a9b576b8c375dcb7ffd2756b89857
-        checksum/prometheus-ce-config: 2c2782fa4a5352d2d9c3711ae34f3c240833158c61c537f075eee79038b20a02
+        checksum/config: ed73063c8e94a38efbaca064c62b7c8da8901879d50a456e0af19caa6e26d713
+        checksum/init-sysctl: 26a379f68c62dcbee8d42c63f4547c5e8f851a2c72cd3f54314ff1bb84898494
+        checksum/plugins: 664212a24b2f5562a2dd881cdfb686749103d6fd6486373681ebcb23785206c0
+        checksum/secret: 606d99b4fa6072944a79dc9abed89ec00b58667125cbeed027e3310258cb9e71
+        checksum/prometheus-config: e3801eef699241d8cc4f0c61fdda7f5a18996ea7e463edd0c9fe6406ea297861
+        checksum/prometheus-ce-config: a1509c3732498ded808b106119aa24d481ba5273053b9e740682f041e046fce1
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -217,7 +217,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -235,7 +235,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -277,7 +277,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -321,7 +321,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -344,7 +344,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -470,14 +470,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -509,7 +509,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -522,7 +522,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.0
+        chart: sonarqube-2026.3.1
         release: non-default-security-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -108,9 +108,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c19968dc3e585ba8be2dd6bb29ed90117c39e8649c2d5b9bef605bedf728014
-        checksum/plugins: 2a511c3e0cd848c898861ded8a637cf67930b132dec83309e2bdf84de76a073b
-        checksum/secret: 45a2ea25b852e5943c80d0e6cdf95d9a98b87d57c937d8ee1297d553534ae8ee
+        checksum/config: 39c39bb4ab4e0abb8552deb40984f57c560956f5151319841cd72120a10e5a1e
+        checksum/plugins: b936af56f567619a0e078db6f5ac3fafc66401fac3fa913739a843785efcf9cf
+        checksum/secret: 699306ab72328062d21649ac3ec7685de00acc8601668ab6b2e317e51ffc0424
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -121,7 +121,7 @@ spec:
       initContainers:
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -138,7 +138,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_WEB_SYSTEMPASSCODE
@@ -230,7 +230,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -256,14 +256,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: openshift-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a37e19b67ef5c9f8b03368a1ddf9b5e77d6493916eae20b7704018452285537e
-        checksum/init-sysctl: 2db0e063abf54ede487f5673dc8c1213ce14fe3aa495c7382350ebffea99ccf9
-        checksum/plugins: e31ce94042ee0653ac6eb0ee5210f49c491f4cfce08dba6b900eddb6b1c3f584
-        checksum/secret: c1bccd480986378813474f1f960ed16b600e701d351cb356f29dc3542a3c2c28
+        checksum/config: a24f66089bb0af5f4e41881458b44648bdf223c611c884d17427d06e996b63ff
+        checksum/init-sysctl: 7183b94e6b8a07eb78d290343a1004b264396cd3f65ff6721860272bb499e1e0
+        checksum/plugins: a60725cf17d8cf3520e837d83e6beae16c0a98f4c86506abb0e858f4a37f92c7
+        checksum/secret: fc8ced1dc379b456a166242007142d38f80dca5444c8cceee12485b5be0a7177
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -333,14 +333,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c0c79f9ff179ecd6db2867d9e9a0cdee945883689f2a6f7cb431b2433b07aaf1
-        checksum/init-sysctl: 03228864c43d8b626134ff9e3d17417dc8a37f5858a12e44834aab0ad78fa81b
-        checksum/plugins: 334353c924d6211b2946e00f4661e025c12adab4a4f84ce11120b000a37d85fb
-        checksum/secret: 462cfe69d69ed57a23a2a6bab8c394b196eff405368196b92252aa46323ce3b2
+        checksum/config: 876594b21dbc4701d9325b43051b2d5d57103e2360fb5d5d79187f08e21deee5
+        checksum/init-sysctl: 6ca463ab421a55cd1d2327f8e80885de74a4ca9f7bfeb3a1cfdd36f1a7404d39
+        checksum/plugins: 49f8bceda5ccf9b79d142dc17c3fd6add702e8b15bc3257292ea65a8bc00edc9
+        checksum/secret: 378288287f9d1e0870c75b3f7fdc1b8b112b575f15700115b2c0bfe9e71a2cc5
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,12 +188,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bc63211ae1b9909fa79c46c1107237b9b687346c3af74eb0e2b38051a21be5ee
-        checksum/init-sysctl: dd5da5f2bbd7640e30aaf5f99fe3973d422b2893444caa2b66112176f061a72a
-        checksum/plugins: fe92325c3d568d25dc69500260f50a43b6c802215f8339fdfc49e06dc4530b4a
-        checksum/secret: b28b6578a49f3dd54c49ff72fdaa104c003a64dcde3a117ee55bbe50d5508cfe
-        checksum/prometheus-config: 323493af79c72b0fc1e13e76cbb1487c01726ef3a0199cea2b2701c0098385ba
-        checksum/prometheus-ce-config: fc5f96c8216e1f5a4c7c4f2537f02fa2789aa005dea3ddcff8cd7e93729b1b44
+        checksum/config: 951e048c2b7343c972807809e55496f96fdfb53976c4f62f17aff18f6c091eaa
+        checksum/init-sysctl: 1ae0bac11e69c29820a53860cd379ff331660c4b4f57c60ccdb76b31cedab7b0
+        checksum/plugins: 806ac9177af47de493c51c3e935010511f970f6dd1193a1778870c62c6c63155
+        checksum/secret: f4936aaaadf958742288045b7202ea658a9d3ae6d191046d709791fd6888af45
+        checksum/prometheus-config: b3661347f25dfd065ebcf6394f1830fb62c8ea0b9c00a9ec235ec7fef307663d
+        checksum/prometheus-ce-config: 123b895f1b852cef9a8b8c10ae8d7e0d395b679337bdbed44b47bc83d4b86846
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -221,7 +221,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -263,7 +263,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -307,7 +307,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -330,7 +330,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -456,14 +456,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -149,7 +149,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -170,7 +170,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -190,11 +190,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f06526f5ec8c53b5c643abcb6c516919ed2dd77d033a8b2582ca3eb32cfdd6ae
-        checksum/init-fs: 964e09b61940f00fb62071882322bfa44db0b452faf372bac0946577b3e03008
-        checksum/init-sysctl: 32ec53facd29f8bf02cd8be0ffd90869332759234eeef7b9b01f963738c1c7c4
-        checksum/plugins: 0dd46feec86ad18b7137bf33d563b74ac285c9f6671b530c9e8f33c0657b9937
-        checksum/secret: d22f919dae4ad14f544f1fbf9397a7e52f72f279e1b481d4060f6880df7c38b8
+        checksum/config: 1b2d501c8be1b5e7dee556c57348273d076bde9c18221fc216ddf2e21130cc5a
+        checksum/init-fs: 9201352620524934b38454f74ddb3bd18de8f072ec3df141e9d398ffdddeb67b
+        checksum/init-sysctl: c836bb84c91997d78acf2c6265ed9e27873b32899b0f283c16730d4df35df377
+        checksum/plugins: e4d6be4c390a4197583e596d7b32d6033aa8b6ed64717fad008abea5f82c3ef6
+        checksum/secret: de923935f02276e16bca72890fd5c190a14756211df87c109d4e8eaa317f26f2
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -204,7 +204,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -222,7 +222,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -257,7 +257,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -274,7 +274,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -382,14 +382,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7181c0eb666b478e002d0eab14c6d2e0483975a45fe2a75758ab7e9c95082ed2
-        checksum/init-sysctl: 7a549ecb8eed58b286b9626dbffbcc5b6855da71f731608072d4ec233648ed16
-        checksum/plugins: c1dba03b0170ab94c5443acdf0e8b8806e0a3e96aa936f8bdd4cb74032c50481
-        checksum/secret: 0c63233357228558cd4d6f1bbfcd86d44352de7f42d73a1902dc15f233d7946d
+        checksum/config: 9ba8d1cab1db7c254169599d3813bb7231b90ce34c7df17fc084d4da661c2824
+        checksum/init-sysctl: 1a512579d737ffb73334b63a8978bc1e1ca2ff872b080e7b0efe868eb8ab336a
+        checksum/plugins: cab9b588fc7a09a1694f5b2f4b8de59e00ea986d3955357bdeabd3c6c9428562
+        checksum/secret: 60fc9b8583d5fa60f3c8d59ead90107380bdefb63978d97847de8707e3aea36a
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -359,7 +359,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -372,7 +372,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.0
+        chart: sonarqube-2026.3.1
         release: secret-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -142,7 +142,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -162,10 +162,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 52e6fa872339a1caa6cf88c76a26a2ca912016ff5116cca1d299930cff6e7ebd
-        checksum/init-sysctl: 91844f152e9d2cc1b13a2f911170a51f48ac0113aefbb17e715c0592fd159dea
-        checksum/plugins: 971a20760dd95ebda7ee5e73ba8c3522b106199dc455ff93283666c67d216861
-        checksum/secret: 57a2ccc87a9a08cfa923711985be9d2de659fbbc4ec65515c44afad01d7e5380
+        checksum/config: 3ba4505478d05b8e4d5fd53b95844b984c6ae09af27ac765a5d856e8eabd2b25
+        checksum/init-sysctl: 090b2f721285969a4475804c2769e455a016481433d419db72b747692e7c2d2b
+        checksum/plugins: c39a0bb83e4795f1ff59568fe2728d83c7b4d1c8d98790a9e1eb0e5d2c969adc
+        checksum/secret: 199468c0cb1896267633d3bf77a5f05c1771550ffb17b07c5a0d7041c8ba3d3c
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -175,7 +175,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -194,7 +194,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -211,7 +211,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -313,14 +313,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -21,7 +21,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bca9cb31b08718b2e00ef9aa9f77fe6e5b080657e27588258c117baeddf72f40
-        checksum/init-sysctl: de9d7d8a429732169f31a4a096b9b4fe2fa8303a99d08a4f5960f1d420a75e74
-        checksum/plugins: ba8751d5de88679c858cca11aaca902225b9980712ff8944aaaa894a649400e7
-        checksum/secret: e7d74590169ebc6d17945dfead0fda7b91d5b3e3a5a59f2991c2011c6d196eb6
+        checksum/config: b39340eed6005d7a5295006fe66f2ba9aa671c2a2567cbd54ac824dff019bdb5
+        checksum/init-sysctl: 49b369d19e72076983a105c836778663807c4b087af0f934c4cc0c43c0f26932
+        checksum/plugins: 9f9b8043d4641726ecbc0ac50c20a731b7715eb3d06b5cf4ef32b8a70e658dcc
+        checksum/secret: 1f8e4e366edd9e5f5f54a8dd2564d4fcdc2e8078f1a7ca5a1145b549f6b3988e
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -170,10 +170,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a20d552b4176faed336476cf4430dca30b61f2351f09ed84ad3c8ffcce6f64c4
-        checksum/init-sysctl: 218b328e784b99eef59f019bf5fa5b6ccec285655d9d3afc8a094bc83f5cab7b
-        checksum/plugins: c61477b0604fcd1bb13795a87f00a41767ea48cb7e4f3d84bdeb24c4b9a35d76
-        checksum/secret: f6d09dc0c64dfb18fca2000a9bf41449a0478054a85a3a5b661bd386234159e0
+        checksum/config: f46201ff241d09912d6eed01a8ea3872a32c0bc8f50164029fbdb760c3cca9e5
+        checksum/init-sysctl: ca016ef4ebf4cf249fc4097d95143d922e8b2d95e02d040771b7a6e9dd38e22f
+        checksum/plugins: 7f830994acee9bbd364c9df979a9013db9cccb3722b494b8c7b8777340d4bb77
+        checksum/secret: c56fcd70d627d84e10baf625246da30232cc4894696272fd706d976564006a0c
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -183,7 +183,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -202,7 +202,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -219,7 +219,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -317,7 +317,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -344,14 +344,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -383,7 +383,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -395,7 +395,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.0
+        chart: sonarqube-2026.3.1
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -406,7 +406,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.3.0-enterprise
+        image: sonarqube:2026.3.1-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8ed770a1b790f3d3036ad9eae503628807b042e9748d955410c16e0e42460736
-        checksum/init-sysctl: 64e2801428cc684fa8df77abd10f2214cea1d6603a536552c970d7f7d65c0eef
-        checksum/plugins: 977deec429ae49b50312312deb8b80eed817e975fb80e1a53b22a0baadc25a97
-        checksum/secret: aa450b90d20602540605c2bf0474706c811c9bec4f8771fc31762495dfa607b8
+        checksum/config: a1589d79fa8e3ba59b68f8e453f6d98969dcb5a6fbff20d97f6a93dce94b19ee
+        checksum/init-sysctl: 957741969a9e46d973acfc3a5787c19ab43182a0c2a0ed22a3704df02ab1500b
+        checksum/plugins: b8e603efc449cd7b9db5c7c43e280750a45ca455fd27cdfbfe8a506c41ef32c1
+        checksum/secret: d89b0d93fe4ba08fd7c75b760eadef8cf62633d1018aa129affae783be9538d2
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -382,7 +382,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -394,7 +394,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.0
+        chart: sonarqube-2026.3.1
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -405,7 +405,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.3.0-enterprise
+        image: sonarqube:2026.3.1-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 90d1c7505751fa69f23cc81c43a530115ec557ec9931e5da2217794d0a2c5e6c
-        checksum/init-sysctl: 1ccb3dfdc967cd5bfef814cc430a730ca9fe966204340b92f2385693caf135ed
-        checksum/plugins: 65e7f8b8381a8c57622bf0b21da4cc66b2ecfb6c6d44713f9ff1bc8cea7766a5
-        checksum/secret: 279cbab1c81379011a7a1e2dbb72c9d4303f315917ba6372e62215160d8af742
+        checksum/config: 297ab96275ee260adabcad3f7e5c146043f553b65b0d94614770845cc59cf91d
+        checksum/init-sysctl: dc51e8b46ab7b58b29a3b21a3a16da5bd04dd777d6aa4d5c4a2922a42c092ab0
+        checksum/plugins: 01cf839f85a04fadbc57e8ee107be6b98c6cbfe6eb4f6eaccae8486d4a8f386b
+        checksum/secret: 37c92278e1770bdd663793d685294e5861c3165d9a2a6f3e1392fc2d091e73fd
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -382,7 +382,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -394,7 +394,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.0
+        chart: sonarqube-2026.3.1
         release: sonar-web-context-values.yaml
         heritage: Helm
       annotations:
@@ -405,7 +405,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.3.0-enterprise
+        image: sonarqube:2026.3.1-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.0-enterprise"
+    app.kubernetes.io/version: "2026.3.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 92b2d5322deb3a918fcc882eeab4e0499cae3ae741f4fd8709500fdc51f36d4e
-        checksum/init-fs: bb0473e6f7342578ef38f9f95e786847f696cacb08671cd3d12249ecfcfa5787
-        checksum/init-sysctl: c814e5ebbe366751df66203b21a25711a1d1c9944fcf2d4bc9c43240e0c55f2c
-        checksum/plugins: a3f985b21689459c3fc4cde84b0a6cd33fd7e8a802ec9f8f2846581c33ab8038
-        checksum/secret: 988edb6d071a107eb366b717a3b00ac6f481513c0890c92756b1c9bc8c0b867d
+        checksum/config: f74e65ff2cab3fd1902b4e0947bd021f33a4ab95eeecf62c9a57d055da8514d6
+        checksum/init-fs: 27939a62b11f6c8af7fa5b0348061057c379751df532d3da93b673177cb98e3a
+        checksum/init-sysctl: 2250f4f499a6552e56b5bac376165e3983c1824989b308d2cedab768e273fb8e
+        checksum/plugins: ba59781f339a9f4f3198a7641c9314b94f512f2188fb1d17ab53a2f7fc5019a8
+        checksum/secret: 5cbdf8a186f4f4f96b45cf98409aa7483cd93d8b3e7e055de4b359747406a8a0
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -264,7 +264,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.0-enterprise
+          image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.0
+              value: 2026.3.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -389,14 +389,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.0
+    chart: sonarqube-2026.3.1
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2026.3.0-enterprise"
+      image: "sonarqube:2026.3.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -133,7 +133,7 @@ func TestShouldUseImageTag(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2026.3.0-enterprise"
+	expectedContainerImage := "sonarqube:2026.3.1-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -219,7 +219,7 @@ func TestDeveloperEdition(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2026.3.0-developer"
+	expectedContainerImage := "sonarqube:2026.3.1-developer"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2026.3.0-enterprise
+  tag: 2026.3.1-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
  - Upgraded SonarQube Helm charts and app versions to `2026.3.1` across all configurations, including `sonarqube` and `sonarqube-dce`.
- **Configuration updates:**
  - Updated image tags to `2026.3.1` in `values.yaml`, CI tests, and Azure/GCP marketplace manifests.
  - Updated `CHANGELOG.md` and `README.md` files for both editions to reflect the new release version.
  - Updated `SQ_VERSION` and `GCLOUD_TAG` environment variables in GitHub workflow files.
- **Test updates:**
  - Regenerated test fixtures for both editions to match the updated chart versions and image tags.

<sub>This will update automatically on new commits.</sub>