### PR TITLE
SONAR-30618 Make ca-certs keystore copy writable for read-only base images

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file.
 * Deprecate root-level `extraInitContainers` in favour of the node-specific values
 * Add CA certificate support with multi-cert bundling to `install-plugins` init container for plugin downloads from servers using self-signed or private CA certificates
 * Fix multi-cert CA bundle handling in `install-oracle-jdbc-driver` init container
+* Fix `ca-certs` init container failing with "keytool: Permission denied" on base images whose JVM keystore is read-only, by making the keystore working copy writable
 
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -72,8 +72,18 @@ spec:
         - name: ca-certs
           image: {{ default (include "sonarqube.image" .) .Values.caCerts.image }}
           imagePullPolicy: {{ .Values.ApplicationNodes.image.pullPolicy  }}
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+                for f in /tmp/secrets/ca-certs/*; do cat "$f"; echo; done > /tmp/certs/ca-bundle.pem
+              fi
           {{- with (include "sonarqube.initContainersSecurityContext" .) }}
           securityContext: {{- . | nindent 12 }}
           {{- end }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -118,8 +118,17 @@ spec:
         - name: ca-certs
           image: {{ default (include "sonarqube.image" .) .Values.caCerts.image }}
           imagePullPolicy: {{ .Values.searchNodes.image.pullPolicy  }}
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+              fi
           {{- with (include "sonarqube.initContainersSecurityContext" .) }}
           securityContext: {{- . | nindent 12 }}
           {{- end }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to this chart will be documented in this file.
 * Upgrade SonarQube Community build to 26.6.0.123539
 * Add CA certificate support with multi-cert bundling to `install-plugins` init container for plugin downloads from servers using self-signed or private CA certificates
 * Fix multi-cert CA bundle handling in `install-oracle-jdbc-driver` init container
+* Fix `ca-certs` init container failing with "keytool: Permission denied" on base images whose JVM keystore is read-only, by making the keystore working copy writable
 
 ## [2026.3.1]
 * Upgrade Chart's version to 2026.3.1

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -47,8 +47,18 @@ spec:
     - name: ca-certs
       image: {{ default (include "sonarqube.image" $) .Values.caCerts.image }}
       imagePullPolicy: {{ .Values.image.pullPolicy  }}
-      command: ["sh"]
-      args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
+      command: ["sh", "-c"]
+      args:
+        - |
+          cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+          chmod u+w /tmp/certs/cacerts
+          if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+            for f in /tmp/secrets/ca-certs/*; do
+              keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+            done
+            for f in /tmp/secrets/ca-certs/*; do cat "$f"; echo; done > /tmp/certs/ca-bundle.pem
+          fi
       {{- with (include "sonarqube.initContainerSecurityContext" .) }}
       securityContext: {{- . | nindent 8 }}
       {{- end }}

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -373,8 +373,18 @@ spec:
         - name: ca-certs
           image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+                for f in /tmp/secrets/ca-certs/*; do cat "$f"; echo; done > /tmp/certs/ca-bundle.pem
+              fi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -700,8 +710,17 @@ spec:
         - name: ca-certs
           image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+              fi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -354,8 +354,18 @@ spec:
         - name: ca-certs
           image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+                for f in /tmp/secrets/ca-certs/*; do cat "$f"; echo; done > /tmp/certs/ca-bundle.pem
+              fi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -586,8 +596,17 @@ spec:
         - name: ca-certs
           image: sonarqube:2026.3.1-datacenter-app
           imagePullPolicy: IfNotPresent
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+              fi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -189,8 +189,18 @@ spec:
         - name: ca-certs
           image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+                for f in /tmp/secrets/ca-certs/*; do cat "$f"; echo; done > /tmp/certs/ca-bundle.pem
+              fi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -170,8 +170,18 @@ spec:
         - name: ca-certs
           image: sonarqube:2026.3.1-enterprise
           imagePullPolicy: IfNotPresent
-          command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; for f in /tmp/secrets/ca-certs/*; do cat \"$f\"; echo; done > /tmp/certs/ca-bundle.pem; fi;"]
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp -f "${JAVA_HOME}/lib/security/cacerts" /tmp/certs/cacerts
+              chmod u+w /tmp/certs/cacerts
+              if [ "$(ls /tmp/secrets/ca-certs)" ]; then
+                for f in /tmp/secrets/ca-certs/*; do
+                  keytool -importcert -file "${f}" -alias "$(basename "${f}")" \
+                    -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt
+                done
+                for f in /tmp/secrets/ca-certs/*; do cat "$f"; echo; done > /tmp/certs/ca-bundle.pem
+              fi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Testing done using a local `kind` cluster.

----
## Summary by Gitar

- **Init container adjustments:**
  - Explicitly add `chmod u+w` to the `ca-certs` init container script to ensure the copied keystore is writable.
  - This resolves "Permission denied" errors occurring when using read-only base images.
- **Configuration updates:**
  - Updated `ca-certs` initialization logic in `sonarqube` and `sonarqube-dce` charts and corresponding unit test fixtures.
- **Documentation:**
  - Added entries to `CHANGELOG.md` for both charts documenting this permission fix.


<sub>This will update automatically on new commits.</sub>