### PR TITLE
REL-4651 Release SQCB 26.6

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.4.0]
+* Upgrade Chart's version to 2026.4.0
+* Upgrade SonarQube Community build to 26.6.0.123539
+
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1
 * Upgrade SonarQube Server to 2026.3.1

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.3.1
+version: 2026.4.0
 appVersion: 2026.3.1
 keywords:
   - coverage
@@ -36,9 +36,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.3.1"
+      description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.3.1"
+      description: "Upgrade SonarQube Community build to 26.6.0.123539"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,10 +1,13 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.4.0]
+* Upgrade Chart's version to 2026.4.0
+* Upgrade SonarQube Community build to 26.6.0.123539
+
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1
 * Upgrade SonarQube Server to 2026.3.1
-* Upgrade SonarQube Community build to 26.6.0.123539
 
 ## [2026.3.0]
 * Upgrade Chart's version to 2026.3.0

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1
 * Upgrade SonarQube Server to 2026.3.1
+* Upgrade SonarQube Community build to 26.6.0.123539
 
 ## [2026.3.0]
 * Upgrade Chart's version to 2026.3.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.3.1
+version: 2026.4.0
 appVersion: 2026.3.1
 keywords:
   - coverage
@@ -41,9 +41,7 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.3.1"
-    - kind: changed
-      description: "Upgrade SonarQube Server to 2026.3.1"
+      description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
       description: "Upgrade SonarQube Community build to 26.6.0.123539"
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -44,10 +44,12 @@ annotations:
       description: "Upgrade Chart's version to 2026.3.1"
     - kind: changed
       description: "Upgrade SonarQube Server to 2026.3.1"
+    - kind: changed
+      description: "Upgrade SonarQube Community build to 26.6.0.123539"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community
-      image: sonarqube:26.5.0.122743-community
+      image: sonarqube:26.6.0.123539-community
     - name: sonarqube-developer
       image: sonarqube:2026.3.1-developer
     - name: sonarqube-enterprise

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -16,7 +16,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 SonarQube Server Version: `2026.3.1`
 
-SonarQube Community Build: `26.5.0.122743`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
+SonarQube Community Build: `26.6.0.123539`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 
 ## Kubernetes and Openshift Compatibility
 
@@ -498,7 +498,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `annotations`           | SonarQube Pod annotations                                                                                             | `{}`               |
 | `edition`               | SonarQube Edition to use (`developer` or `enterprise`).                                                               | `None`             |
 | `community.enabled`     | Install SonarQube Community Build. When set to `true`, `edition` must not be set.                                     | `false`            |
-| `community.buildNumber` | The SonarQube Community Build number to install                                                                       | `26.5.0.122743`    |
+| `community.buildNumber` | The SonarQube Community Build number to install                                                                       | `26.6.0.123539`    |
 | `sonarWebContext`       | SonarQube web context, also serve as default value for `ingress.path`, `account.sonarWebContext` and probes path.     | ``                 |
 | `httpProxySecret`       | Should contain `http_proxy`, `https_proxy` and `no_proxy` keys, will supersede every other proxy variables            | ``                 |
 | `httpProxy`             | HTTP proxy for downloading JMX agent and install plugins, will supersede initContainer specific http proxy variables  | ``                 |

--- a/charts/sonarqube/ci/ci-values.yaml
+++ b/charts/sonarqube/ci/ci-values.yaml
@@ -5,7 +5,7 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "26.5.0.122743-master-community"
+  tag: "26.6.0.123539-master-community"
 monitoringPasscode: "test"
 
 resources:

--- a/charts/sonarqube/openshift-verifier/values.yaml
+++ b/charts/sonarqube/openshift-verifier/values.yaml
@@ -10,6 +10,6 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "26.5.0.122743-master-community"
+  tag: "26.6.0.123539-master-community"
 
 monitoringPasscode: "test"

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -54,7 +54,7 @@ OpenShift:
 # Set the chart to use the latest released SonarQube Community Build
 community:
   enabled: false
-  buildNumber: "26.5.0.122743"
+  buildNumber: "26.6.0.123539"
 
 # The following settings are used when deploying to Azure Marketplace
 # global:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -304,7 +304,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-static-hazelcast-values.yaml
@@ -357,9 +357,9 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f31636ff454668595b8674a934fcada9f9ff7b3240f9dc8c6cf74cdf91c3fe94
-        checksum/config: 42ffc54e217de96f4cf96d6cb8aca737b411ae5dd029b8735efcd8143dd9d015
-        checksum/secret: 143d11603aab996c88905044b3bcf34e517f90f959fe070d669cf624b450d716
+        checksum/plugins: e8e6708a15871eb048f5a9cab199fda3c610218d8301a03b441d60dff599fb77
+        checksum/config: c18e54a5b2b346d466c0c8431ce059c36885bcdfe4d563116f0194911c93bfa9
+        checksum/secret: 04c724e94a1c1a8f24664a2b78bc432c370d2435cc71840d57a546f35481a990
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -437,7 +437,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-static-hazelcast-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-static-hazelcast-values.yaml"
@@ -600,10 +600,10 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: df2f3912f8c47fbba48334006843f53372863c4ffd0470266d00753d1562d80a
-        checksum/init-fs: 05fcea32e4326ff31601325de6baf8d599369856c17bad13f8f89ea5107689db
-        checksum/config: 42ffc54e217de96f4cf96d6cb8aca737b411ae5dd029b8735efcd8143dd9d015
-        checksum/secret: 143d11603aab996c88905044b3bcf34e517f90f959fe070d669cf624b450d716
+        checksum/init-sysctl: f67227d721c476b2710645fa6f9d6f988ba27b9b33ac9c977612c5d208c74f7b
+        checksum/init-fs: fcef9cdecb109c563a3a5dd0e3c55dd584c57190651f5704d39434d8cebb74d0
+        checksum/config: c18e54a5b2b346d466c0c8431ce059c36885bcdfe4d563116f0194911c93bfa9
+        checksum/secret: 04c724e94a1c1a8f24664a2b78bc432c370d2435cc71840d57a546f35481a990
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -801,7 +801,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 28e5b4ced71ccc2806f62c9bd3be043ed859af6b32cffef5435bccd59e28d5d4
-        checksum/config: 5f5e3f40caeca3fc7a8d78b539a2bbdfa62d6e327dccb797987dda410cc009d5
-        checksum/secret: c471a16d4690466eedd9d242b6879a8931ce33e1eda9a1d61dc678517a891261
+        checksum/plugins: 2252cd3d1c2849eea9ba0b3d808d2633486f12260145743514e9b3713143e4c4
+        checksum/config: e15f3bab31d177e426ae9625a079f804a126ddb4b12eda4ee94db620d1b86a39
+        checksum/secret: 5f740c225b67dc05ff8f6add161ab8fceb3c8c2259201cdac9dab7ec38aad83d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e5ba026c69e6b49c760bc44502142d6e961c9a9058b488a76bc04b1d0acd1786
-        checksum/init-fs: af6f6c689600e50fe7a1fc0582809ee01300370b7af177d7db50d3fc859adc10
-        checksum/config: 5f5e3f40caeca3fc7a8d78b539a2bbdfa62d6e327dccb797987dda410cc009d5
-        checksum/secret: c471a16d4690466eedd9d242b6879a8931ce33e1eda9a1d61dc678517a891261
+        checksum/init-sysctl: 883b4e117fc01d424a4c3cfc1429e774d9f6878c81a3410c9b4dd63ec19684fc
+        checksum/init-fs: 531b8362dbae6fa4f6521c6b9ebac3afc48a19ae06b5078b9593161b259a7ea5
+        checksum/config: e15f3bab31d177e426ae9625a079f804a126ddb4b12eda4ee94db620d1b86a39
+        checksum/secret: 5f740c225b67dc05ff8f6add161ab8fceb3c8c2259201cdac9dab7ec38aad83d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -793,7 +793,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: application-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -235,7 +235,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -282,7 +282,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -308,7 +308,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -361,9 +361,9 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 306dbe8ed39704d70af1b92318bf12e34b5e3819d17276d6164dd74503099c95
-        checksum/config: 3b083a44b24e2d8c0d75b703cf596869b3a90b2eef9f45aaa7a1735b52cad50f
-        checksum/secret: c03730026f28f87c31a04c06cc268ffe0b03091fdf9498de75668f25fd26b685
+        checksum/plugins: 2bda5746fe990a6decb5a472ae5feedd2fbbb9a1c515b2e81e8ea885a1c3a114
+        checksum/config: 3e93365933f046d46b57dfc9a58e0a50caf2461456c437c8c2c5e45d69121ae4
+        checksum/secret: 4fcdf56b28c2bb3c1425d9113cc14b48aaeb2c52210ed742587557054ac5e9e6
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -448,7 +448,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -584,7 +584,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -622,10 +622,10 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 792eafd5d9f331926bf6ce2b911a1be46dcaa6a1a26bcf55b787ec7f6277b2d2
-        checksum/init-fs: e6b6531033ab8b9ad2e44525808780aef02cdd61682fc61e00c28534fe214a54
-        checksum/config: 3b083a44b24e2d8c0d75b703cf596869b3a90b2eef9f45aaa7a1735b52cad50f
-        checksum/secret: c03730026f28f87c31a04c06cc268ffe0b03091fdf9498de75668f25fd26b685
+        checksum/init-sysctl: e5ca56d0316a0857195224c6843e4b9925af34e844152478822763c73792a8a3
+        checksum/init-fs: 279f2fcf25688453f2e21f583b181eb993e2c030ee766eeae0c10b7bba440d12
+        checksum/config: 3e93365933f046d46b57dfc9a58e0a50caf2461456c437c8c2c5e45d69121ae4
+        checksum/secret: 4fcdf56b28c2bb3c1425d9113cc14b48aaeb2c52210ed742587557054ac5e9e6
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -852,7 +852,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -241,7 +241,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -266,7 +266,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -319,7 +319,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -345,9 +345,9 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9dcc6ae75ec4371587aed60f5e72dfb4a86d9e2e38dc02268cf96d4a6b81b9df
-        checksum/config: adc3cbe9c23b191b990e5ede7af6e83e33cf10bbc48193876f2f0cd8ee3f0880
-        checksum/secret: b028169a2b33e515dcbe9f20ce540b04809101a8e79751fdfb77770b23b1fe4e
+        checksum/plugins: 2255463b55c2a2ee02c964b012789f6a2f4b6f8e24571f653766874267542a5a
+        checksum/config: 1902c6bab5c2a30596233f4173b7e2d183f758ebc5a9daa802ad9cf86d81fca4
+        checksum/secret: a0f36d1b8db88c267b724e1cec24e8aa7f527a25a2a4cbb46cb77f69312257d9
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -407,7 +407,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -523,7 +523,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -561,10 +561,10 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 1496761c57f9e4ac50f1ec52aad0f025595718c2edef1602edd3c7edca5960f9
-        checksum/init-fs: a8d7e40b0149186d4a88413b5a00d9d2c691421e73e69a8eec2d83203ba98cbf
-        checksum/config: adc3cbe9c23b191b990e5ede7af6e83e33cf10bbc48193876f2f0cd8ee3f0880
-        checksum/secret: b028169a2b33e515dcbe9f20ce540b04809101a8e79751fdfb77770b23b1fe4e
+        checksum/init-sysctl: cd2929ab34a1d273859cd0b8ca6984c489280ad6415394b82824d18f2b52038b
+        checksum/init-fs: 0f354a4393aab1494976da642f261c5b4a6139ec9392666d57d2090d8290ca06
+        checksum/config: 1902c6bab5c2a30596233f4173b7e2d183f758ebc5a9daa802ad9cf86d81fca4
+        checksum/secret: a0f36d1b8db88c267b724e1cec24e8aa7f527a25a2a4cbb46cb77f69312257d9
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -786,7 +786,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -358,9 +358,9 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c82d2374f9628b3a4abd05a53b2ba59a7f092ab1807614b05b0a759fd031496e
-        checksum/config: 49e47dbf759615ac2f1013db43294e05be5f2236d648d07ef2f6d006cd0aaef1
-        checksum/secret: 93cfbeba0b2a5598a6052a8e39edab63d552352586f6181705e8d842895b5bc6
+        checksum/plugins: 2f0cda562164399df149ccbd76ef4bf9167cdfaf4c4a83346a944fa42283297a
+        checksum/config: dc143158193e07eb3ca245dd5da48eca81e7129dd1203d8e1c2bfac86df18d13
+        checksum/secret: 4b70778b653df5716f87a18efc14227092ef2f49e952202f77287b47dca818ec
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -547,10 +547,10 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9b622a236b24c1c4ff2735a909eff743bc74b4491e42230d96b578581839db77
-        checksum/init-fs: c4c830cf6c451265d2ced2819fd1e0752f26f24a27cc362cf903720d8b2b8ed5
-        checksum/config: 49e47dbf759615ac2f1013db43294e05be5f2236d648d07ef2f6d006cd0aaef1
-        checksum/secret: 93cfbeba0b2a5598a6052a8e39edab63d552352586f6181705e8d842895b5bc6
+        checksum/init-sysctl: e39f184a08be8e0424c7bc3f8e1f8c24ef03cc0c8c2bd266412bd1472cc4d18c
+        checksum/init-fs: 89e70189bf5b2d67e556921f443d5bb7a91fe52f92506a11ab45146096742eaa
+        checksum/config: dc143158193e07eb3ca245dd5da48eca81e7129dd1203d8e1c2bfac86df18d13
+        checksum/secret: 4b70778b653df5716f87a18efc14227092ef2f49e952202f77287b47dca818ec
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -748,7 +748,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -789,7 +789,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.1"
+    helm.sh/chart: "sonarqube-dce-2026.4.0"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 
@@ -246,7 +246,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 
@@ -271,7 +271,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -350,9 +350,9 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c27580a68179f955218fa7de062e20098b12fb7242287cfbe4fd9beb64cf48c6
-        checksum/config: 40846996fddae2cb4b10d97cf6a22edeb836c7aad97696409ac6a809b6c9301b
-        checksum/secret: c6c12de657f83d2a313297cd1d79d6b51e02fea6b725355a2dbe16579c52edcc
+        checksum/plugins: 1245b36b3ef8ea87ebf2c53e30aadaa0768c5ad87ffbe2dd8735cd30717fc826
+        checksum/config: a98bd84a2c15e476e50fd2906ad6c967f5b4b86e98d26ed4e1c5b0aacd0dc54c
+        checksum/secret: aad5dcbd75f356f0b6f6048216b5a71662d17a11c5f651b61e2ecb5150c05e9e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -424,7 +424,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -600,10 +600,10 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d97a7379c7f016db8808419cf4c242d7b572d7decfa42ad51b126cac90363801
-        checksum/init-fs: d68a60c8710170787dc865e8c104c5678815ff6c705551efa1bcb37554802712
-        checksum/config: 40846996fddae2cb4b10d97cf6a22edeb836c7aad97696409ac6a809b6c9301b
-        checksum/secret: c6c12de657f83d2a313297cd1d79d6b51e02fea6b725355a2dbe16579c52edcc
+        checksum/init-sysctl: 64fa7a1b514f842a9be88e7233d118da349a199348f3afe542a5b7dab1776e35
+        checksum/init-fs: b1dfcb0fc08801416a027b934c0d8eb59bf1141af6a96177f001f7cfd8243def
+        checksum/config: a98bd84a2c15e476e50fd2906ad6c967f5b4b86e98d26ed4e1c5b0aacd0dc54c
+        checksum/secret: aad5dcbd75f356f0b6f6048216b5a71662d17a11c5f651b61e2ecb5150c05e9e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -858,7 +858,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: config-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 283bc04ceba3f0ab6963b697f4b39a3a181033c63f3bc98775604754165073a9
-        checksum/config: 726fdbeeaedbf8e9061d012e8eafadb16709e13b951bafeb4a815eb365ae1020
-        checksum/secret: b5329ebf7bae4d960b470bb7f6f2f8805841b210858c4c4cc45463b79c7bd30f
+        checksum/plugins: 2c06b5fc2dea526d5d9d911c90331e5c21a6577e02a862765f1a30f165a45bb9
+        checksum/config: 624de65d86b4099eb48576f600eca3cd286bc386ae632af0ffaac1748b4123ec
+        checksum/secret: 417c6bc2487bcae9b96ddf7b481c06503a3fa795393b55dca6b251112c491b3c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 59f8c3150d4b8b96689e3a61160b5bb8cd05a1df5d40a43b08010c106fc797e6
-        checksum/init-fs: 24dff34d541fea82048f15fc2f3a5c47454fbfe4be3c473b7c557f4d4d90153f
-        checksum/config: 726fdbeeaedbf8e9061d012e8eafadb16709e13b951bafeb4a815eb365ae1020
-        checksum/secret: b5329ebf7bae4d960b470bb7f6f2f8805841b210858c4c4cc45463b79c7bd30f
+        checksum/init-sysctl: 4803385495aaff9895f5c7e2a02cbd0f346e148217c35fa1cad40ad0d56f7132
+        checksum/init-fs: f4a2499210797687d6e05c5bf51fe91c2f1b0bdbbcef1bdfdd2dbf1644d7a9f3
+        checksum/config: 624de65d86b4099eb48576f600eca3cd286bc386ae632af0ffaac1748b4123ec
+        checksum/secret: 417c6bc2487bcae9b96ddf7b481c06503a3fa795393b55dca6b251112c491b3c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -734,7 +734,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: dc7b74a71b55c59eefd203aaece3b2a0ab2f7bc0cb9f27bc41c7f1c56f565536
-        checksum/config: 6e0186abbc9692d7d6ce3fe59ca6270cef7af63ccc53d820b757dda34b3ad3e0
-        checksum/secret: 4295207ffbe26692137cb4c64c97edcdc522068f5d7ef1f372fa85975df9fba3
+        checksum/plugins: 29822e3d4bc76b14ff923dc5e9296c4f377c9ae406306079a0900aa3b2de99ba
+        checksum/config: df90168942eadcfc350ae8b5df508707e754bb317870947c4a0c7685b36961b5
+        checksum/secret: e30806b363c821dd37fa58607a210b1604fef7b2cbce9ccb06af4f30571aa1e3
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 03a499c6b114feb4219fcb9f78ba1128ad7d6d64443fcf2c14fa5226a2d8b9e3
-        checksum/init-fs: f21bb830a145f6915489907491fccbde0dd44773829322cae6bb81a761898df8
-        checksum/config: 6e0186abbc9692d7d6ce3fe59ca6270cef7af63ccc53d820b757dda34b3ad3e0
-        checksum/secret: 4295207ffbe26692137cb4c64c97edcdc522068f5d7ef1f372fa85975df9fba3
+        checksum/init-sysctl: d3325cb9bb682e152b6e1d6192aa6a98a60ac836ef9c5729a2455b9f2aaef235
+        checksum/init-fs: 964f20a2ad266770089a84fe33a1c1cab037f47e4d5fb562899fc6afa3e431c0
+        checksum/config: df90168942eadcfc350ae8b5df508707e754bb317870947c4a0c7685b36961b5
+        checksum/secret: e30806b363c821dd37fa58607a210b1604fef7b2cbce9ccb06af4f30571aa1e3
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -734,7 +734,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: default-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 92ee4c33dbf9eecde927af559f8c8a66d367c3ecc8a70adc8110786457024903
-        checksum/config: ee0c5e9c5bac26d75d8ca8c475f6c1753b8b1f88504dab23d96d7fd1839f82ea
-        checksum/secret: 3b328d3d25b9ece11a209d035d66058b1174c96786dca372dc3de96bd50d7e6b
+        checksum/plugins: cd84ba6421b7faf5f92e876f1b4dcaa575a0bc72b240df7a5e30db084c64a6e6
+        checksum/config: 1e82ae4525f14cfac41d1e7fb8e91c640848c2679d59b523fd8281fd9308e31f
+        checksum/secret: b663cd195cefdf29d8d2ef83a1ecf054406aeb8d959f3baa967b93283a5a472c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: ac4492f57d99891a964306d974dbec6f715be48e1cce6ca5cd84a47814204a94
-        checksum/init-fs: 1a14f183184e72df76543175af2b5f859c1bcc4d6780a23b15a087468d506c13
-        checksum/config: ee0c5e9c5bac26d75d8ca8c475f6c1753b8b1f88504dab23d96d7fd1839f82ea
-        checksum/secret: 3b328d3d25b9ece11a209d035d66058b1174c96786dca372dc3de96bd50d7e6b
+        checksum/init-sysctl: 3dcc27bca6b267ff572a596f4c79139173791040e0c4a3a39a5896f3f1d6e96e
+        checksum/init-fs: 9e76331c68638abdbf23f6de534d286202e5da3e7134a6b3ec5226fb139d28d9
+        checksum/config: 1e82ae4525f14cfac41d1e7fb8e91c640848c2679d59b523fd8281fd9308e31f
+        checksum/secret: b663cd195cefdf29d8d2ef83a1ecf054406aeb8d959f3baa967b93283a5a472c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -734,7 +734,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: deprecation-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a2720076d5306240986b258634977fbc486c722b52275c3c2ce5e5fa2321a79d
-        checksum/config: 35364b1ccf81af82fb55cf46b7b42829674e4a6cec9b6165e83e9f385b9df420
-        checksum/secret: 9efe073cf6cf1287359578b05f159311a465ff1963a50ee5cd301e23336ad070
+        checksum/plugins: fbde51ae85126e322fe9703529763136123ec2a7f77f44c490b53e708c366e4e
+        checksum/config: c726e34c4f87372e922a5bce6e69575bbb43ca9ccd6dc8f8b4946deb91ec26de
+        checksum/secret: 1a9227d07b7103b406d0b3e4ce901f204df3ac3e1e8a8e2302bd4a9f8a3a340d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -387,7 +387,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -500,7 +500,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -538,10 +538,10 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: c242a5999873b7b291f22f21d5bad15482e93543ffdde527bfc35b4328bad490
-        checksum/init-fs: 7214842aa9331ea477e38af40d2dc1962861b85591e69fa2bb655b8d0b28b5b5
-        checksum/config: 35364b1ccf81af82fb55cf46b7b42829674e4a6cec9b6165e83e9f385b9df420
-        checksum/secret: 9efe073cf6cf1287359578b05f159311a465ff1963a50ee5cd301e23336ad070
+        checksum/init-sysctl: a66b0c6c8c2e39777ed386e2275823a53328889379a150e2ad679763ec771630
+        checksum/init-fs: 78d09064f2c41f3291e1a5492855858b7d931264635e8c7b877d554d52871c79
+        checksum/config: c726e34c4f87372e922a5bce6e69575bbb43ca9ccd6dc8f8b4946deb91ec26de
+        checksum/secret: 1a9227d07b7103b406d0b3e4ce901f204df3ac3e1e8a8e2302bd4a9f8a3a340d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -739,7 +739,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9e4ede51cae7c22d1cd2204946fb24fe19802a514bb59b99aac8ceffc7fa8e37
-        checksum/config: 514354160e02076b5fb9bc6f5dc5a2db910cfb5badc07d0956055f1c0322af96
-        checksum/secret: e31c2e7862bf0ba64ee8ec7a3fbf99ff1836d6a31081992fb9f76a29b4866da5
+        checksum/plugins: ce3ea243cbba46c82202718157874885366fb30df11941e4d409b00cf8b829b0
+        checksum/config: 9a51822997e6b07dcc3ccd5500c9013ea64440c3a9d3d24920b0f2704d378398
+        checksum/secret: 18e35daffb86bd977fea857c0edef74a1192d12735b55c481572eff174353fc8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -499,7 +499,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -537,10 +537,10 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: c0b829263294f76fce22b32a0acdfdca936e8b20cb03099f3b12e409baaa71de
-        checksum/init-fs: c82e189116e6e053beb845d1b447e62b7d12daf5af8197cb563afa4dd4aa0f7c
-        checksum/config: 514354160e02076b5fb9bc6f5dc5a2db910cfb5badc07d0956055f1c0322af96
-        checksum/secret: e31c2e7862bf0ba64ee8ec7a3fbf99ff1836d6a31081992fb9f76a29b4866da5
+        checksum/init-sysctl: 76834fabb4e5cd23e612ba2728578b83038d4ac235884b5d90549f9b43e2d818
+        checksum/init-fs: cc8f4793316015d654851273213bd2e37da2c019c2add59b73538db2faa5c248
+        checksum/config: 9a51822997e6b07dcc3ccd5500c9013ea64440c3a9d3d24920b0f2704d378398
+        checksum/secret: 18e35daffb86bd977fea857c0edef74a1192d12735b55c481572eff174353fc8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -743,7 +743,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: extraconfig-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -343,9 +343,9 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d7c8674c8269a03d94101923934df7e0ffc7ece74ca99bb08c530cedd07a859e
-        checksum/config: a8ae91092e260b5f70772fb85ce5fd932461ed30d2b3c4e7279a9c4c3bd0dd18
-        checksum/secret: 0171727b4d30a83214b23e1131443d72cf4fb9bb969864d04f60e26a03e17816
+        checksum/plugins: 3bfb318d23f271c70e76bb687b12e7c581080e423bf16e3af94797f6d53ea3c3
+        checksum/config: dc345fc836ba5cac792ddcf1c6e4ad5b1a52bf07da066de9c0c04c782676aaa1
+        checksum/secret: 0af9484ee076128625bccc8a9fc10851ade17456c32def4b8366fab3d85e1b3a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -381,7 +381,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -529,7 +529,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -567,10 +567,10 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 02fca2701f9f5c95d99d4b60489e159ce75ad2bbc5e69f5fbc8bc3206b9075e8
-        checksum/init-fs: 39e14507e918ed8803c77c8ab6f5df0b14979207d8eb45654bfa4e2525e58e58
-        checksum/config: a8ae91092e260b5f70772fb85ce5fd932461ed30d2b3c4e7279a9c4c3bd0dd18
-        checksum/secret: 0171727b4d30a83214b23e1131443d72cf4fb9bb969864d04f60e26a03e17816
+        checksum/init-sysctl: 32d21c1866b6c6ab737f6850c2a6cdb3c21b64987feddbda2da5d9720b1f0932
+        checksum/init-fs: dc28743209208870716eeeffa9fa9cf6c7c4a69ff2feba9baf3bf989b41febab
+        checksum/config: dc345fc836ba5cac792ddcf1c6e4ad5b1a52bf07da066de9c0c04c782676aaa1
+        checksum/secret: 0af9484ee076128625bccc8a9fc10851ade17456c32def4b8366fab3d85e1b3a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -768,7 +768,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: hpa-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b87b5662c6d0bcbe43770c7453066bc22b9c6048b82e6734f5b54fc11c6cc474
-        checksum/config: cf80e57e6a18abc93cfb425afdee6bf2646a3cea2ae558e322a29aa78994ac67
-        checksum/secret: 68ad6b63805818f7078a5f1543909ab546e3a53fe0529debf5f17266b6c3904c
+        checksum/plugins: aca97f6e1093818d2ead17a39525571e9437b3418af2de258119f16af059f0ee
+        checksum/config: 98a51d7f4b750010394a8445318b3fc22117cc7f13c7963cc8764ed82ff5fb5d
+        checksum/secret: 0d8e798013a1b62a593d4d9401d312697f7745c31173f0ad5a682c8483276cad
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b4351926cb1507ef811be13cede9bd1312756b9fef89c3180c1666a975d75b74
-        checksum/init-fs: 1f45ba04739e0e17660e61348e721595e479575fd1bc850f747d1adf45979820
-        checksum/config: cf80e57e6a18abc93cfb425afdee6bf2646a3cea2ae558e322a29aa78994ac67
-        checksum/secret: 68ad6b63805818f7078a5f1543909ab546e3a53fe0529debf5f17266b6c3904c
+        checksum/init-sysctl: 8ede1f997848ab144ea7d28984a31815b2c7a4dcf863b70f140da8d06eb46f53
+        checksum/init-fs: 3b7c240ce8787b98f3431338bedc04dff3d38119b7817cbc86a7b6d779bd06b7
+        checksum/config: 98a51d7f4b750010394a8445318b3fc22117cc7f13c7963cc8764ed82ff5fb5d
+        checksum/secret: 0d8e798013a1b62a593d4d9401d312697f7745c31173f0ad5a682c8483276cad
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -759,7 +759,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ea44473d35e4fef9760800154585a43ca2726f5f9742fbc2bb0698ea3662911f
-        checksum/config: b75bde5826a1b5c7be95eb3288d546bafd8de1dd6a4873843b2f3a8bf2da3c47
-        checksum/secret: 2acca3a21f59d15ffbf239019baffe11f9d6c078b81d1a63509b84933653d55a
+        checksum/plugins: 181c4e1bc4d3572a755c39602eb053b6b0210f543e4d44073f95a6542131b6a5
+        checksum/config: 219ad55538bfb3b14402bc52e751e89f9ae50ec4ee250c1fdd79aeeabe22a3c8
+        checksum/secret: f68a966a33cc49e93d7d230cedc37b94af095a9791b849913305611f0bfae4f0
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a9ccca68d18a96dee2b4cde5a100ebbfa897219b9a26cd46689fb08706a262d9
-        checksum/init-fs: a3a528859ca50b95c7e97203556d889a54ef8299d01bf998f9bd3b12f203ead8
-        checksum/config: b75bde5826a1b5c7be95eb3288d546bafd8de1dd6a4873843b2f3a8bf2da3c47
-        checksum/secret: 2acca3a21f59d15ffbf239019baffe11f9d6c078b81d1a63509b84933653d55a
+        checksum/init-sysctl: 0e127e2f61edae87bbfe17d140f117d41b5cbfa95e11ce4c0d22fe41ac771d89
+        checksum/init-fs: 17e85764f42b1b0eb771e039bcd63113676b6e68b9f0a0e47a5074fcb19c25f6
+        checksum/config: 219ad55538bfb3b14402bc52e751e89f9ae50ec4ee250c1fdd79aeeabe22a3c8
+        checksum/secret: f68a966a33cc49e93d7d230cedc37b94af095a9791b849913305611f0bfae4f0
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -760,7 +760,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 18beed5eb0e399338c97fc8ef58a7319df5747ac77da3580de340d3f2b607a8a
-        checksum/config: eb6808df24099f897ffed5c3f697e688da50cc1d24234d3b1cf0a7c2b5c5851f
-        checksum/secret: 750e676755f73854c435daafc0686bd44a6acd95b72ca01c70058351c4307aae
+        checksum/plugins: 032c14cd12bcc732b750fa771c2e8e10a1de9d046fca63a5f08dbdc75cef08c4
+        checksum/config: f48243edd0c40e4fd932fe0c506ef8853dae3f57135e5928a63d57d935a64479
+        checksum/secret: d1e89fd3e427fca9bc139920caad685a641769ccf633dd52b066e24e4466d8f8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9b22cf69910432bcb8f024fd2fd8dc7cdf93fefeb98d427ac090f763caaefd70
-        checksum/init-fs: 47099013da0247de8e9ccc2f28575f5913284d54e615309d14a16a9d48b8f115
-        checksum/config: eb6808df24099f897ffed5c3f697e688da50cc1d24234d3b1cf0a7c2b5c5851f
-        checksum/secret: 750e676755f73854c435daafc0686bd44a6acd95b72ca01c70058351c4307aae
+        checksum/init-sysctl: fed83bab92f00e514b097df8f4e578eef989dc37b68408dc1a72027d2404ccc3
+        checksum/init-fs: 4787a7f24f5010284eeedff5652c230188b4ad25552bfd1a2d2aa7d71f78821b
+        checksum/config: f48243edd0c40e4fd932fe0c506ef8853dae3f57135e5928a63d57d935a64479
+        checksum/secret: d1e89fd3e427fca9bc139920caad685a641769ccf633dd52b066e24e4466d8f8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -730,7 +730,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -767,7 +767,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -84,7 +84,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -99,7 +99,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -134,7 +134,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -223,7 +223,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -534,7 +534,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -556,7 +556,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -581,7 +581,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -607,7 +607,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -786,9 +786,9 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: baf10f53ff043fba61eadb888d757050b0c556b624ca5350ba07169b428e79e0
-        checksum/config: c9fbae5cdffed455ad07c917c898ff6bc041e93fb89c8dc41b9cf71a54be7927
-        checksum/secret: 0fdb613c052f23ea3c5b8560e8c30c04eecb2e8b87edbef27645cd798534422f
+        checksum/plugins: 86a2260d659afe25cf0856f27b6f625bc4e6a3e9b9373b6f63d07c059e0b5d33
+        checksum/config: 01ed5b1e6ee29a7b3c67b1d95a02b5241dc1efeb9b74ffdbd281ec82ac7481fa
+        checksum/secret: 2db4d74f64467d54631ce698a89499c11581b5499b19b76ebeaef1c0077b091e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -824,7 +824,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -937,7 +937,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -975,10 +975,10 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9440e9dd2ad4d6d9c390c3686083a0750f6af685cf9e215603f99d514a01008b
-        checksum/init-fs: 40e3ce817d3c1a4b87309852fc0638ebf98336e5ee4d6d8f7c70f3e87bd05613
-        checksum/config: c9fbae5cdffed455ad07c917c898ff6bc041e93fb89c8dc41b9cf71a54be7927
-        checksum/secret: 0fdb613c052f23ea3c5b8560e8c30c04eecb2e8b87edbef27645cd798534422f
+        checksum/init-sysctl: bc953ca10838fb3757d609dd71a38843b30e19bf438f07c0ec49118b6985a8e7
+        checksum/init-fs: dec1774b0b15d470fbf15d4d58134ba07b40518c4a37559989347fab5c606c60
+        checksum/config: 01ed5b1e6ee29a7b3c67b1d95a02b5241dc1efeb9b74ffdbd281ec82ac7481fa
+        checksum/secret: 2db4d74f64467d54631ce698a89499c11581b5499b19b76ebeaef1c0077b091e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -1188,7 +1188,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1390,7 +1390,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -347,9 +347,9 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: dfb9b91fae1365830ae8a15a1dc3faadfac7b782602e24613ee9678fdf75d5c7
-        checksum/config: 448caeeffaebd8ac550bae0c883f74841fad46a1fa3e42666f5ea6859c812875
-        checksum/secret: c91ee9b263390cd2ff5e8d508e4040e66c7235bbee236758a403e0dbbade9b19
+        checksum/plugins: 3182b8666aaa2250e88f1e4c3442ed6f7b32101659ededcd97086e055ae8468d
+        checksum/config: 40feda48077a140c18968a109ba3b6d48799069d80e665780250f3b9567c22e9
+        checksum/secret: b331c4107a9acf043fe56824486807fcf9a2abd2b3ff4e409b638731bd7f9e74
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -580,10 +580,10 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b5076be011319263021e164e7ad86687fc472e43abe2221ea700ce3559dd0fde
-        checksum/init-fs: 949ae44cf86146b99c4456dac502cff37621dce7c98356f3cd24ccb57903b3da
-        checksum/config: 448caeeffaebd8ac550bae0c883f74841fad46a1fa3e42666f5ea6859c812875
-        checksum/secret: c91ee9b263390cd2ff5e8d508e4040e66c7235bbee236758a403e0dbbade9b19
+        checksum/init-sysctl: d533ec6bcaa546d0e388886b7606b992bca6e3a9e97a49e5c5d214e1cd4d9210
+        checksum/init-fs: ec6975bd3577c451503a58983ae96a846195d06cf4b4b3907d9475b745980e7d
+        checksum/config: 40feda48077a140c18968a109ba3b6d48799069d80e665780250f3b9567c22e9
+        checksum/secret: b331c4107a9acf043fe56824486807fcf9a2abd2b3ff4e409b638731bd7f9e74
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -781,7 +781,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -178,7 +178,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -227,7 +227,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -252,7 +252,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -331,9 +331,9 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2dedec287c6bbac89397715c80417b3e27f9eff0e42ae65e0b05fe65a6e27586
-        checksum/config: b5d2f98dc13b596bc21e0e650dc10e00bf0dc802a99b1552feb37fc45446ab59
-        checksum/secret: a975e751a7643c17ad4d6c258028a87dab778e761ad67ad7042f0f0c1f071ccd
+        checksum/plugins: c8b2a9d34bafa6f659bae1c49139671d33dbda899e627b9d166da5f81e9041a2
+        checksum/config: 2452ad372c106417a2865606fc9f6876bb87692073f06e04fb40fe90e7ee046d
+        checksum/secret: 473c05657f0da6adadeba8c0b1658537f4caa3d793865f40825b704662a04819
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -369,7 +369,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -482,7 +482,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -520,10 +520,10 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 10ff6c9dd8a3fa1e2ccd93e12b5cb15a933d0cb4c3914b5808f19d66d09624b8
-        checksum/init-fs: 91b8aeafe6dd6b0d509caba9030c6b6b28c0c23dd1ab6d09a8ba4664f6b4c660
-        checksum/config: b5d2f98dc13b596bc21e0e650dc10e00bf0dc802a99b1552feb37fc45446ab59
-        checksum/secret: a975e751a7643c17ad4d6c258028a87dab778e761ad67ad7042f0f0c1f071ccd
+        checksum/init-sysctl: b238440ed9e2401747396396f267015a54f0ae5733e639f2dced926bf4db2a43
+        checksum/init-fs: 1fa4b04eb37b50d74cbd68abe2810d1da6f0aabb5202cced7768f157ee51cdd7
+        checksum/config: 2452ad372c106417a2865606fc9f6876bb87692073f06e04fb40fe90e7ee046d
+        checksum/secret: 473c05657f0da6adadeba8c0b1658537f4caa3d793865f40825b704662a04819
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -721,7 +721,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -240,7 +240,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -262,7 +262,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -287,7 +287,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -313,7 +313,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -340,7 +340,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -445,7 +445,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-tls-values.yaml
@@ -471,9 +471,9 @@ spec:
         release: mcp-tls-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: de58234c2e9995c30068e168db82895de77caf6ed1e155344865d600b58ea972
-        checksum/config: c8be6a560209546ecd137eb7534c466282935f6debd79b5557a6e4c8be2b7e1f
-        checksum/secret: e7e909d43524531c2daf86b48608b685c3249eaa5a76e23e3d612f8440840f99
+        checksum/plugins: 5ce89bb5e1a1d36abaa758f9b4652b2d27f6db5e7e347c1fb00e1199cbd61b29
+        checksum/config: 18cd5ffca3e969fb797333f75bd68d81f59e1d8607d023da016f74179ba01b58
+        checksum/secret: 40909465ca4ff84ab3c6297a0555e080b5807dbd03ba8e8996a429f832114394
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -509,7 +509,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-tls-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -626,7 +626,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-tls-values.yaml"
@@ -664,10 +664,10 @@ spec:
         release: mcp-tls-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 66004d733f5980b010f675fa6c036c9816ca0967228c5a8f29b20fd89d10694b
-        checksum/init-fs: c375ac42c28cc1f47d57775212de0c0e14f9140b512288d3c88087f910bfb567
-        checksum/config: c8be6a560209546ecd137eb7534c466282935f6debd79b5557a6e4c8be2b7e1f
-        checksum/secret: e7e909d43524531c2daf86b48608b685c3249eaa5a76e23e3d612f8440840f99
+        checksum/init-sysctl: a9f695a429a15d881787fabbf85fce06ea2c388aeb88bcfa7aa845c49961d390
+        checksum/init-fs: 1cf03c6d871f293c54c4216dda7c191509c10f77db98715b78f6f1faa4d48a95
+        checksum/config: 18cd5ffca3e969fb797333f75bd68d81f59e1d8607d023da016f74179ba01b58
+        checksum/secret: 40909465ca4ff84ab3c6297a0555e080b5807dbd03ba8e8996a429f832114394
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -865,7 +865,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -236,7 +236,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -258,7 +258,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 
@@ -358,7 +358,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -449,7 +449,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-values.yaml
@@ -475,9 +475,9 @@ spec:
         release: mcp-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e1773c04f446fc914c708b01ed3d2619f8f688f356f31d608c9563707d9e6eea
-        checksum/config: 0665c88f1dee8d54149a7e360ad33ca88e76dab2a9b96873cdcc19043ecefbee
-        checksum/secret: bb629b3aa9f657d48c2932c6fc5af585535ab8d0bf61b65216075c272106c4eb
+        checksum/plugins: bcc1e0f996790e852eec74e62c251ce0862b729201517c241fd93809fa958cb2
+        checksum/config: 51aa2a275ae6dc6362b2884beba0e9ad1146bdb460120bd8747ce621a3e9dde6
+        checksum/secret: 8c3f61e5e5cea58c86c6dbe51a1ddf15663fe17770eabe8f38113f134e9aaa91
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -513,7 +513,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -632,7 +632,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-values.yaml"
@@ -670,10 +670,10 @@ spec:
         release: mcp-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 1d7e84757431475e86f29d34e41c9b476b576a8e0f1c0a3a5c0e170ba2b0fb70
-        checksum/init-fs: 78f7a0d27467b2c45b789037cb272a4cce1b49536e30a3d1e74bc609b4ef08e8
-        checksum/config: 0665c88f1dee8d54149a7e360ad33ca88e76dab2a9b96873cdcc19043ecefbee
-        checksum/secret: bb629b3aa9f657d48c2932c6fc5af585535ab8d0bf61b65216075c272106c4eb
+        checksum/init-sysctl: 8859307f8b464ad11e2803c9da1c7e6009ed3ca7c49e27da160b17449c5278a9
+        checksum/init-fs: c44ba4b8f5db8ebab822382102a73859fc67881ccf30c79b3ba0eb6dc197cf80
+        checksum/config: 51aa2a275ae6dc6362b2884beba0e9ad1146bdb460120bd8747ce621a3e9dde6
+        checksum/secret: 8c3f61e5e5cea58c86c6dbe51a1ddf15663fe17770eabe8f38113f134e9aaa91
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -871,7 +871,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -236,7 +236,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -258,7 +258,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -358,7 +358,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -449,7 +449,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-web-context-values.yaml
@@ -475,9 +475,9 @@ spec:
         release: mcp-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: eedbab29d8821ed2f27c0d77059bf1ccdaba7ef7df5e65998f967d665a28d41f
-        checksum/config: b225963c0b84fce3f05e16ce8082bf79bdf89707dcf19af656de12d635cded8f
-        checksum/secret: 391cbef6801476efd35aba60ccd0049010ee126ba19aaeab7ce2cce55c1afef0
+        checksum/plugins: 30226f4af72e31f510f5711aa5da329de5e997af14879d0b6828397031b5459f
+        checksum/config: 1ca4e3f02b105e17e0b059f9f9fc050e7ebd410dcc3fd632d99374cde5c24c7c
+        checksum/secret: 157baf9b25733d1a99faf529513bc9165bddb2c876ff610d61c1da14572920c1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -513,7 +513,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -630,7 +630,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-web-context-values.yaml"
@@ -668,10 +668,10 @@ spec:
         release: mcp-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f203e844ed8627572aa4d60945cca8235bfa196586591f38e588d624e54e19c7
-        checksum/init-fs: 487ca7f5a8c6276e87abfd6a8edb52a373acc81a92a5c59e1ddcc7ffa5b60063
-        checksum/config: b225963c0b84fce3f05e16ce8082bf79bdf89707dcf19af656de12d635cded8f
-        checksum/secret: 391cbef6801476efd35aba60ccd0049010ee126ba19aaeab7ce2cce55c1afef0
+        checksum/init-sysctl: 84973d7e8248805f7bc31484730b635d8f597c2f97bc7967b62712fb5439871d
+        checksum/init-fs: 43e8f86c39eca373a77b4032f9e9037ce330242adc8f396b3612b7a7efa75515
+        checksum/config: 1ca4e3f02b105e17e0b059f9f9fc050e7ebd410dcc3fd632d99374cde5c24c7c
+        checksum/secret: 157baf9b25733d1a99faf529513bc9165bddb2c876ff610d61c1da14572920c1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -869,7 +869,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e6cd08e6685aaffeabb4db5349bc16436e5c10ce9c3fade7a6e830c6e73f720b
-        checksum/config: f5229ebb9801bef959e26c370ed3674ee8712eb293b8ce3744b9963abdc3493e
-        checksum/secret: be836c2e3093fad3b6b476d541f9a65d58416df120e001ffdf94c6fe9416cf5b
+        checksum/plugins: 795331d6d2ec3267242f8eb70556a0a8862008c3604b714df06685c31d26041a
+        checksum/config: 651c3dd8e67ff276f0517fab5b0a58730ddd88a9e5defd1f4e561fd4979027a5
+        checksum/secret: 532626085ad25b28f4637ede3b9fb568cdaf9810929574e6399e358f2f796d70
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -681,10 +681,10 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2d132b07cc529baac59fae0c3d79bf587585eaa24a0c2d7eb2a3ade13a1af53d
-        checksum/init-fs: 260681bdf1796a9aac4b3999612d3a0c38db0e2e81088b5df6cdb73d86105775
-        checksum/config: f5229ebb9801bef959e26c370ed3674ee8712eb293b8ce3744b9963abdc3493e
-        checksum/secret: be836c2e3093fad3b6b476d541f9a65d58416df120e001ffdf94c6fe9416cf5b
+        checksum/init-sysctl: a440d5f2a8156cad0f37447544814f23775f8eb1ac18f75f0bd68ceb68d40c97
+        checksum/init-fs: 6ad383587c2b7372e68d6ad7ec7979244ec30c5733e22001063c41e1e991e3d9
+        checksum/config: 651c3dd8e67ff276f0517fab5b0a58730ddd88a9e5defd1f4e561fd4979027a5
+        checksum/secret: 532626085ad25b28f4637ede3b9fb568cdaf9810929574e6399e358f2f796d70
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -882,7 +882,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ea390d22770d724123c24ddc203a47338fd34c956b69eb0f39a4d538de5a48a2
-        checksum/config: 1fb40bc48169bd826fbf58da0473d78c6655b72b7c727ddd39e17a97310e87e4
-        checksum/secret: 4a9d50ab5a5fa025119f820b7a1643bfb14818ee3e61b3edb72cdacbb317d7c2
+        checksum/plugins: 009f1f6c218a7cd8b75068ff43301c19f4a9aca0c709c855d6185679f650eb49
+        checksum/config: 621cd2df0877aca18f3f1fa212ee1f49c46b8e004cbe193f9edac7f4766e16ca
+        checksum/secret: 999003bed1f09bbce68f20850c56157956aa71beac9c8e47ee189239d369a71a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -681,10 +681,10 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0aad2c276c9f851ae532e7d69ef144be9ed06e2112800c8af45957268530fdca
-        checksum/init-fs: 6f407902d7728ae5c804d51014d7832795c7ac75591450cc5eda17289df5637d
-        checksum/config: 1fb40bc48169bd826fbf58da0473d78c6655b72b7c727ddd39e17a97310e87e4
-        checksum/secret: 4a9d50ab5a5fa025119f820b7a1643bfb14818ee3e61b3edb72cdacbb317d7c2
+        checksum/init-sysctl: a6eeed1c755464d1f99ef653fe0c5f1614b67b8fefb149b6d9097767c2b7cc5b
+        checksum/init-fs: f18f49141de30c3560a32d4a7425f19de6ee677fb817efea24beced087fddcca
+        checksum/config: 621cd2df0877aca18f3f1fa212ee1f49c46b8e004cbe193f9edac7f4766e16ca
+        checksum/secret: 999003bed1f09bbce68f20850c56157956aa71beac9c8e47ee189239d369a71a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -882,7 +882,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 37686937453d51a7513ea2615129940016e9f031df0faa073aedfde811503f54
-        checksum/config: 8d57b3a7800fa7fefbfad971965f0b3246103d0644591a49f7d1e11d24f0f20e
-        checksum/secret: fc9ab5b57e26475af8fac70f0444df9824a7486c6687ddc67de67a39d4d5f91a
+        checksum/plugins: 6ad06982a59454aa4b7c696b1bbd9ceb438f83257bed885a180d803dd37ab09f
+        checksum/config: c18019ae62249e5335e038d0db265784ac0db1c518428fe14e8a7052d692201e
+        checksum/secret: 5fae6292407ba5e0e68ae9ccb3e83f57205dd4b13af5d1a1a662a9cdf0c8c1f4
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -548,10 +548,10 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 20a4f415ebeb6887a8b9c84daf9a43d0dba3db44e72db99b77c33df4c8229670
-        checksum/init-fs: 6fe993ef9b4ebf08f2cf70734e9b5f887acb4240f50bdb65fe33e7b416c9f827
-        checksum/config: 8d57b3a7800fa7fefbfad971965f0b3246103d0644591a49f7d1e11d24f0f20e
-        checksum/secret: fc9ab5b57e26475af8fac70f0444df9824a7486c6687ddc67de67a39d4d5f91a
+        checksum/init-sysctl: 146b2e2dc98b2cfd293636cc165048a6f741cd4cd36ae512aa9911c17d2fa93e
+        checksum/init-fs: b17d1640c08b116a53c549e9c16a2ae2717461cd38bf8e7d4be66bf100c1c74d
+        checksum/config: c18019ae62249e5335e038d0db265784ac0db1c518428fe14e8a7052d692201e
+        checksum/secret: 5fae6292407ba5e0e68ae9ccb3e83f57205dd4b13af5d1a1a662a9cdf0c8c1f4
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -764,7 +764,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -344,9 +344,9 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: eb230315ead764fc3afeb2cc8479a87cda4883593354b6fc8fd3b878e1e405b1
-        checksum/config: 03096787b74765c8ec7186387761be8c345acf003e9ad684d6725fd40cb9fc95
-        checksum/secret: 34067745ed4abc2db2d202173f40a536b90ca9d0600e743299e0ec4d4eeb762d
+        checksum/plugins: df946b9d628140b4a1c88311fd4aff69adfeac4b3a068e62ee204f4e8f0f66e0
+        checksum/config: bb11ad7c4aa802497e27c791f86f1483c4a5f297a431235b4865b1c474d7dce6
+        checksum/secret: 9996aae1896135122737ceee9cbf9d55eb90c2a5a52a62f0cf79cf35a1da3033
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -548,10 +548,10 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 7042f4e86a32443052aafed8d324c0484a2b9b7f2bf21903a4d57ac30bed9c2e
-        checksum/init-fs: 19f145ae076d21e7dcca0622ee347cfcb266feb4e3f82573661c231307cc25d0
-        checksum/config: 03096787b74765c8ec7186387761be8c345acf003e9ad684d6725fd40cb9fc95
-        checksum/secret: 34067745ed4abc2db2d202173f40a536b90ca9d0600e743299e0ec4d4eeb762d
+        checksum/init-sysctl: f785b8c0925e19d85b97a4494b1ea5eed2f3e025290e49be5bee349dc512311c
+        checksum/init-fs: 78c20cc7eead2e21dbd7e218be4caa40d93b22347a02d1d97d87d4abb877e9c4
+        checksum/config: bb11ad7c4aa802497e27c791f86f1483c4a5f297a431235b4865b1c474d7dce6
+        checksum/secret: 9996aae1896135122737ceee9cbf9d55eb90c2a5a52a62f0cf79cf35a1da3033
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -764,7 +764,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: node-topology-values.yml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -248,7 +248,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -270,7 +270,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -295,7 +295,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -374,11 +374,11 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5133700ae6d6484935650cd101a9c4bf56f9e56c9000ee2a1a9d1a51079e7b85
-        checksum/config: ab475399ae6096853d3234b0c8d006d4a05fc54335a4bc4c741eb2921b0c872d
-        checksum/secret: 0f8bd8af0b8149254c9df544153171a9aa58a38e67029d39595b9c0aff217218
-        checksum/prometheus-config: c1a857f8b6d2af478d799a39b8a087b523fb09a5cfc590f67282726c8a9f672b
-        checksum/prometheus-ce-config: 8f36c6882a457145b2c9f8a3dd0dfce3404a944052efdca685223737b024e245
+        checksum/plugins: c35566b8221fc45149ef8a6a0d92a7f87abe45e3a594623d8a966d4e2cce3d7f
+        checksum/config: 3c93a8c24fcf723f256232a9a869a0f5c7e5b9c8877eabe93394900c42435e82
+        checksum/secret: d9ab7c5665efa60ea11b3bb771788634caf93556a300ede49990e1d84e5d78f7
+        checksum/prometheus-config: 02a015437189e38b473efecdf1bc5a210e0a4b1dcb2382dc6f94429ba2eaf7ec
+        checksum/prometheus-ce-config: 18a2d1369b59b22e31fd8cd42463141e87627acfb62bfd8d33f9c2dcd99fbe3c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -589,7 +589,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -627,10 +627,10 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 63e731d23475f2529bc1551c53f2a5578e851c18549fd5bd2e31258aee20f933
-        checksum/init-fs: a51efb422e81180b49386c66b951c1815fd70c1b4a07887b053bed5513d0affc
-        checksum/config: ab475399ae6096853d3234b0c8d006d4a05fc54335a4bc4c741eb2921b0c872d
-        checksum/secret: 0f8bd8af0b8149254c9df544153171a9aa58a38e67029d39595b9c0aff217218
+        checksum/init-sysctl: dfa831afbde1eb0e7c3d727ab2803e54da7cfe2b19584b0d113fc0902bd6d642
+        checksum/init-fs: 2aa205f5bdfd3c87b9807b26edfbc4081df3ec147db5f1a912e699004520a2fd
+        checksum/config: 3c93a8c24fcf723f256232a9a869a0f5c7e5b9c8877eabe93394900c42435e82
+        checksum/secret: d9ab7c5665efa60ea11b3bb771788634caf93556a300ede49990e1d84e5d78f7
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -865,7 +865,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -347,9 +347,9 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 756b4e54881da7cfc66949c5d147df4a18b83181fe5912cff5de667534e7e969
-        checksum/config: f03a1307aa1c549530bf290fd99232bfeef70a9a4b42a93067c9e5b8d0bf07e7
-        checksum/secret: 1e7ffaf81a69695b2254b4beb290e6e9729ca99cb404d4ca7c364a465c38192e
+        checksum/plugins: ea8bf55002a3dc74102ba5266f3b93c3a4a879b18b71dc91f8db418a6478b53e
+        checksum/config: 4203f4e85b56212446cbaeea2fdf9abc39701c6719303e9dfeadf447453db86c
+        checksum/secret: 79d6150ba4e9ac1697fade6cfc32a98c60f048736fa4413d226c937bb89bf30f
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -580,10 +580,10 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 442ac48d4f54c147ef66f6119b949eaf44c5533f439ca3369593bcc9e84121bf
-        checksum/init-fs: 108a018264cac458276d1548aa26cd8f06b3a91720dd55eb7a2fb30befd427dd
-        checksum/config: f03a1307aa1c549530bf290fd99232bfeef70a9a4b42a93067c9e5b8d0bf07e7
-        checksum/secret: 1e7ffaf81a69695b2254b4beb290e6e9729ca99cb404d4ca7c364a465c38192e
+        checksum/init-sysctl: 1bbc85e50a6a337c212640c9078216897c95e3d6e88caddfa9e266e335e2cb13
+        checksum/init-fs: 28a315a4306d0d44e5f3be77b1189bd8b39dbc2029dd7b5989908f70e7f767f7
+        checksum/config: 4203f4e85b56212446cbaeea2fdf9abc39701c6719303e9dfeadf447453db86c
+        checksum/secret: 79d6150ba4e9ac1697fade6cfc32a98c60f048736fa4413d226c937bb89bf30f
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -781,7 +781,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -251,7 +251,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 
@@ -273,7 +273,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -377,11 +377,11 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 36693ca127cede63a959e83c249ba8f0c7363073c9239db4201ffe7d6d4acc74
-        checksum/config: ab4752105af970d276c9e90ae5ae2bc870ef73669c171b13e91f69ba395efbf0
-        checksum/secret: cb74396ff2c974ea1dbb8895c59d42fed9c3e706effe9e321e341cb76fd19e23
-        checksum/prometheus-config: 01aac62b4bf12611035ab342f7f817291ee03f86a6e3a088df8e82799c5c12cd
-        checksum/prometheus-ce-config: 2fa5bf97f1d35de12c12d385ab44cc8e6ebada71a4623726948d923368fd5f12
+        checksum/plugins: 08f23825c3f2255271cfa580230c094d1ba17928a8175ea96714937f51735545
+        checksum/config: 795a44b95659fb8ebb46ed06b1e31db3c8a45bd00c2de5c63d7bd6a95bcd4d2e
+        checksum/secret: ef79a4ae37123b4cf7b9e3526411f193757a7056a28b587fc269be90712d6a75
+        checksum/prometheus-config: 52fc952840b330970dba42f515379cd67601c159091b04fee82860a707e601b0
+        checksum/prometheus-ce-config: 0dda8e81decd4a86656e7edbfa8fda81d2325585a32d7f16df4f3cc73922297e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -502,7 +502,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -636,7 +636,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -674,10 +674,10 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 81a72da4a9876d25d3b314f508ad8a528698b40ee710a68f7595c40f667c46d7
-        checksum/init-fs: 45cb301ccd1b5d90446d9edb2ff99cabbd264dad2548b4bd8e2d5723b152497a
-        checksum/config: ab4752105af970d276c9e90ae5ae2bc870ef73669c171b13e91f69ba395efbf0
-        checksum/secret: cb74396ff2c974ea1dbb8895c59d42fed9c3e706effe9e321e341cb76fd19e23
+        checksum/init-sysctl: 751865073215fa93e7ed41f903e54bcb03f9073fca8cbdc0983c14311fec6632
+        checksum/init-fs: 66142f41add00cdebdfab5c3a7e52d982bc21df5f7af40e7ad8e2286e1b75e9e
+        checksum/config: 795a44b95659fb8ebb46ed06b1e31db3c8a45bd00c2de5c63d7bd6a95bcd4d2e
+        checksum/secret: ef79a4ae37123b4cf7b9e3526411f193757a7056a28b587fc269be90712d6a75
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -875,7 +875,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b80d87afb2264f4e30c8e1632856f5d38e488ffe6fa4bb55f0f8f339c81dd6b6
-        checksum/config: a1ddd5824e4d02f59f9fb7e41640bc53148b9558ad67e6b0a26f36811caca8f2
-        checksum/secret: 2b89fe88d72ca98103f947553fb8301740314e9a87c759e8505b092593abb914
+        checksum/plugins: d226a5196b9b1dca94753347ca1f7d70791e55e34cbef5bedfacfc049732ccc6
+        checksum/config: 43c848ccf2203f670ea6dee440ae059a9f0fe48ba0af4f56904b0ec0d0a535dd
+        checksum/secret: d6531110d6c58d400d8fa747780d36485052c2ae77eb867daee430be703cd84b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -535,10 +535,10 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2a768dfd1465510a0a7d640975e78df50c912a74a7474485ccca1570053a192b
-        checksum/init-fs: 1d26d1f403336d36bdf235c1709812335040e02588b5ddd39e031fa502e800a5
-        checksum/config: a1ddd5824e4d02f59f9fb7e41640bc53148b9558ad67e6b0a26f36811caca8f2
-        checksum/secret: 2b89fe88d72ca98103f947553fb8301740314e9a87c759e8505b092593abb914
+        checksum/init-sysctl: 136740e924ca2992784414513569ce86db05ffbdb9ee7033ba9e1dbb35dea917
+        checksum/init-fs: d988abf40f603f8855a745ede46cbff4da3b15e52cca9963498e09992b38ef1b
+        checksum/config: 43c848ccf2203f670ea6dee440ae059a9f0fe48ba0af4f56904b0ec0d0a535dd
+        checksum/secret: d6531110d6c58d400d8fa747780d36485052c2ae77eb867daee430be703cd84b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -736,7 +736,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -204,7 +204,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -230,7 +230,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -283,9 +283,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b77e78cf67938c37422c53df36cdc73f4372587cfa42d64daa1141e2b03b7aa3
-        checksum/config: 30ed5083e24c629dc9fa9925ee8a7a682662f494bdb418a69184f446c4731d45
-        checksum/secret: 012b3a6b96771ff0bf062ce0d73389bb2e4bf99d431f580f466e3433e1c67c20
+        checksum/plugins: ca14e258f8898ba217beb9cdaa87729493aeda4cfcffc103862003958c37a4f9
+        checksum/config: c19f39d59d80b7c7879d1e706ce6b55a3fc024ced84e02e5c9396672fbfa2e84
+        checksum/secret: 65513b968d0136df5eda1b08e055746891f809bd7e9fd21f731652f228ab6230
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -355,7 +355,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -480,7 +480,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -518,8 +518,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: 30ed5083e24c629dc9fa9925ee8a7a682662f494bdb418a69184f446c4731d45
-        checksum/secret: 012b3a6b96771ff0bf062ce0d73389bb2e4bf99d431f580f466e3433e1c67c20
+        checksum/config: c19f39d59d80b7c7879d1e706ce6b55a3fc024ced84e02e5c9396672fbfa2e84
+        checksum/secret: 65513b968d0136df5eda1b08e055746891f809bd7e9fd21f731652f228ab6230
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -692,7 +692,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -358,9 +358,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 1372eebba6c22f3466843a203054b57247593a6e5160248e0af2041bdab85514
-        checksum/config: c94f08b93c0700fb133dc8eb622df311f76655a38be7c9e8393200c15f90eed4
-        checksum/secret: ea8a9df96097e952b092f4a189d63fd3e0552059c1d1f02641af93b1e95616e5
+        checksum/plugins: b80ed077f8dada5804361a38abb1e3e7c86cdd31aa25d59dadd90db2dbb03b61
+        checksum/config: 98af638691949f9f2f0385ff1d9a757b5c9eb1d6963c43ab151dc0de45913a9d
+        checksum/secret: cb478b57a6330851f2bd61b92800f0b808fd39ec2c9433a7ccab9bafdbb686e1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -547,10 +547,10 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 6362763f083d420960ba1e9995aae2ba30e5ec22dd2a692e9771482d0729d02f
-        checksum/init-fs: 121fb9a13827715ac9eb901d6a4b1bf935f1ae3edd42d52e36061c09026d3e62
-        checksum/config: c94f08b93c0700fb133dc8eb622df311f76655a38be7c9e8393200c15f90eed4
-        checksum/secret: ea8a9df96097e952b092f4a189d63fd3e0552059c1d1f02641af93b1e95616e5
+        checksum/init-sysctl: bc1ab474986502d2ccc1160df742de61ba7dad7904511b23d78c947bad4ffe03
+        checksum/init-fs: 9db43ad72232d085f36ad70b571c14a5fc5528946d6a1b15972b703c16167902
+        checksum/config: 98af638691949f9f2f0385ff1d9a757b5c9eb1d6963c43ab151dc0de45913a9d
+        checksum/secret: cb478b57a6330851f2bd61b92800f0b808fd39ec2c9433a7ccab9bafdbb686e1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -748,7 +748,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -789,7 +789,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.1"
+    helm.sh/chart: "sonarqube-dce-2026.4.0"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -247,7 +247,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -276,7 +276,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -305,7 +305,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -336,7 +336,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -362,9 +362,9 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c91982da5d708e2028b391a221cb669067aa9203c051798c178e180dbcac516c
-        checksum/config: 44aaab6115409aeb7c18f178f12a7db49d10fb58ee311937b8a883f3f5e6193e
-        checksum/secret: 93048e60d71aedd044a82850729cbe0afac173a727961f2206b1295032e0cd17
+        checksum/plugins: 7eb0cc5c5c20e93d4921fe59f08899611c80ca7fd7db76d24930d6a3ef72731a
+        checksum/config: b371b6d255d7481e736c901f2e065b1def1c6adbff42f12b338425e63d8352a0
+        checksum/secret: 788417e5478d08521891bab079bde9cab6d25a32ab9133ff0a80fd64e77285ba
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -400,7 +400,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -513,7 +513,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -551,10 +551,10 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: edf799638b1bde3ef82c3d395952a45890ee684ed9f54f7c039c1899735bc451
-        checksum/init-fs: d8590afbaf1b7ceda4bff518aced878e306e9415121564464c86a16f8cdee09c
-        checksum/config: 44aaab6115409aeb7c18f178f12a7db49d10fb58ee311937b8a883f3f5e6193e
-        checksum/secret: 93048e60d71aedd044a82850729cbe0afac173a727961f2206b1295032e0cd17
+        checksum/init-sysctl: cae1a24aaeb69c31c71a3b4bf2a7293fb93db1422e8ce40324f0744519d11a96
+        checksum/init-fs: 3ccb3203697d0b549b98e5ce9ca45d24c5521c232279cdd5616cfb44797486fb
+        checksum/config: b371b6d255d7481e736c901f2e065b1def1c6adbff42f12b338425e63d8352a0
+        checksum/secret: 788417e5478d08521891bab079bde9cab6d25a32ab9133ff0a80fd64e77285ba
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -752,7 +752,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: service-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -49,7 +49,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -63,7 +63,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -77,7 +77,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -92,7 +92,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -111,7 +111,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -124,7 +124,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -227,7 +227,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -249,7 +249,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -274,7 +274,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -353,9 +353,9 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2b67f271fd7a0b087ca435cb64e2d1502eb44f2a7b7cce0335733d3c7eb6ba46
-        checksum/config: 6bb1fdd4d290c887815d8884462d62ce935af377e96e88ef5db52017aff5d2cd
-        checksum/secret: e1f8e90987009bc1c32f652630c77e4dee75e10b36f574b9bce1cde4d5905493
+        checksum/plugins: 0f2d3b2cd51a15f1c5c396b6a2977675cf4196ee8e01d7e54d5c329d40bde33f
+        checksum/config: 95ce1d8cfb0c0a7ecce64d5b60f4477d11ee69a0680388cd1c96048da63be358
+        checksum/secret: af7c0b60bcb0c31b069e899023f4199faee264f3280bcfa3881bfbb9ae93e185
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -391,7 +391,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -504,7 +504,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -542,10 +542,10 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b8fb8feecfffbeda5bff1d6c9b48cd3c79645f7dafe40b2d999a86152fe93963
-        checksum/init-fs: 4c05e112b021bb0788c8f9f3fdaa178b61fe8bb6fc2ca8d895e3275316068362
-        checksum/config: 6bb1fdd4d290c887815d8884462d62ce935af377e96e88ef5db52017aff5d2cd
-        checksum/secret: e1f8e90987009bc1c32f652630c77e4dee75e10b36f574b9bce1cde4d5905493
+        checksum/init-sysctl: 2cf175ccdb0be9721db9fc4feb33cc05ee5e1a279724c7befce85bef4f38f9fa
+        checksum/init-fs: 57f1a64cbb8adfaad8a9705ddb2a048c93de2c1c8a463a1ec1088405c6cfe0fd
+        checksum/config: 95ce1d8cfb0c0a7ecce64d5b60f4477d11ee69a0680388cd1c96048da63be358
+        checksum/secret: af7c0b60bcb0c31b069e899023f4199faee264f3280bcfa3881bfbb9ae93e185
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -743,7 +743,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -206,7 +206,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -255,7 +255,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -333,7 +333,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -359,9 +359,9 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9f40804cf6414c41287a1fdb86838f1c8ac548329fafa9fd4964485d37f52ea2
-        checksum/config: 47cf3fca18348887dde22f1058a915b1294ce3b428b266d9a6ab8f0b908dc98c
-        checksum/secret: 5e3acadb1f27e04c31bfe40a7fd626c001b1b683fe4ac62a8fcf4cf11fad1446
+        checksum/plugins: a9bf8349550837b86b8f4dad1acab48c2b8cff693ab533e70f1e92deae7743b2
+        checksum/config: f0c1b0ce2b55f906ad1bce8c13c47a86ef72a6406f91990b959d0cb728aac600
+        checksum/secret: 763637efa6adfe11afc6bb4fa73a91130d6a6e645e32ca875e151eae06e1cdcf
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -433,7 +433,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -558,7 +558,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -596,10 +596,10 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: bddf2a83da4b91c1554c84ffb7dc4932cc2bb18259f0a019624c018c6500e8dd
-        checksum/init-fs: 86a37754d3aba193e382a18c0b9cf4b775c09445a2699a2dd0d771019bfea8db
-        checksum/config: 47cf3fca18348887dde22f1058a915b1294ce3b428b266d9a6ab8f0b908dc98c
-        checksum/secret: 5e3acadb1f27e04c31bfe40a7fd626c001b1b683fe4ac62a8fcf4cf11fad1446
+        checksum/init-sysctl: 83c777e106490e488dab1135161c54d7d33fe486ad306a3ad6b7cb90d0507969
+        checksum/init-fs: 63de4268318f21c25040326650f9cd33a9e13f80f745727a3e0457ef0ddb13a6
+        checksum/config: f0c1b0ce2b55f906ad1bce8c13c47a86ef72a6406f91990b959d0cb728aac600
+        checksum/secret: 763637efa6adfe11afc6bb4fa73a91130d6a6e645e32ca875e151eae06e1cdcf
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -793,7 +793,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -820,7 +820,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -861,7 +861,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.1"
+    helm.sh/chart: "sonarqube-dce-2026.4.0"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -358,9 +358,9 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 56b2a2acec99e507bf04867153bc6983291c8168eb44ae24f3e4c832eeac6072
-        checksum/config: 339acbb1eb874da02606f31ab38f3155c0e6da1e91130161d0ce515cfe8970cf
-        checksum/secret: 9f6faeab26acb9d702b9e17c9143c0549d5c119042a18c4b37cc729c42957343
+        checksum/plugins: d291d42d828cc17dd8ef2205d9e5971f8c97d8122cd8bd721f3a476dff5058f0
+        checksum/config: 338ab010265906e72c8b62c8982dd1c0cc72e03a051f372809e50d5f64a7423e
+        checksum/secret: d7beeeee3ab03f69a0bade65e17eb0a6249db7c7a5131ef6b720e9aa3c206023
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -547,10 +547,10 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e3cc43f355a919f47e6f93c43fba4a9ff56200fb88d89ec54f1ab6b2bd9f2588
-        checksum/init-fs: a50771bed8b8584da796f0dacbb3967ad8a12c5610bd8b282f9a4a865ba31fbf
-        checksum/config: 339acbb1eb874da02606f31ab38f3155c0e6da1e91130161d0ce515cfe8970cf
-        checksum/secret: 9f6faeab26acb9d702b9e17c9143c0549d5c119042a18c4b37cc729c42957343
+        checksum/init-sysctl: 041914a7ed09e71192c94347f1c550eb83e7379d0df406c077ce7e2ff3731e66
+        checksum/init-fs: 7dbc5dbe9f2790d7b2818fd8f77fff80b7b1ba39d5e67969e83b14f0b47801ac
+        checksum/config: 338ab010265906e72c8b62c8982dd1c0cc72e03a051f372809e50d5f64a7423e
+        checksum/secret: d7beeeee3ab03f69a0bade65e17eb0a6249db7c7a5131ef6b720e9aa3c206023
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -744,7 +744,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -771,7 +771,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -812,7 +812,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.3.1"
+    helm.sh/chart: "sonarqube-dce-2026.4.0"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
     app.kubernetes.io/name: topology-spread-constraints-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: topology-spread-constraints-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c071f141dde7666dfee290e384bb6d137d46414349d7aa8c5903b7704a44977a
-        checksum/config: d4101c93433ad42aeedcb126e19deb994f5a3ae2e468e01061d3320c51f17f03
-        checksum/secret: 4575f20bcd6dba4e8fcf175cfaa79dfb3444d9e8043c7cdfd202c4cf76fa2905
+        checksum/plugins: 180fe929450aa723d8d03053b416eba136a46f80d7dee0d9872281d9064afaba
+        checksum/config: f9be72cd88fe68ac26ed2486b91602b110cba9c46e2fe7ee9f784ca6929753db
+        checksum/secret: 627c2b5185ccb109e1f5754a95d7093037c54843a8bb1efdd7c8a7b5e99ac61d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "topology-spread-constraints-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "topology-spread-constraints-values.yaml"
@@ -541,10 +541,10 @@ spec:
         release: topology-spread-constraints-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: ccd8ae42d653da541b1c6fa15298e25ccf739411f41eeac953df27d50812a0c4
-        checksum/init-fs: ce5df7acee6f0b84a084492acb375090c686532e76c46812a1acba095d75ca4f
-        checksum/config: d4101c93433ad42aeedcb126e19deb994f5a3ae2e468e01061d3320c51f17f03
-        checksum/secret: 4575f20bcd6dba4e8fcf175cfaa79dfb3444d9e8043c7cdfd202c4cf76fa2905
+        checksum/init-sysctl: e0e97de96af12a83513f11cde0342969bdbcadb95e1334f0051e0e1423971146
+        checksum/init-fs: b9d8dbea209dae9186ceb580d4719a6edddd9957bf2a9d24e18e688057469aa0
+        checksum/config: f9be72cd88fe68ac26ed2486b91602b110cba9c46e2fe7ee9f784ca6929753db
+        checksum/secret: 627c2b5185ccb109e1f5754a95d7093037c54843a8bb1efdd7c8a7b5e99ac61d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -750,7 +750,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.3.1
+    chart: sonarqube-dce-2026.4.0
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -151,7 +151,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -171,10 +171,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8c3968bd3aea8e5b7b0d37573b84fa4a85495d3d635a7844e2b2de2e322961b7
-        checksum/init-sysctl: 63d9c0156ae478217e3b8347c41f50f0bef02fb10c22421b318d4f39d169ff56
-        checksum/plugins: 2610c9a8f14fea09dd6a261eea63bcf47148026f61ef029ad50862cd967b9393
-        checksum/secret: 3a8b484d4212e53ccc81155eab1e45fffcd3d3eedf06f54a1d2f908f23efba42
+        checksum/config: f8aa11f39a0e5d00b8b50d9eaf3ed699745188e09567c2c1c63fc269353a7b50
+        checksum/init-sysctl: 6b529bd8bcc2d60623f4c142ecf474354b0898e76dadc0bc6958c77afe788443
+        checksum/plugins: 11b3085442c8fe26074ef53cf7874d8e729fadd1af33b0f50cd3c5865fddaecf
+        checksum/secret: 2c83f97b3e967ed3bb7af7f9ab9c1602c9aecf8b0b67c8df5491c6d4265bf3b2
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -403,7 +403,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a94adc47fb8ef925220c47c9573d6d62a0236aa55a0ecaf3573aa0559e609f8d
-        checksum/init-sysctl: 98c93bd4052d1b83f1675eb1d211b6e01eb98f26b48c708d7dbd8b6f0db23d90
-        checksum/plugins: 11dbad3f5ebde2745999aa018dc8c76bd310a401bd4c4c52a001b0a5d553afa5
-        checksum/secret: c6fbdfa6794ee1c798f4981b31e71fed3200705a14a6c8a17eae6de32b828f61
+        checksum/config: 2b78880050714a43d35f042fe01e683150d016f9dc6029fba2188b1276972dea
+        checksum/init-sysctl: d027b010d598347124b4296e2e6dfb852591026a98a7bb411ffcdcd2acbb4638
+        checksum/plugins: 9eaabe13f981cdd65c90af94917c2c3c555b697510ea518acaf5e94668b91304
+        checksum/secret: d768c9544c7824d46e3e4006eae2083fe938bfa486fd9a830160644485343358
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -233,7 +233,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -338,7 +338,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9bfaf06015ae84dbe90c4964230ad27c22ac6c4f1020a446e23ca5bf371b93cb
-        checksum/init-sysctl: 63deea3e23c68715cfdc2f5765d10c7a0482e5d947bb2b5fad9299525ca0c5d0
-        checksum/plugins: d8fa89cd7c853853f927ac1e82477fa56dcdaf3899fa25ff9105fddcd95850e0
-        checksum/secret: ad4ac2a81cf51b61c786c9fd77681f7533218e8b063467cfb8176942a681d038
+        checksum/config: d3631e22e9ad1c1261a52cf0aee0d920f2de6c8290257b9be1898de5b72c3a64
+        checksum/init-sysctl: 6f3bfb84371d597881cd6732c4821db3daeae660c48b744fc9ec86280ec99de7
+        checksum/plugins: eaacb5c535b24189275fd298b546b065768c71abe69eb5751f7b282dcc303ac7
+        checksum/secret: 94bab275a0b3922436d3a4f7363bdfa1ce1adf11d0761480206e0d9099d6baa0
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,7 +320,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -359,7 +359,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -372,7 +372,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.1
+        chart: sonarqube-2026.4.0
         release: change-admin-password-hook-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2d2489b345b1a7736347072d73bc5c65f68ae1e613a51a37daf54626d6a3864d
-        checksum/init-sysctl: 20ad3d580496a40153ebf968b95ddab399d04c9eee6d4fd566d5240326be56ff
-        checksum/plugins: 85ab978a814970bf6c4260a962c0be6805dcdb5c38a0eae0769ddf82deaad6ba
-        checksum/secret: 9230f4bdaad4fc7173b66b6d6d8111bba8fb95c29c20d0f58b1dc784260420ae
+        checksum/config: 3eaa127cc35f561c02063d182ff3fdc0efc20c71a2915864a4be3af5c66fb8ba
+        checksum/init-sysctl: 214b994ee2edf9cd8e1c98992d7d96e3785a6d5bf623000b84b1fa8391794870
+        checksum/plugins: 3b32836c9081ed29751f1c470a262f6b78d75a6deacb36fe1eba4b1fff095de5
+        checksum/secret: a6d77f0805e698b75c44334998e808c7cd76149ba4e2d269d165ce1698321c2e
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -58,7 +58,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -139,7 +139,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -159,10 +159,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8df1f4a64c412f2c0c2126d9c845e5d4b8a93d9bd6d089753d679c912a4933aa
-        checksum/init-sysctl: bdc05c762f3ec69076b4e37b85d3bbe85afa860e78cb3504d51d39a1f4adf969
-        checksum/plugins: 933c30d875d4557651383434c54d70612b9d89f92b790dc2ace050041011445e
-        checksum/secret: eef1cd2f04af4f298a931e52e9d010b035459ca35123f122697bb5c3db210323
+        checksum/config: 5fe58941717ed91250c9ce31aacbfa2adee188b4c184a2b863416b2ce0076828
+        checksum/init-sysctl: 47dd9c70e910490f2d27cbd80a29d675ec17544d45a2e8c8905375f68dbdec30
+        checksum/plugins: d6d588edfee491192bb6d0137006a5cfa8fc62495a2ec2c3fb6554400244c913
+        checksum/secret: 4b79d1cfcb4eebf3f625c1001a5cfe097c7d2340f416d916f10b6adf0cbe53c6
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -252,7 +252,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -384,7 +384,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: config-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1b37cb258a04b6c316845f6604394aff3f31efdb2a4027a8995d036c1c5df975
-        checksum/init-sysctl: 010c92993b89ee3c1990822ad7236fffdba3cf26610b860ed182eb82228bcc94
-        checksum/plugins: 98f344d008a160487a54d1da19795686fb15c672a2d0d94624f5c54722d67e78
-        checksum/secret: af0e5074c066ffd36b9037dd9b1f5912bac8b7e80ea1a613a72b7f941cbe8909
+        checksum/config: 4e3072d9c42dd082315e1385cca4566e4058956cbcd2c5f2e0c1eeab629a375b
+        checksum/init-sysctl: 6a6cc5808cfacecc0d221d99c4fe79bf3fe7e26b18945159cfe7cf0845988cd9
+        checksum/plugins: 723b41f42132706372dcde7d17e01125e067f06bb3ebe864f8259b19475b5088
+        checksum/secret: 131245eb20c3509405980af882e63ad7c1154fb07a21d792e32485d6b4684b4e
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a1e9c51ca00ffb85f89e9eae98e50d7ceecb81a2eadb99dcd1da75dcee2d7421
-        checksum/init-sysctl: 1db4a548219720c0c7bec1dd1099a700a401619bedaf9415ba85ef0c33e39981
-        checksum/plugins: 5a0946c58a79904d12324dbeaa9722d5fa65a311aa03040c0f3a3469d362c7f7
-        checksum/secret: 3993321fef4507a09c8d04ef2474e878c5d65929a80b1f67495c956c5e63710b
+        checksum/config: 10bbd835f3261307730db88828a7071210301b8158a1d942751d42bded4d3f83
+        checksum/init-sysctl: cb24a342eb4fb5cd7bec09cf752daa8b565c3e1f826b4ea18772ad2be25056ef
+        checksum/plugins: 3b319f69f9a1654901aaa085dfe9d630e9ab9ef9e5f3280ce5c3b4872a73a319
+        checksum/secret: 709a1f1323bc7dc1a7b647d6d8f57707216d11c9dbbf186dca580702aeeb7496
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: default-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -156,10 +156,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 279d4e29a04af9a533555aebb8acea7d3064cd55ece8c554d5a11def1d1576f0
-        checksum/init-sysctl: d107c3a5acf6a0ba715790f5039e5e195a0a2dc4b565e0af9b2c6d161f2b914c
-        checksum/plugins: d7dae62654c8788c6a81f3ffe4b3bb8fcd2f5e123df852f0bb9fc8c83918e1aa
-        checksum/secret: f7e1878f2a4f401ecb0efc5aae4592bd67dbd65f4650b13e0a2a5d61a9f02525
+        checksum/config: 440c0ed538977d0b956868c194ba0a2eec3567d563f3cda32f15611a23590b90
+        checksum/init-sysctl: 5ec6aacf7afede0323d753f0f06642060d5e8b9706fadd38801f13261b89ba42
+        checksum/plugins: 658f0be6cba59775a71c469790842027e8cb38f425c9e00fcdc1239831abe9fb
+        checksum/secret: 992c4e176019919954042c6bc86a8bca6c99f0a12636404a56fdb251a4cc7429
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -205,7 +205,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -307,7 +307,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: deployment-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -165,7 +165,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -185,12 +185,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d56cbbadf7d73bfc69241f1b15ffd3818c0b18100dc9ace6b122a88b27fae206
-        checksum/init-sysctl: e8254b05929a6beaab1a0778f30659c044cf4a46e123cbb565d25857c5d1e58f
-        checksum/plugins: edd4c48968937c034393d16f1e18e81ef268390c3128cd4061b60b01f02d803f
-        checksum/secret: 4126acfbf409df2bc105b06192272bdba551a006e3f1ea2eea1717845abd24f0
-        checksum/prometheus-config: 9cc9ddb2e3c8a6876e20501015d52204b6dd9c2f61d2684387595751f5c59d45
-        checksum/prometheus-ce-config: b2dc89f61d9c38d3cd1c43d3a2d1e404a45d8b9ab6824fad12f244f9188e39ab
+        checksum/config: 7fe1069ae7ce59da3db748926c60eedc93c26e8ec27ccd44a24cac2df948fe22
+        checksum/init-sysctl: 12779b4def6cf53c9b44d235bbe0cd5bede2d542bdd67d108f96d68ae7002966
+        checksum/plugins: fda18251dd4e64f41be587785624137698c9a4c2d794a64a16df8b0659cfa6dc
+        checksum/secret: e440e41bd44b851a6eb0af6e700aea9118152639f6716a753449e13802d088bc
+        checksum/prometheus-config: 45c0cbb3c18160bf0fa0104f4c87f1079183465c83fc5494e7591109bcae32c3
+        checksum/prometheus-ce-config: 7b0e9eb6862ffb2eef5e9af8092b2879a6d5318a1b24fe4e13d2e6025b783260
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -298,7 +298,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -425,7 +425,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
     app.kubernetes.io/name: host-path-values.yaml
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 664739f3c5feb42e566bde92450121e729f9fb80a5a608cfdd2a23964b5a1396
-        checksum/init-fs: 1bb14f9582d0937846df852e3f24b9e84568c10efd1625cab36e9eee64d2844b
-        checksum/init-sysctl: c2bfc31fc03e35948b6dcddc4a2ffafd797e05a77ac8dd0bd3fcfe7a4728c526
-        checksum/plugins: 6001f9436fa1e68cd960783d85de12d51ed618e319088b1a542b7b53068cefd9
-        checksum/secret: 7f51561785cb18b2d390d2838d61528e1b38323be4028f1207e018463c7504c4
+        checksum/config: 0f91e1254cdcbded48b25ba5843f116fa5a84fa7791a80008391d6987cc2007f
+        checksum/init-fs: 6ac4211b045cb9355ba28bc3db2863d7c90618ccd25abf814915951d29bd8636
+        checksum/init-sysctl: a1ba9ee3334f759434f75eb4a842f514b050074e60ac2978f4799b2cd59e5d42
+        checksum/plugins: 2435479faf54e8dbb9be7cd879f72d22bc5024943a3ab9cd5e449e03ff238602
+        checksum/secret: 5db441a28b5d418a3c68e151e185a2c1020465c1a5fdf5548e4dac343b240c0d
       labels:
         app: sonarqube
         release: host-path-values.yaml
@@ -272,7 +272,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -381,7 +381,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: host-path-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: host-path-values.yaml-sonarqube
-    app.kubernetes.io/version: "26.5.0.122743-community"
+    app.kubernetes.io/version: "26.6.0.123539-community"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -202,7 +202,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:26.5.0.122743-community
+          image: sonarqube:26.6.0.123539-community
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -220,7 +220,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:26.5.0.122743-community
+          image: sonarqube:26.6.0.123539-community
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -255,7 +255,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:26.5.0.122743-community
+          image: sonarqube:26.6.0.123539-community
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -388,7 +388,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: host-path-values.yaml-ui-test
-      image: "sonarqube:26.5.0.122743-community"
+      image: "sonarqube:26.6.0.123539-community"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1a2e782cfaefd08edc83943a7f9854812fe09a70c3b8bf5c04a93efa1b5348b1
-        checksum/init-sysctl: d40f7e21bf7c4d9d94a9b85cfa72703749d6c2a6e4ae2bd09e87f551f866f74f
-        checksum/plugins: 24caebccc2d75db1a09bd94cf73f50cb3ef24bc1abaf266ac6d254c72e48f228
-        checksum/secret: 1b68fde4912d88ff76b56471b2c4a62ed5fff7733c2a5e476a1212c0d17714fd
+        checksum/config: 6aa60f78497d3cf4449bc300b32eab39e7b08c6c993deedb943e4523762410c3
+        checksum/init-sysctl: 67bf6b909eca710d101ec5e143dfaf7d9a80848b31b012d19eea575eccd01adc
+        checksum/plugins: 4aeb1b7e7a66381560c4330b5371ff9c5dae758209b6ffc426d59c1253ad6cc8
+        checksum/secret: 22442916643a2ec84f993df0df7161bb3c987b4cbcfab490260881cf5974956f
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -331,7 +331,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ec66b61660de8f5cef6e5115befb8558d5398c74b2d79c402e289a7346d8cc39
-        checksum/init-sysctl: 4d7639ef3ce5859aa2ade5883482cff4cf5850cf9e181be3e0445fcc10405389
-        checksum/plugins: 77683b6c73c557ebe601b0c7b58103eaf3a9e876ba14c25d4ce90ff672797269
-        checksum/secret: 196258937c3904dfea206d6a699ca2344dac430b580ce4c55e94280703c39cf6
+        checksum/config: a6e3169d3912bafdca440eaff60a44bf6d2594e5c444d09e25861964d0061e7d
+        checksum/init-sysctl: 5b161c68cc1923f65a84d2a27dbbad249c4bfefa96ae441355a12ffbb2e26a67
+        checksum/plugins: 7fef3b3df3c7047114c35cf3b247877a5ef95bacd5c971f21c0a9e8088a23311
+        checksum/secret: 45a38bd00a2eb5d3bc3921b08ceb470264ac83a4fea1e4db456442b463d3dc85
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -332,7 +332,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: http-routes-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2206c9836bd213ecf42687fd32c83f7083fd52d4e2d6fc8afe04600af1a879f1
-        checksum/init-sysctl: 0a8abfd3db223684fab0bc0fe1fe9f939db2588990ca35051e6534d1ba4ea2d5
-        checksum/plugins: ab43faf087f5b9a77c9d40c9c4349af82853243a7707c492bd91fc1b8ddf636a
-        checksum/secret: 1e584e25a432a868aed8f1f7b173574112c7b8557addbf57d3a3204d58880353
+        checksum/config: 82f82e79008b3dc2f25722d433e3605ede5b609e85131cef245231b3c0b68792
+        checksum/init-sysctl: ac8e55c8e23e5c8c90deba322e789eb93f64c0286e866a807b1277875ab6d370
+        checksum/plugins: 23fec03a0062f5d2b7232eb5a9107e00c1c017e56b4b9d090bd8ef662a6ba873
+        checksum/secret: 792d2f71a6b909abfcf1e9bdcbfc8fcc2e0bf8a6e7ff81b0ef7d525ec89111b8
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -339,7 +339,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -73,7 +73,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -430,7 +430,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -577,7 +577,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -597,10 +597,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 622af5e3ba616bcbe6f86d1462fada778fc7b7e159681b810e2742bfa8384188
-        checksum/init-sysctl: 21bee56527e146cb882395d5941d683e804bd31feb64f9751932fa063a0b4465
-        checksum/plugins: bd00805e7a34dc0272942d22acfbde1c91e56fa62babc8c16e971a639becfb63
-        checksum/secret: 83f0ef7ce8385ec9e1e08547369e12f45de2aa6ae07f8a7b249658629c5ef2ac
+        checksum/config: 525f00aa77e9dfe3d0eaf02370cb7ec027601df83410a4329f409ea043e21ef1
+        checksum/init-sysctl: 19548f564ebf9a0369de5c6f4f5950b46af7b5e50b8939a990de7c397113659a
+        checksum/plugins: 5e27f98548e31093547dde4c1be36c1d3e047c798b74a21ecf5467c15b86918f
+        checksum/secret: 1b3f3c7f2cbc31c793c0b1c858844677583d62a38f8d9275f291f56f4e128b02
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -646,7 +646,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -962,7 +962,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 17bc84577c4b93ae15bfdea8c5158348c69b18ccd1558a088d3b6714f12c5067
-        checksum/init-sysctl: ea1eccb35bab5e1f9c8d421904bde50061819bbc1fef30ca8e8f6369d72bc713
-        checksum/plugins: fb5df28d02e18a49e66c68cbe60e0bc504338ee02f7cfec45ee554208d652e22
-        checksum/secret: adb750489a26ad062b3278072f0e55270cafc255fa8da61ddbd6fadee73f707a
+        checksum/config: 33ad198aff9726c2ec0a51169cc18aa5bf2b60f65774bd3d42a980c2c8207006
+        checksum/init-sysctl: ea3b788e07750bcdd68b4de74b79d52f22255a37ac08dae26c9ef0850975a787
+        checksum/plugins: bbf71281cd30eb417bf8546f614fac10ef009510022da169d14bc5d75b8b496b
+        checksum/secret: 4becc4315c935463958a5234a5f821969c955a5db9e870de7720de980d238fe5
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,7 +358,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: install-plugins-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -35,7 +35,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -162,7 +162,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -182,10 +182,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 45f2e44cea7c59d6d754f627f7fc400e75c3cd4071f6b38dd4a459406f30d237
-        checksum/init-sysctl: 26ba80aeb8ee0b0418fd2ccb78344a506a3c1841e6991c2089ee699cc952c938
-        checksum/plugins: 348a3cedace93e2fb351359fc36fe0516d10e3ae2dc9529c393ca4a885a43bd6
-        checksum/secret: 803711b9627fe9a7c48391436ddd621c3c83ac9b12ff1b1c9d715319a4f26c2e
+        checksum/config: edd02d22f721c29e3f9d2d0c350c9495eba7bf4f635b583ea1c38c0b8f7111f7
+        checksum/init-sysctl: ea3d38e8925405063ef8097050cf091af37bbcb8b7b4f304c7b708f98251019c
+        checksum/plugins: f0ea3ca4fbceab603ab4796331343c6e9bc74c2a1bfc11a5d3e6fe43ec21c9da
+        checksum/secret: 25afb9d3d3ee52a293b09751dcac852bbcd6e0b6d99561498b6890ac56f1421e
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -231,7 +231,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -340,7 +340,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -136,7 +136,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -157,7 +157,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -262,7 +262,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-tls-values.yaml
@@ -282,10 +282,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ed0b6533b39cdf805d831d83159716edea686eb738cd9ddd692f1fee8ae12dab
-        checksum/init-sysctl: 056c849623c16889959d19cfb34485b49d60c9f47bd2e5a46ed63197dbbee914
-        checksum/plugins: 7c457c72526f29c748043036e2a2fd1cc806535f1d83caf71945b442cfe1adc4
-        checksum/secret: 22df7594c2c96bc223681bfb775f8eea26f196fc8073b3206fa37ab407e82d3c
+        checksum/config: fd0cfa6d51a79050d48964d17f6e2a4855515da171f67d944dbdddeb8de26eee
+        checksum/init-sysctl: 3908ecfbf7460ece2c7e65b21f18d558ffb6e4dcdc954cc961b1985b243822b6
+        checksum/plugins: e08a398796e12cd2766e2b67245356a3eba1e8fc0914aed3fc36447ba52e028a
+        checksum/secret: b6dc6d14520a1ae17fb0ed604201517a0f1824027849202ebf07b49858dc8344
       labels:
         app: sonarqube
         release: mcp-tls-values.yaml
@@ -331,7 +331,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -437,7 +437,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -132,7 +132,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -154,7 +154,7 @@ metadata:
   name: mcp-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -266,7 +266,7 @@ metadata:
   name: mcp-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-values.yaml
@@ -286,10 +286,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f1493982c7840b35b726bcb538ee522daaec5739ac5aecc7344b786bfd69038a
-        checksum/init-sysctl: 51e163c5f58cf66b1e035cc5f0463251fd943d8badd53a0df58af386d3d4a2a3
-        checksum/plugins: fbc2972cf825735e13baf75ad34424495b080c9af89e8546fe472056dfc1f3e3
-        checksum/secret: f43e391bc212f95e2d1142e087f3394d22098fafa89c15a220552c51b3c815de
+        checksum/config: 6a53ccfd2008b444cb66ddca9dd8a19cdabefb6db13680920bbb4bf3317cf42c
+        checksum/init-sysctl: 5367553c49449ccd620c30da5cfceed59f95f28a3894535c6875d6b5651a738b
+        checksum/plugins: 8131e6c097a0d22d103145b704ce48f03c0c0e2fdb07eb2b48e8af73935ecd12
+        checksum/secret: aa9979660cf9988c77012501f94ba51019af71582579f07c77594e2805683b98
       labels:
         app: sonarqube
         release: mcp-values.yaml
@@ -335,7 +335,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -443,7 +443,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -132,7 +132,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -154,7 +154,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -266,7 +266,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-web-context-values.yaml
@@ -286,10 +286,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5ed27d905d8db1c0c51e8c21851d784c46684697a24cfb1915334b8c16adabc8
-        checksum/init-sysctl: 36ec73060ec362e1d8a13e3d0de8d596f49450ccdfa30828fc012186c684ea6c
-        checksum/plugins: cd3c8c0a5a2310625e95c59676a726b1279c90d1bb4f5015f1484d856f07c313
-        checksum/secret: e95f44415404697227d735f66afde30b4962572926d47dd8bd3dd7dd00a974c0
+        checksum/config: ec6bd9a00b0fdb00d9afb2fd188972b80314353a7dddd80abb2764d1f4971ac2
+        checksum/init-sysctl: 7c76d68326cc9568b569bbc0be96de86606f847a5ccabb92009d4bd31b5395a2
+        checksum/plugins: 45ee15eb39000dd902a1aaa4ab64b8a024ec1304aa7a4ea4b6040c2056a1eb89
+        checksum/secret: d4423feefade02fd78c36ffdf775d76e13e44266f5641982c77c3132f382a793
       labels:
         app: sonarqube
         release: mcp-web-context-values.yaml
@@ -335,7 +335,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -441,7 +441,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2a6126851f3817fb554978da8f9b36d8deb063f7221e42fba262c61fc94dc6de
-        checksum/init-sysctl: b28cd1bcbdbac730e1c3a1ab87675604a6314f201f4565a8925612713675a702
-        checksum/plugins: c61af4c081abe17af75bb8d18d175562fa1bc25b45b6a259e107d3e9a56cc8c0
-        checksum/secret: de2c4915b3fa878fadaca666ef1c607df38ba0ed89fecdef40ad09137de925ca
+        checksum/config: 082b34d530e9adaec295435ebd4ab48aa70528710796eb4879e5c2f836222cc3
+        checksum/init-sysctl: cbe2a6055a4a4f5044f8fe27b878795b9ed208f7a85c5ef87ebda46f05348241
+        checksum/plugins: 046a67f75450976cb1ddfe1a512227ebe6b49e7009d16635ed23c998e1669851
+        checksum/secret: fadafb83564f8ef63a382cc5034e7f6ae4402ba851284d912663fb81e9642539
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,7 +387,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 02a637760a13292533e723a778d141d31df102634ad74b037089b3fa9bb51ae5
-        checksum/init-sysctl: 06f69ce467032cd14218cac9ba29f72b341539dd2eacd21c89a68eb2607f42a9
-        checksum/plugins: 9bba3d5ef5eba49e3626d834632b29c2b70270b766205d397bc49c4a06d0d428
-        checksum/secret: 82867d0326a7a391bcd0ab88c69bf0b9e0e2e636cefa3644ddd151e71abb1c7b
+        checksum/config: 325f94c7640c39dc3bc76083ec7388eae09fa6027eef706cdfcc97109a997aa7
+        checksum/init-sysctl: 216177ef8a69f248a24de3c35d8f99f6650ed9eff911d405935878fe001a638f
+        checksum/plugins: c7081977f858da939832390e6d922fd23d06cba709cced1846d0f2f66f7ecc23
+        checksum/secret: f30024fafffa4d413a71b11728cf2e2fcd28f628d9411e0ccbec3407a4f5f034
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,7 +387,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -182,7 +182,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -202,12 +202,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ed73063c8e94a38efbaca064c62b7c8da8901879d50a456e0af19caa6e26d713
-        checksum/init-sysctl: 26a379f68c62dcbee8d42c63f4547c5e8f851a2c72cd3f54314ff1bb84898494
-        checksum/plugins: 664212a24b2f5562a2dd881cdfb686749103d6fd6486373681ebcb23785206c0
-        checksum/secret: 606d99b4fa6072944a79dc9abed89ec00b58667125cbeed027e3310258cb9e71
-        checksum/prometheus-config: e3801eef699241d8cc4f0c61fdda7f5a18996ea7e463edd0c9fe6406ea297861
-        checksum/prometheus-ce-config: a1509c3732498ded808b106119aa24d481ba5273053b9e740682f041e046fce1
+        checksum/config: f34200a6183b6f3e603ac06b204f7f30c792b4ef7c1bd7bb7edd2218f65a8752
+        checksum/init-sysctl: 8dafc63871769f33b77cb93f96df7273d9911778044fa21c2f81cbd86732d9f3
+        checksum/plugins: 3f63d1532675b84a2b732aa5770d0886348a800a03b6a9e9824d3230650f8aa0
+        checksum/secret: 404a25612c4eec4dca12d5d434a32695b00fa161ea457d1e3bd31e2d2988d65e
+        checksum/prometheus-config: 5298921ea04c0954d0df21fb2c41388ab74c8fa6d9ff0161ce2a4e6af259a9de
+        checksum/prometheus-ce-config: a52fe91cabeeae0adef11f18d6ef0311dc98f0dfe7d1dd4b210c3edf01ae4e9d
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -344,7 +344,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -470,7 +470,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -509,7 +509,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -522,7 +522,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.1
+        chart: sonarqube-2026.4.0
         release: non-default-security-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -108,9 +108,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 39c39bb4ab4e0abb8552deb40984f57c560956f5151319841cd72120a10e5a1e
-        checksum/plugins: b936af56f567619a0e078db6f5ac3fafc66401fac3fa913739a843785efcf9cf
-        checksum/secret: 699306ab72328062d21649ac3ec7685de00acc8601668ab6b2e317e51ffc0424
+        checksum/config: 2c02e54fb4dae41b5a3031a7507b3ea9993ecf137575e28cb1b1f6b6a7925768
+        checksum/plugins: 6a4a0b81b28a92405c4067ef083e59d240dc5cf90521644b249e9324ff9750f9
+        checksum/secret: 9fa66ae8f1eb8121a2bede3760733a4b8a5173c1b68ab6589bb0bcaced1fda63
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -138,7 +138,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_WEB_SYSTEMPASSCODE
@@ -230,7 +230,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -256,7 +256,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: openshift-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a24f66089bb0af5f4e41881458b44648bdf223c611c884d17427d06e996b63ff
-        checksum/init-sysctl: 7183b94e6b8a07eb78d290343a1004b264396cd3f65ff6721860272bb499e1e0
-        checksum/plugins: a60725cf17d8cf3520e837d83e6beae16c0a98f4c86506abb0e858f4a37f92c7
-        checksum/secret: fc8ced1dc379b456a166242007142d38f80dca5444c8cceee12485b5be0a7177
+        checksum/config: e55654d56b5a863c8188895174fcbb6e516c7c117c8c2ffab131dcadad4608ba
+        checksum/init-sysctl: 7328762211c392b255b511a1787168abfbdb275e9119ceeffaf2c99f9ef907a9
+        checksum/plugins: dd408852aedd98f603bc5592e357b94bb08f0068ef6624c41d7b3b2710c270fc
+        checksum/secret: 8bb1da9e307e67c75f9f0c4869162a6a3ef72c7494e223f19fc4217b714ea78e
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -333,7 +333,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 876594b21dbc4701d9325b43051b2d5d57103e2360fb5d5d79187f08e21deee5
-        checksum/init-sysctl: 6ca463ab421a55cd1d2327f8e80885de74a4ca9f7bfeb3a1cfdd36f1a7404d39
-        checksum/plugins: 49f8bceda5ccf9b79d142dc17c3fd6add702e8b15bc3257292ea65a8bc00edc9
-        checksum/secret: 378288287f9d1e0870c75b3f7fdc1b8b112b575f15700115b2c0bfe9e71a2cc5
+        checksum/config: c3bce9e39c1aec78b180f857df4d75aff4a9b78bb8d0aba48f1fc90e0dd62494
+        checksum/init-sysctl: b08261d44b1cbce3fa124187d6716b7315978ba40f025b42a59c34af8faa2a61
+        checksum/plugins: 245263e7f3c5ea756cef51d637eea9ebaf438cd2bf2952c06a7c3273c9adab65
+        checksum/secret: ddb1248c8be0cc098c7b10679a9f6335c6204eeaea671c41006dc23007f9a213
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,7 +358,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -188,12 +188,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 951e048c2b7343c972807809e55496f96fdfb53976c4f62f17aff18f6c091eaa
-        checksum/init-sysctl: 1ae0bac11e69c29820a53860cd379ff331660c4b4f57c60ccdb76b31cedab7b0
-        checksum/plugins: 806ac9177af47de493c51c3e935010511f970f6dd1193a1778870c62c6c63155
-        checksum/secret: f4936aaaadf958742288045b7202ea658a9d3ae6d191046d709791fd6888af45
-        checksum/prometheus-config: b3661347f25dfd065ebcf6394f1830fb62c8ea0b9c00a9ec235ec7fef307663d
-        checksum/prometheus-ce-config: 123b895f1b852cef9a8b8c10ae8d7e0d395b679337bdbed44b47bc83d4b86846
+        checksum/config: 73035bf37163f90efca1907070ce3fc9ac16051277784e4e97cf7a12c9011b10
+        checksum/init-sysctl: 8922469ec70002ea53864192d7d9fd0ca4061a405e0f7e91dd5d725c04c66238
+        checksum/plugins: 953ce1bb8dd673745973fa155f91ea99ccc5954bc555da070b87370d96781add
+        checksum/secret: b70f1b595e819c62ac4343622a66d19da1c4e6d7b57fc9aa7556895d24103449
+        checksum/prometheus-config: 140a71ff41b0773c7322e6b67266fad3c8240cc092065d3fec4684a532cac399
+        checksum/prometheus-ce-config: f04dcf5aa9587d5f73eaa5606c6d12105028d9503d7e9f0ad6649a5876fccdf2
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -330,7 +330,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -456,7 +456,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: proxies-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -149,7 +149,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -170,7 +170,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -190,11 +190,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1b2d501c8be1b5e7dee556c57348273d076bde9c18221fc216ddf2e21130cc5a
-        checksum/init-fs: 9201352620524934b38454f74ddb3bd18de8f072ec3df141e9d398ffdddeb67b
-        checksum/init-sysctl: c836bb84c91997d78acf2c6265ed9e27873b32899b0f283c16730d4df35df377
-        checksum/plugins: e4d6be4c390a4197583e596d7b32d6033aa8b6ed64717fad008abea5f82c3ef6
-        checksum/secret: de923935f02276e16bca72890fd5c190a14756211df87c109d4e8eaa317f26f2
+        checksum/config: aae98c8107cca58cf73bb29953945a03fbdb26c2ab76916ea3172b81381feb07
+        checksum/init-fs: 26c31c70f44f07bf1a39202744b37cb7ea7c29677bbea8823ac1a75ca657902b
+        checksum/init-sysctl: 23e0e0bb17a20b2050c08d2336cd71c740f1b6ca65353f4a13372c7ef88f4b59
+        checksum/plugins: 3ad535d263c095e4b8ec152314995c3905e31e8aa075cbacf0c25e22b8c4fc4e
+        checksum/secret: 83be113d55a6fb5f847c246aded0f67c638c906db46a6bad674cf32402d9a298
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -274,7 +274,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -382,7 +382,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: pvc-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9ba8d1cab1db7c254169599d3813bb7231b90ce34c7df17fc084d4da661c2824
-        checksum/init-sysctl: 1a512579d737ffb73334b63a8978bc1e1ca2ff872b080e7b0efe868eb8ab336a
-        checksum/plugins: cab9b588fc7a09a1694f5b2f4b8de59e00ea986d3955357bdeabd3c6c9428562
-        checksum/secret: 60fc9b8583d5fa60f3c8d59ead90107380bdefb63978d97847de8707e3aea36a
+        checksum/config: a4b7898832e0cbd07860503f4e4ce312cc5f80c0cec2635a37cee5d2f0960ba2
+        checksum/init-sysctl: 5563ae80cb7cc44bb42e56708d0ce19eaea7aa849dc031f43c773243b40461f6
+        checksum/plugins: 9959988d5b606f4d49b863cf81d75acf7818dc409e814b4d6c893a584409c08c
+        checksum/secret: 53348600a1b4dab74146077043992a5bdecd89652590612bdb45444d562838d4
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,7 +320,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -359,7 +359,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -372,7 +372,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.1
+        chart: sonarqube-2026.4.0
         release: secret-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -142,7 +142,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -162,10 +162,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3ba4505478d05b8e4d5fd53b95844b984c6ae09af27ac765a5d856e8eabd2b25
-        checksum/init-sysctl: 090b2f721285969a4475804c2769e455a016481433d419db72b747692e7c2d2b
-        checksum/plugins: c39a0bb83e4795f1ff59568fe2728d83c7b4d1c8d98790a9e1eb0e5d2c969adc
-        checksum/secret: 199468c0cb1896267633d3bf77a5f05c1771550ffb17b07c5a0d7041c8ba3d3c
+        checksum/config: 52148d5dbcbd52e7536aac496eb7c295dad9e07b09f6a8a09ab9b6e771b4a2f7
+        checksum/init-sysctl: 381e63f834b1eeeef9a2c5c27ef041918fd8e54b6e3702c410e6383d19705648
+        checksum/plugins: 4e9517b2be186a144ce4c5e58dec090f5a23a9070f590564bda48f225bad8919
+        checksum/secret: 3178fee1a68ee3a08bcf23d90fd30f924d92ed11a13fa4347365d99c8978eeae
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -211,7 +211,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -313,7 +313,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: service-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -21,7 +21,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b39340eed6005d7a5295006fe66f2ba9aa671c2a2567cbd54ac824dff019bdb5
-        checksum/init-sysctl: 49b369d19e72076983a105c836778663807c4b087af0f934c4cc0c43c0f26932
-        checksum/plugins: 9f9b8043d4641726ecbc0ac50c20a731b7715eb3d06b5cf4ef32b8a70e658dcc
-        checksum/secret: 1f8e4e366edd9e5f5f54a8dd2564d4fcdc2e8078f1a7ca5a1145b549f6b3988e
+        checksum/config: f40aa310ae50839489da2419eb424abab27241d2e766bed689b5c4270caa436e
+        checksum/init-sysctl: a4e32471f335798f90b3cea67cdafe60c038b8de6844dbba9c00240c40e421b6
+        checksum/plugins: 7599f2fa2b21fcce14a78b44ca69f9b5b6415b82f2395269a0961519ee48af77
+        checksum/secret: 591778fe99082fa7be753423878e177e564164bf667f5dacafb3020beac0b2ac
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,7 +320,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -170,10 +170,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f46201ff241d09912d6eed01a8ea3872a32c0bc8f50164029fbdb760c3cca9e5
-        checksum/init-sysctl: ca016ef4ebf4cf249fc4097d95143d922e8b2d95e02d040771b7a6e9dd38e22f
-        checksum/plugins: 7f830994acee9bbd364c9df979a9013db9cccb3722b494b8c7b8777340d4bb77
-        checksum/secret: c56fcd70d627d84e10baf625246da30232cc4894696272fd706d976564006a0c
+        checksum/config: 6e61b0b07ddb7d1f388275c0e1dee9a0ac6c5281b99d48840568d638a60f8645
+        checksum/init-sysctl: 1ad5c508cb14f05229c9ae294de0bd856e4c3b48c9dd380981104974944bdafa
+        checksum/plugins: 4cb063e3d5ba5abfe2dd7badddf3cc822047a8c179719ebe7c555e05cc3ca61d
+        checksum/secret: 9dbc0d09645eea1a210fbbfe3dbe28210357b1a2481b61c5a3ca6674bcfae4da
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -219,7 +219,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -317,7 +317,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -344,7 +344,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -383,7 +383,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -395,7 +395,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.1
+        chart: sonarqube-2026.4.0
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a1589d79fa8e3ba59b68f8e453f6d98969dcb5a6fbff20d97f6a93dce94b19ee
-        checksum/init-sysctl: 957741969a9e46d973acfc3a5787c19ab43182a0c2a0ed22a3704df02ab1500b
-        checksum/plugins: b8e603efc449cd7b9db5c7c43e280750a45ca455fd27cdfbfe8a506c41ef32c1
-        checksum/secret: d89b0d93fe4ba08fd7c75b760eadef8cf62633d1018aa129affae783be9538d2
+        checksum/config: ef6bfa7856429244655c2564a930a07388e4106a9f84f3f4e2e50309534205be
+        checksum/init-sysctl: 0f903cae0d61f392f039f5ccafb0d164f1413c62a67673e32ff55139c6037b03
+        checksum/plugins: 4dba59a122795b0d834643628e16ef96589161b417fac43f159848db0a9d6cac
+        checksum/secret: c392b39565f2ed8f0ee75bea9dc4c893cf65cc65a18bf2b8c64673b3652bfaa2
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -343,7 +343,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -382,7 +382,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -394,7 +394,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.1
+        chart: sonarqube-2026.4.0
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 297ab96275ee260adabcad3f7e5c146043f553b65b0d94614770845cc59cf91d
-        checksum/init-sysctl: dc51e8b46ab7b58b29a3b21a3a16da5bd04dd777d6aa4d5c4a2922a42c092ab0
-        checksum/plugins: 01cf839f85a04fadbc57e8ee107be6b98c6cbfe6eb4f6eaccae8486d4a8f386b
-        checksum/secret: 37c92278e1770bdd663793d685294e5861c3165d9a2a6f3e1392fc2d091e73fd
+        checksum/config: e60513625e2be48829bb43695595c09cc5534341f2a20db3768fccede6fb5c4c
+        checksum/init-sysctl: 63275adbafe9014deea669a856116508609c3cbd60212342bc3d4d5a57448753
+        checksum/plugins: ab83f4790e0698e74f8d38e0e17559051beadff5ea4204ef5f9fb6f66c690769
+        checksum/secret: 8c18ea709ac7884411cf7b8f82afa2161ff736dbf402ab5b714cbc31c40e89e2
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -343,7 +343,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -382,7 +382,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -394,7 +394,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.3.1
+        chart: sonarqube-2026.4.0
         release: sonar-web-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f74e65ff2cab3fd1902b4e0947bd021f33a4ab95eeecf62c9a57d055da8514d6
-        checksum/init-fs: 27939a62b11f6c8af7fa5b0348061057c379751df532d3da93b673177cb98e3a
-        checksum/init-sysctl: 2250f4f499a6552e56b5bac376165e3983c1824989b308d2cedab768e273fb8e
-        checksum/plugins: ba59781f339a9f4f3198a7641c9314b94f512f2188fb1d17ab53a2f7fc5019a8
-        checksum/secret: 5cbdf8a186f4f4f96b45cf98409aa7483cd93d8b3e7e055de4b359747406a8a0
+        checksum/config: 2b1ce8be4fabedd9d304122ceb23ac31d90a340fc7a431cea6fef286973e366a
+        checksum/init-fs: 7494966e6603796588c3f1c5daa962018427f8462936cafb62ebaf58a64bc728
+        checksum/init-sysctl: 242c60f67a6bca364cdd4fe5e7f4efd72307440b7414f9c2661b1afb87b8574f
+        checksum/plugins: 1841c47901dae4670271e69493393ee8b2395a074839cb42c327508f4790f238
+        checksum/secret: 2812b2392e93a8b919d427e1448a8d78a34ea6c1fc3f7da9263a8571d037245e
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.3.1
+              value: 2026.4.0
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -389,7 +389,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.3.1
+    chart: sonarqube-2026.4.0
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -23,7 +23,7 @@ var chartPath string = "../../charts/sonarqube"
 var releaseName string = "sonarqube"
 
 // Community Build Version
-var expectedContainerImage string = "sonarqube:26.5.0.122743"
+var expectedContainerImage string = "sonarqube:26.6.0.123539"
 
 // Ensure we are using the dry-run flag
 var helmOptions *helm.Options = &helm.Options{

--- a/tests/unit-test/test-cases-values/sonarqube/test-build-number.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-build-number.yaml
@@ -1,3 +1,3 @@
 community:
   enabled: true
-  buildNumber: "26.5.0.122743"
+  buildNumber: "26.6.0.123539"


### PR DESCRIPTION
----
## Summary by Gitar

- **Version upgrades:**
  - Upgraded SonarQube Community build from `26.5.0.122743` to `26.6.0.123539` across Helm chart values, documentation, and tests.
  - Updated `CHANGELOG.md` to reflect the new SonarQube Community build version.

<sub>This will update automatically on new commits.</sub>