### PR TITLE
fix(sonarqube/ui-test): add chart `tolerations` and `nodeSelector`

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.4.1]
+* Upgrade Chart's version to 2026.4.1
+* Apply chart-level `nodeSelector` and `tolerations` to the Helm UI test pod
+
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
 * Upgrade SonarQube Community build to 26.6.0.123539

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.4.0
+version: 2026.4.1
 appVersion: 2026.3.1
 keywords:
   - coverage
@@ -41,13 +41,9 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.4.0"
-    - kind: changed
-      description: "Upgrade SonarQube Community build to 26.6.0.123539"
-    - kind: added
-      description: "Add CA certificate support with multi-cert bundling to install-plugins init container"
+      description: "Upgrade Chart's version to 2026.4.1"
     - kind: fixed
-      description: "Fix multi-cert CA bundle handling in install-oracle-jdbc-driver init container"
+      description: "Apply chart-level nodeSelector and tolerations to the Helm UI test pod"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community

--- a/charts/sonarqube/templates/tests/sonarqube-test.yaml
+++ b/charts/sonarqube/templates/tests/sonarqube-test.yaml
@@ -19,6 +19,12 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+  {{- with .Values.nodeSelector }}
+  nodeSelector: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations: {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
     - name: {{ .Release.Name }}-ui-test
       image: {{ .Values.tests.image | default (include "sonarqube.image" .) | quote }}


### PR DESCRIPTION
The Helm UI test pod (`charts/sonarqube/templates/tests/sonarqube-test.yaml`) did not inherit the chart-level `nodeSelector` and `tolerations` values. On clusters where SonarQube runs on tainted or specially labeled nodes, the main workload schedules correctly (via `_pod.tpl`), but `helm test` creates a separate pod that stays `Pending` because it cannot tolerate taints or match the required node labels. This change applies the existing `.Values.nodeSelector` and `.Values.tolerations` to the test pod spec, consistent with the main SonarQube pod and the change-admin-password hook.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`
  - `charts/sonarqube/CHANGELOG.md`: added `## [2026.4.1]` with chart version bump and fix entry
  - `charts/sonarqube/Chart.yaml`: bumped `version` to `2026.4.1` and updated `artifacthub.io/changes`