### PR TITLE
feat(httproute): standardizes the generated HTTPRoute manifest structure

### DIFF
--- a/charts/sonarqube/templates/http-route.yaml
+++ b/charts/sonarqube/templates/http-route.yaml
@@ -9,27 +9,41 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  parentRefs:
-  - name: {{ .Values.httproute.gateway }}
-    {{- if .Values.httproute.gatewayNamespace }}
-    namespace: {{ .Values.httproute.gatewayNamespace }}
-    {{- end }}
   hostnames:
     {{- with .Values.httproute.hostnames }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  rules:
-  {{- if .Values.httproute.rules -}}
-    {{- with .Values.httproute.rules -}}
-    {{ toYaml . | nindent 4 }}
+  parentRefs:
+    {{- if .Values.httproute.parentRefs }}
+    {{- toYaml .Values.httproute.parentRefs | nindent 4 }}
+    {{- else }}
+    - name: {{ .Values.httproute.gateway }}
+      {{- if .Values.httproute.gatewayNamespace }}
+      namespace: {{ .Values.httproute.gatewayNamespace }}
+      {{- end }}
+      {{- if .Values.httproute.sectionName }}
+      sectionName: {{ .Values.httproute.sectionName }}
+      {{- end }}
+      {{- if .Values.httproute.gatewayKind }}
+      kind: {{ .Values.httproute.gatewayKind }}
+      {{- end }}
+      {{- if .Values.httproute.gatewayGroup }}
+      group: {{ .Values.httproute.gatewayGroup }}
+      {{- end }}
     {{- end }}
-  {{- else }}
-  - matches:
-    - path:
-        type: PathPrefix
-        value: {{ include "sonarqube.webcontext" . }}
-    backendRefs:
-    - name: {{ include "sonarqube.fullname" . }}
-      port: {{ .Values.service.externalPort }}
-  {{- end }}
+  rules:
+    {{- if .Values.httproute.rules }}
+    {{- toYaml .Values.httproute.rules | nindent 4 }}
+    {{- else }}
+    - backendRefs:
+        - group: {{ .Values.service.group | default "" | quote }}
+          kind: {{ .Values.service.kind | default "Service" }}
+          name: {{ include "sonarqube.fullname" . }}
+          port: {{ .Values.service.externalPort | default 9000 }}
+          weight: {{ .Values.httproute.weight | default 1 }}
+      matches:
+        - path:
+            type: {{ .Values.httproute.matchType | default "PathPrefix" }}
+            value: {{ include "sonarqube.webcontext" . | quote }}
+    {{- end }}
 {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -153,12 +153,16 @@ ingress-nginx:
 httproute:
   enabled: false
   # gateway: my-gateway
+  # sectionName: http # adding section name for choose http or https routing
   # gatewayNamespace: my-gateway-namespace # optional
   # labels:
   #   somelabel: somevalue
+  # # Optional: only if your setup requires overriding the defaults
+  # gatewayKind: Gateway            
+  # gatewayGroup: gateway.networking.k8s.io
   # hostnames:
   #   - sonarqube.your-org.com
-  # The rules are optional, by default we will create one with the SonarWebContext prefix and the SonarQube service values
+  # # The rules are optional, by default we will create one with the SonarWebContext prefix and the SonarQube service values
   # rules:
   # - matches:
   #   - path:
@@ -167,6 +171,8 @@ httproute:
   #   backendRefs:
   #   - name: my-service1
   #     port: 8080
+  #   timeouts:
+  #     request: 30s
 
 ingress:
   enabled: false


### PR DESCRIPTION
### Summary
Enhances the `HTTPRoute` template to support standard and advanced Kubernetes Gateway API configurations, including custom parent references and flexible routing rules.

### Changes
- **Templates**: Added support for `parentRefs`, `sectionName`, `gatewayKind`, and `gatewayGroup` in `http-route.yaml`. Fixed custom `rules` indentation.
- **Values**: Documented the new fields with commented examples in `values.yaml`.