### PR TITLE
SONAR-28162 Bump GCP Deployer image 2025.4

### DIFF
--- a/google-cloud-marketplace-k8s-app/Dockerfile
+++ b/google-cloud-marketplace-k8s-app/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM=gcr.io/cloud-marketplace-tools/k8s/deployer_helm:0.12.6
+ARG FROM=gcr.io/cloud-marketplace-tools/k8s/deployer_helm:0.12.19
 FROM $FROM
 
 ENV WAIT_FOR_READY_TIMEOUT 1200


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `deployer_helm` image from `0.12.6` to `0.12.19` in `google-cloud-marketplace-k8s-app/Dockerfile`.

<sub>This will update automatically on new commits.</sub>