### PR TITLE
fix: curl isn't present in image for inject-prometheus-exporter

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
 * Upgrade SonarQube Community build to 26.6.0.123539
+* Replace curl with wget in the prometheus-exporter init container, as curl is not available in the image
 
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -39,6 +39,8 @@ annotations:
       description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
       description: "Upgrade SonarQube Community build to 26.6.0.123539"
+    - kind: changed
+      description: "Replace curl with wget in the prometheus-exporter init container, as curl is not available in the image"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -142,7 +142,7 @@ spec:
           resources:
 {{ toYaml (default .Values.initContainers.resources .Values.ApplicationNodes.prometheusExporter.resources) | indent 12 }}
           command: ["/bin/sh","-c"]
-          args: ["curl -s '{{ template "prometheusExporter.downloadURL" . }}' {{ if .Values.ApplicationNodes.prometheusExporter.noCheckCertificate }}--insecure{{ end }} --output /data/jmx_prometheus_javaagent.jar -v"]
+          args: ["wget '{{ template "prometheusExporter.downloadURL" . }}' {{ if .Values.ApplicationNodes.prometheusExporter.noCheckCertificate }}--no-check-certificate{{ end }} --output-document /data/jmx_prometheus_javaagent.jar -v"]
           volumeMounts:
             - mountPath: /data
               name: sonarqube

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
 * Upgrade SonarQube Community build to 26.6.0.123539
+* Replace curl with wget in the prometheus-exporter init container, as curl is not available in the image
 
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -44,6 +44,8 @@ annotations:
       description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
       description: "Upgrade SonarQube Community build to 26.6.0.123539"
+    - kind: changed
+      description: "Replace curl with wget in the prometheus-exporter init container, as curl is not available in the image"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -132,7 +132,7 @@ spec:
       resources: {{- toYaml . | nindent 8 }}
       {{- end }}
       command: ["/bin/sh", "-c"]
-      args: ["curl -s '{{ include "prometheusExporter.downloadURL" . }}' {{ if $.Values.prometheusExporter.noCheckCertificate }}--insecure{{ end }} --output /data/jmx_prometheus_javaagent.jar -v"]
+      args: ["wget '{{ include "prometheusExporter.downloadURL" . }}' {{ if $.Values.prometheusExporter.noCheckCertificate }}--no-check-certificate{{ end }} --output-document /data/jmx_prometheus_javaagent.jar -v"]
       volumeMounts:
         - mountPath: /data
           name: sonarqube


### PR DESCRIPTION
`inject-prometheus-exporter` exit with error `/bin/sh: 1: curl: not found`

Replaced curl with wget, as curl is not available in the image.

Please ensure your pull request adheres to the following guidelines:
- [X] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`