### PR TITLE
SONAR-25813 Allow initContainers to use CaCerts

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -6,6 +6,8 @@ All changes to this chart will be documented in this file.
 * Upgrade SonarQube Community build to 26.6.0.123539
 * Add `searchNodes.extraInitContainers` and `applicationNodes.extraInitContainers` to allow per-node-type extra init containers
 * Deprecate root-level `extraInitContainers` in favour of the node-specific values
+* Add CA certificate support with multi-cert bundling to `install-plugins` init container for plugin downloads from servers using self-signed or private CA certificates
+* Fix multi-cert CA bundle handling in `install-oracle-jdbc-driver` init container
 
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -39,6 +39,14 @@ annotations:
       description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
       description: "Upgrade SonarQube Community build to 26.6.0.123539"
+    - kind: added
+      description: "Add searchNodes.extraInitContainers and applicationNodes.extraInitContainers for per-node-type extra init containers"
+    - kind: deprecated
+      description: "Deprecate root-level extraInitContainers in favour of node-specific values"
+    - kind: added
+      description: "Add CA certificate support with multi-cert bundling to install-plugins init container"
+    - kind: fixed
+      description: "Fix multi-cert CA bundle handling in install-oracle-jdbc-driver init container"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/install-oracle-jdbc-driver.yaml
+++ b/charts/sonarqube-dce/templates/install-oracle-jdbc-driver.yaml
@@ -14,5 +14,5 @@ data:
   install_oracle_jdbc_driver.sh: |-
       rm -f {{ .Values.sonarqubeFolder }}/extensions/jdbc-driver/oracle/*
       cd {{ .Values.sonarqubeFolder }}/extensions/jdbc-driver/oracle
-      curl {{- if .Values.caCerts.enabled }} --cacert /tmp/secrets/ca-certs/* {{- end }} {{ if .Values.jdbcOverwrite.oracleJdbcDriver.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ .Values.jdbcOverwrite.oracleJdbcDriver.url }}
+      curl {{- if .Values.caCerts.enabled }} --cacert /tmp/certs/ca-bundle.pem{{- end }} {{ if .Values.jdbcOverwrite.oracleJdbcDriver.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ .Values.jdbcOverwrite.oracleJdbcDriver.url }}
 {{- end }}

--- a/charts/sonarqube-dce/templates/install-plugins.yaml
+++ b/charts/sonarqube-dce/templates/install-plugins.yaml
@@ -15,6 +15,6 @@ data:
       rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
       cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.ApplicationNodes.plugins.install }}
-      curl {{- if $.Values.caCerts.enabled }} --cacert /tmp/secrets/ca-certs/*{{- end }} {{ if $.Values.ApplicationNodes.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.ApplicationNodes.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
+      curl {{- if $.Values.caCerts.enabled }} --cacert /tmp/certs/ca-bundle.pem{{- end }} {{ if $.Values.ApplicationNodes.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.ApplicationNodes.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
       {{- end }}
     {{- end }}

--- a/charts/sonarqube-dce/templates/install-plugins.yaml
+++ b/charts/sonarqube-dce/templates/install-plugins.yaml
@@ -15,6 +15,6 @@ data:
       rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
       cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.ApplicationNodes.plugins.install }}
-      curl {{ if $.Values.ApplicationNodes.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.ApplicationNodes.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
+      curl {{- if $.Values.caCerts.enabled }} --cacert /tmp/secrets/ca-certs/*{{- end }} {{ if $.Values.ApplicationNodes.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.ApplicationNodes.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
       {{- end }}
     {{- end }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -83,7 +83,6 @@ spec:
             - mountPath: /tmp/certs
               name: sonarqube
               subPath: certs
-              readOnly: true
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
           {{- with .Values.env }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -172,6 +172,10 @@ spec:
             - name: plugins-netrc-file
               mountPath: /root
             {{- end }}
+            {{- if .Values.caCerts.enabled }}
+            - mountPath: /tmp/secrets/ca-certs
+              name: ca-certs
+            {{- end }}
           {{- with (default (fromYaml (include "sonarqube.initContainersSecurityContext" .)) .Values.ApplicationNodes.plugins.securityContext) }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -73,7 +73,7 @@ spec:
           image: {{ default (include "sonarqube.image" .) .Values.caCerts.image }}
           imagePullPolicy: {{ .Values.ApplicationNodes.image.pullPolicy  }}
           command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
           {{- with (include "sonarqube.initContainersSecurityContext" .) }}
           securityContext: {{- . | nindent 12 }}
           {{- end }}
@@ -83,6 +83,7 @@ spec:
             - mountPath: /tmp/certs
               name: sonarqube
               subPath: certs
+              readOnly: true
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
           {{- with .Values.env }}
@@ -173,8 +174,10 @@ spec:
               mountPath: /root
             {{- end }}
             {{- if .Values.caCerts.enabled }}
-            - mountPath: /tmp/secrets/ca-certs
-              name: ca-certs
+            - mountPath: /tmp/certs
+              name: sonarqube
+              subPath: certs
+              readOnly: true
             {{- end }}
           {{- with (default (fromYaml (include "sonarqube.initContainersSecurityContext" .)) .Values.ApplicationNodes.plugins.securityContext) }}
           securityContext: {{- toYaml . | nindent 12 }}
@@ -210,9 +213,11 @@ spec:
             - name: oracle-jdbc-driver-netrc-file
               mountPath: /root
           {{- end }}
-          {{- if .Values.caCerts.enabled }} 
-            - mountPath: /tmp/secrets/ca-certs
-              name: ca-certs
+          {{- if .Values.caCerts.enabled }}
+            - mountPath: /tmp/certs
+              name: sonarqube
+              subPath: certs
+              readOnly: true
           {{- end }}
           {{- with .Values.env }}
             {{- . | toYaml | trim | nindent 12 }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -4,6 +4,8 @@ All changes to this chart will be documented in this file.
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
 * Upgrade SonarQube Community build to 26.6.0.123539
+* Add CA certificate support with multi-cert bundling to `install-plugins` init container for plugin downloads from servers using self-signed or private CA certificates
+* Fix multi-cert CA bundle handling in `install-oracle-jdbc-driver` init container
 
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -44,6 +44,10 @@ annotations:
       description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
       description: "Upgrade SonarQube Community build to 26.6.0.123539"
+    - kind: added
+      description: "Add CA certificate support with multi-cert bundling to install-plugins init container"
+    - kind: fixed
+      description: "Fix multi-cert CA bundle handling in install-oracle-jdbc-driver init container"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -48,7 +48,7 @@ spec:
       image: {{ default (include "sonarqube.image" $) .Values.caCerts.image }}
       imagePullPolicy: {{ .Values.image.pullPolicy  }}
       command: ["sh"]
-      args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+      args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
       {{- with (include "sonarqube.initContainerSecurityContext" .) }}
       securityContext: {{- . | nindent 8 }}
       {{- end }}
@@ -202,8 +202,10 @@ spec:
           mountPath: /root
         {{- end }}
         {{- if .Values.caCerts.enabled }}
-        - mountPath: /tmp/secrets/ca-certs
-          name: ca-certs
+        - mountPath: /tmp/certs
+          name: sonarqube
+          subPath: certs
+          readOnly: true
         {{- end }}
       env:
         {{- with (include "sonarqube.install-plugins-proxy.env" .) }}
@@ -233,8 +235,10 @@ spec:
           mountPath: /root
         {{- end }}
       {{- if .Values.caCerts.enabled }}
-        - mountPath: /tmp/secrets/ca-certs
-          name: ca-certs
+        - mountPath: /tmp/certs
+          name: sonarqube
+          subPath: certs
+          readOnly: true
       {{- end }}
       env:
         {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 8 }}

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -201,6 +201,10 @@ spec:
         - name: plugins-netrc-file
           mountPath: /root
         {{- end }}
+        {{- if .Values.caCerts.enabled }}
+        - mountPath: /tmp/secrets/ca-certs
+          name: ca-certs
+        {{- end }}
       env:
         {{- with (include "sonarqube.install-plugins-proxy.env" .) }}
         {{- . | nindent 8 }}

--- a/charts/sonarqube/templates/install-oracle-jdbc-driver.yaml
+++ b/charts/sonarqube/templates/install-oracle-jdbc-driver.yaml
@@ -8,5 +8,5 @@ data:
   install_oracle_jdbc_driver.sh: |-
       rm -f {{ .Values.sonarqubeFolder }}/extensions/jdbc-driver/oracle/*
       cd {{ .Values.sonarqubeFolder }}/extensions/jdbc-driver/oracle
-      curl {{- if .Values.caCerts.enabled }} --cacert /tmp/secrets/ca-certs/* {{- end }} {{ if .Values.jdbcOverwrite.oracleJdbcDriver.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ .Values.jdbcOverwrite.oracleJdbcDriver.url }}
+      curl {{- if .Values.caCerts.enabled }} --cacert /tmp/certs/ca-bundle.pem{{- end }} {{ if .Values.jdbcOverwrite.oracleJdbcDriver.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ .Values.jdbcOverwrite.oracleJdbcDriver.url }}
 {{- end }}

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -9,6 +9,6 @@ data:
       rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
       cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.plugins.install }}
-      curl {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
+      curl {{- if $.Values.caCerts.enabled }} --cacert /tmp/secrets/ca-certs/*{{- end }} {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
       {{- end }}
     {{- end }}

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -9,6 +9,6 @@ data:
       rm -f {{ .Values.sonarqubeFolder }}/extensions/plugins/*
       cd {{ .Values.sonarqubeFolder }}/extensions/plugins
       {{- range $index, $val := .Values.plugins.install }}
-      curl {{- if $.Values.caCerts.enabled }} --cacert /tmp/secrets/ca-certs/*{{- end }} {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
+      curl {{- if $.Values.caCerts.enabled }} --cacert /tmp/certs/ca-bundle.pem{{- end }} {{ if $.Values.plugins.noCheckCertificate }}--insecure{{ end }} {{ if $.Values.plugins.netrcCreds }}--netrc-file /root/.netrc{{ end }} -fsSLO {{ $val | quote }}
       {{- end }}
     {{- end }}

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -213,6 +213,9 @@ metadata:
     heritage: Helm
 data:
   install_plugins.sh: |-
+      rm -f /opt/sonarqube/extensions/plugins/*
+      cd /opt/sonarqube/extensions/plugins
+      curl --cacert /tmp/certs/ca-bundle.pem   -fsSLO "https://binaries.sonarsource.com/plugins/org/sonarsource/java/sonar-java-plugin/3.4/sonar-java-plugin-3.4.jar"
 ---
 # Source: sonarqube-dce/templates/jdbc-config.yaml
 apiVersion: v1
@@ -361,7 +364,7 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2bda5746fe990a6decb5a472ae5feedd2fbbb9a1c515b2e81e8ea885a1c3a114
+        checksum/plugins: 8bd56cf921930fef007fa207dfdb36d4ff3f79264cf8964f105ad7f335ca7f7e
         checksum/config: 3e93365933f046d46b57dfc9a58e0a50caf2461456c437c8c2c5e45d69121ae4
         checksum/secret: 4fcdf56b28c2bb3c1425d9113cc14b48aaeb2c52210ed742587557054ac5e9e6
     spec:
@@ -391,6 +394,51 @@ spec:
               subPath: certs
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
+        - name: install-plugins
+          image: sonarqube:2026.3.1-datacenter-app
+          imagePullPolicy: IfNotPresent
+          command: ["sh",
+            "-e",
+            "/tmp/scripts/install_plugins.sh"]
+          volumeMounts:
+            - mountPath: /opt/sonarqube/extensions/plugins
+              name: sonarqube
+              subPath: extensions/plugins
+            - name: install-plugins
+              mountPath: /tmp/scripts/
+            - mountPath: /tmp/certs
+              name: sonarqube
+              subPath: certs
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            {}
+          env:
+            - name: http_proxy
+              valueFrom:
+                secretKeyRef:
+                  name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
+                  key: PLUGINS-HTTP-PROXY
+            - name: https_proxy
+              valueFrom:
+                secretKeyRef:
+                  name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
+                  key: PLUGINS-HTTPS-PROXY
+            - name: no_proxy
+              valueFrom:
+                secretKeyRef:
+                  name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
+                  key: PLUGINS-NO-PROXY
         - name: install-oracle-jdbc-driver
           image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
@@ -535,6 +583,9 @@ spec:
             - mountPath: /opt/sonarqube/data
               name: sonarqube
               subPath: data
+            - mountPath: /opt/sonarqube/extensions/plugins
+              name: sonarqube
+              subPath: extensions/plugins
             - mountPath: /opt/sonarqube/extensions/jdbc-driver/oracle
               name: sonarqube
               subPath: extensions/jdbc-driver/oracle

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -389,7 +389,6 @@ spec:
             - mountPath: /tmp/certs
               name: sonarqube
               subPath: certs
-              readOnly: true
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -199,7 +199,7 @@ data:
   install_oracle_jdbc_driver.sh: |-
       rm -f /opt/sonarqube/extensions/jdbc-driver/oracle/*
       cd /opt/sonarqube/extensions/jdbc-driver/oracle
-      curl --cacert /tmp/secrets/ca-certs/* --netrc-file /root/.netrc -fsSLO https://download.oracle.com/otn-pub/otn_software/jdbc/2113/ojdbc11.jar
+      curl --cacert /tmp/certs/ca-bundle.pem --netrc-file /root/.netrc -fsSLO https://download.oracle.com/otn-pub/otn_software/jdbc/2113/ojdbc11.jar
 ---
 # Source: sonarqube-dce/templates/install-plugins.yaml
 apiVersion: v1
@@ -371,7 +371,7 @@ spec:
           image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -389,6 +389,7 @@ spec:
             - mountPath: /tmp/certs
               name: sonarqube
               subPath: certs
+              readOnly: true
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver
@@ -413,9 +414,11 @@ spec:
             - name: install-oracle-jdbc-driver
               mountPath: /tmp/scripts/
             - name: oracle-jdbc-driver-netrc-file
-              mountPath: /root 
-            - mountPath: /tmp/secrets/ca-certs
-              name: ca-certs
+              mountPath: /root
+            - mountPath: /tmp/certs
+              name: sonarqube
+              subPath: certs
+              readOnly: true
       securityContext:
         fsGroup: 0
       containers:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -373,7 +373,6 @@ spec:
             - mountPath: /tmp/certs
               name: sonarqube
               subPath: certs
-              readOnly: true
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
       securityContext:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -355,7 +355,7 @@ spec:
           image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -373,6 +373,7 @@ spec:
             - mountPath: /tmp/certs
               name: sonarqube
               subPath: certs
+              readOnly: true
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
       securityContext:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -108,7 +108,7 @@ data:
   install_oracle_jdbc_driver.sh: |-
       rm -f /opt/sonarqube/extensions/jdbc-driver/oracle/*
       cd /opt/sonarqube/extensions/jdbc-driver/oracle
-      curl --cacert /tmp/secrets/ca-certs/* --netrc-file /root/.netrc -fsSLO https://download.oracle.com/otn-pub/otn_software/jdbc/2113/ojdbc11.jar
+      curl --cacert /tmp/certs/ca-bundle.pem --netrc-file /root/.netrc -fsSLO https://download.oracle.com/otn-pub/otn_software/jdbc/2113/ojdbc11.jar
 ---
 # Source: sonarqube/templates/install-plugins.yaml
 apiVersion: v1
@@ -187,7 +187,7 @@ spec:
           image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -253,8 +253,10 @@ spec:
               mountPath: /tmp/scripts/
             - name: oracle-jdbc-driver-netrc-file
               mountPath: /root
-            - mountPath: /tmp/secrets/ca-certs
-              name: ca-certs
+            - mountPath: /tmp/certs
+              name: sonarqube
+              subPath: certs
+              readOnly: true
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -122,6 +122,9 @@ metadata:
     heritage: Helm
 data:
   install_plugins.sh: |-
+      rm -f /opt/sonarqube/extensions/plugins/*
+      cd /opt/sonarqube/extensions/plugins
+      curl --cacert /tmp/certs/ca-bundle.pem   -fsSLO "https://binaries.sonarsource.com/plugins/org/sonarsource/java/sonar-java-plugin/3.4/sonar-java-plugin-3.4.jar"
 ---
 # Source: sonarqube/templates/service.yaml
 apiVersion: v1
@@ -173,7 +176,7 @@ spec:
       annotations:
         checksum/config: f8aa11f39a0e5d00b8b50d9eaf3ed699745188e09567c2c1c63fc269353a7b50
         checksum/init-sysctl: 6b529bd8bcc2d60623f4c142ecf474354b0898e76dadc0bc6958c77afe788443
-        checksum/plugins: 11b3085442c8fe26074ef53cf7874d8e729fadd1af33b0f50cd3c5865fddaecf
+        checksum/plugins: aa778a5be8a9c931ff4f4db1a6f2ceeea2ab86e76fe4540ef665495a72a2e047
         checksum/secret: 2c83f97b3e967ed3bb7af7f9ab9c1602c9aecf8b0b67c8df5491c6d4265bf3b2
       labels:
         app: sonarqube
@@ -224,6 +227,53 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
           env:
+            - name: SONAR_WEB_CONTEXT
+              value: /
+            - name: SONAR_WEB_JAVAOPTS
+              value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
+            - name: SONAR_CE_JAVAOPTS
+              value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
+        - name: install-plugins
+          image: sonarqube:2026.3.1-enterprise
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /opt/sonarqube/extensions/plugins
+              name: sonarqube
+              subPath: extensions/plugins
+            - name: install-plugins
+              mountPath: /tmp/scripts/
+            - mountPath: /tmp/certs
+              name: sonarqube
+              subPath: certs
+              readOnly: true
+          env:
+            - name: http_proxy
+              valueFrom:
+                secretKeyRef:
+                  name: ca-certificates-configmap.yaml-sonarqube-http-proxies
+                  key: PLUGINS-HTTP-PROXY
+            - name: https_proxy
+              valueFrom:
+                secretKeyRef:
+                  name: ca-certificates-configmap.yaml-sonarqube-http-proxies
+                  key: PLUGINS-HTTPS-PROXY
+            - name: no_proxy
+              valueFrom:
+                secretKeyRef:
+                  name: ca-certificates-configmap.yaml-sonarqube-http-proxies
+                  key: PLUGINS-NO-PROXY
             - name: SONAR_WEB_CONTEXT
               value: /
             - name: SONAR_WEB_JAVAOPTS
@@ -381,6 +431,12 @@ spec:
             items:
               - key: init_sysctl.sh
                 path: init_sysctl.sh
+        - name: install-plugins
+          configMap:
+            name: ca-certificates-configmap.yaml-sonarqube-install-plugins
+            items:
+              - key: install_plugins.sh
+                path: install_plugins.sh
         - name: install-oracle-jdbc-driver
           configMap:
             name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -171,7 +171,7 @@ spec:
           image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/sonarqube-dce/ca-certificates-configmap.yaml
@@ -5,6 +5,11 @@ caCerts:
     key: forticlient.crt
     path: forticlient.crt
 
+applicationNodes:
+  plugins:
+    install:
+      - "https://binaries.sonarsource.com/plugins/org/sonarsource/java/sonar-java-plugin/3.4/sonar-java-plugin-3.4.jar"
+
 jdbcOverwrite:
   oracleJdbcDriver:
     url: "https://download.oracle.com/otn-pub/otn_software/jdbc/2113/ojdbc11.jar"

--- a/tests/unit-compatibility-test/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/sonarqube/ca-certificates-configmap.yaml
@@ -7,6 +7,10 @@ caCerts:
     key: forticlient.crt
     path: forticlient.crt
 
+plugins:
+  install:
+    - "https://binaries.sonarsource.com/plugins/org/sonarsource/java/sonar-java-plugin/3.4/sonar-java-plugin-3.4.jar"
+
 jdbcOverwrite:
   oracleJdbcDriver:
     url: "https://download.oracle.com/otn-pub/otn_software/jdbc/2113/ojdbc11.jar"


### PR DESCRIPTION
----
## Summary by Gitar

- **Init container configuration:**
  - Mounted `ca-certs` volume to init containers in `sonarqube` and `sonarqube-dce` templates.
  - Updated init containers to generate `/tmp/certs/ca-bundle.pem` from available CA certificates.
- **Plugin and Driver installation:**
  - Updated `install-plugins` and `install-oracle-jdbc-driver` to use `/tmp/certs/ca-bundle.pem` for `curl` operations when `caCerts.enabled` is true.
- **DCE-specific enhancements:**
  - Added `searchNodes.extraInitContainers` and `applicationNodes.extraInitContainers` for per-node-type configuration.
  - Deprecated root-level `extraInitContainers` in favor of node-specific values.
- **Cleanup:**
  - Removed redundant `ca-certs` volume mounts from plugin and driver init containers.
  - Cleaned up obsolete test fixtures in `tests/unit-compatibility-test/fixtures/sonarqube-dce/`.

<sub>This will update automatically on new commits.</sub>