### PR TITLE
REL-4764 Release Sonarqube Community Build 26.7

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -3,7 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
-* Upgrade SonarQube Community build to 26.6.0.123539
+* Upgrade SonarQube Community build to 26.7.0.124771
 * Add CA certificate support with multi-cert bundling to `install-plugins` init container for plugin downloads from servers using self-signed or private CA certificates
 * Fix multi-cert CA bundle handling in `install-oracle-jdbc-driver` init container
 * Fix `ca-certs` init container failing with "keytool: Permission denied" on base images whose JVM keystore is read-only, by making the keystore working copy writable

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -43,7 +43,7 @@ annotations:
     - kind: changed
       description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
-      description: "Upgrade SonarQube Community build to 26.6.0.123539"
+      description: "Upgrade SonarQube Community build to 26.7.0.124771"
     - kind: added
       description: "Add CA certificate support with multi-cert bundling to install-plugins init container"
     - kind: fixed
@@ -51,7 +51,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community
-      image: sonarqube:26.6.0.123539-community
+      image: sonarqube:26.7.0.124771-community
     - name: sonarqube-developer
       image: sonarqube:2026.3.1-developer
     - name: sonarqube-enterprise

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -16,7 +16,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 SonarQube Server Version: `2026.3.1`
 
-SonarQube Community Build: `26.6.0.123539`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
+SonarQube Community Build: `26.7.0.124771`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 
 ## Kubernetes and Openshift Compatibility
 
@@ -513,7 +513,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `annotations`           | SonarQube Pod annotations                                                                                             | `{}`               |
 | `edition`               | SonarQube Edition to use (`developer` or `enterprise`).                                                               | `None`             |
 | `community.enabled`     | Install SonarQube Community Build. When set to `true`, `edition` must not be set.                                     | `false`            |
-| `community.buildNumber` | The SonarQube Community Build number to install                                                                       | `26.6.0.123539`    |
+| `community.buildNumber` | The SonarQube Community Build number to install                                                                       | `26.7.0.124771`    |
 | `sonarWebContext`       | SonarQube web context, also serve as default value for `ingress.path`, `account.sonarWebContext` and probes path.     | ``                 |
 | `httpProxySecret`       | Should contain `http_proxy`, `https_proxy` and `no_proxy` keys, will supersede every other proxy variables            | ``                 |
 | `httpProxy`             | HTTP proxy for downloading JMX agent and install plugins, will supersede initContainer specific http proxy variables  | ``                 |

--- a/charts/sonarqube/ci/ci-values.yaml
+++ b/charts/sonarqube/ci/ci-values.yaml
@@ -5,7 +5,7 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "26.6.0.123539-master-community"
+  tag: "26.7.0.124771-master-community"
 monitoringPasscode: "test"
 
 resources:

--- a/charts/sonarqube/openshift-verifier/values.yaml
+++ b/charts/sonarqube/openshift-verifier/values.yaml
@@ -10,6 +10,6 @@ image:
   pullSecrets:
     - name: pullsecret
   repository: "sonarsource/sonarqube"
-  tag: "26.6.0.123539-master-community"
+  tag: "26.7.0.124771-master-community"
 
 monitoringPasscode: "test"

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -54,7 +54,7 @@ OpenShift:
 # Set the chart to use the latest released SonarQube Community Build
 community:
   enabled: false
-  buildNumber: "26.6.0.123539"
+  buildNumber: "26.7.0.124771"
 
 # The following settings are used when deploying to Azure Marketplace
 # global:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: host-path-values.yaml-sonarqube
-    app.kubernetes.io/version: "26.6.0.123539-community"
+    app.kubernetes.io/version: "26.7.0.124771-community"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -202,7 +202,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:26.6.0.123539-community
+          image: sonarqube:26.7.0.124771-community
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -220,7 +220,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:26.6.0.123539-community
+          image: sonarqube:26.7.0.124771-community
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -255,7 +255,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:26.6.0.123539-community
+          image: sonarqube:26.7.0.124771-community
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -388,7 +388,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: host-path-values.yaml-ui-test
-      image: "sonarqube:26.6.0.123539-community"
+      image: "sonarqube:26.7.0.124771-community"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-test/sonarqube_schema_test.go
+++ b/tests/unit-test/sonarqube_schema_test.go
@@ -15,7 +15,7 @@ import (
 
 var chartPath string = "../../charts/sonarqube"
 var releaseName string = "sonarqube"
-var expectedContainerImage string = "sonarqube:26.6.0.123539"
+var expectedContainerImage string = "sonarqube:26.7.0.124771"
 var sqStsTemplate []string = []string{"templates/sonarqube-sts.yaml"}
 
 func newSQHelmOptions() *helm.Options {

--- a/tests/unit-test/test-cases-values/sonarqube/test-build-number.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-build-number.yaml
@@ -1,3 +1,3 @@
 community:
   enabled: true
-  buildNumber: "26.6.0.123539"
+  buildNumber: "26.7.0.124771"


### PR DESCRIPTION
----
## Summary by Gitar

- **Version upgrade:**
  - Upgraded SonarQube Community Build version from `26.6.0.123539` to `26.7.0.124771` across `Chart.yaml`, `values.yaml`, and documentation.
  - Updated container image tags and test configurations in `ci-values.yaml`, `openshift-verifier/values.yaml`, and `sonarqube_schema_test.go` to reflect the new build version.


<sub>This will update automatically on new commits.</sub>