### PR TITLE
SONAR-30859: Add Agentic Harness core resources to the chart

### DIFF
--- a/.github/scripts/setup_external_minio.sh
+++ b/.github/scripts/setup_external_minio.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Environment variables with default values
+NAME="${NAME:-external-minio}"
+NAMESPACE="${NAMESPACE:-sonarqube}"
+# Fixed credentials and bucket, matching the docker-compose harness's own convention
+# (agentic-workflows/private/integration-harness) so a test-values file can reference known,
+# stable values instead of a freshly generated secret each install.
+ROOT_USER="${ROOT_USER:-minioadmin}"
+ROOT_PASSWORD="${ROOT_PASSWORD:-minioadmin}"
+DEFAULT_BUCKET="${DEFAULT_BUCKET:-agentic-jobs}"
+
+# NOTE: unlike setup_external_postgres.sh, this does not install a Helm chart. Bitnami's `minio`
+# chart (the natural equivalent of their `postgresql` chart) has had all of its free-tier image
+# tags — including `:latest` — pulled from Docker Hub since their August 2025 policy change, so
+# `bitnami/minio` is no longer pullable without a paid subscription. This deploys the official,
+# freely available `minio/minio` image directly instead (the same image the docker-compose harness
+# itself already builds from — agentic-workflows/private/integration-harness/local-infra/minio).
+
+echo "Installing MinIO with the following configuration:"
+echo "  Name: ${NAME}"
+echo "  Namespace: ${NAMESPACE}"
+echo "  Default Bucket: ${DEFAULT_BUCKET}"
+echo ""
+
+echo "Applying MinIO manifests..."
+kubectl apply -n "${NAMESPACE}" -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${NAME}
+type: Opaque
+stringData:
+  root-user: "${ROOT_USER}"
+  root-password: "${ROOT_PASSWORD}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${NAME}
+  labels:
+    app: ${NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${NAME}
+  template:
+    metadata:
+      labels:
+        app: ${NAME}
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args: ["server", "/data"]
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom: {secretKeyRef: {name: ${NAME}, key: root-user}}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom: {secretKeyRef: {name: ${NAME}, key: root-password}}
+          ports:
+            - containerPort: 9000
+          readinessProbe:
+            httpGet: {path: /minio/health/ready, port: 9000}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${NAME}
+spec:
+  selector:
+    app: ${NAME}
+  ports:
+    - port: 9000
+      targetPort: 9000
+EOF
+
+echo ""
+echo "Waiting for MinIO to be ready..."
+kubectl wait --for=condition=ready pod -l app="${NAME}" -n "${NAMESPACE}" --timeout=300s
+
+echo ""
+echo "Creating bucket '${DEFAULT_BUCKET}' (idempotent)..."
+kubectl delete job "${NAME}-init" -n "${NAMESPACE}" --ignore-not-found
+kubectl apply -n "${NAMESPACE}" -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${NAME}-init
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          command:
+            - sh
+            - -c
+            - "mc alias set local http://${NAME}:9000 ${ROOT_USER} ${ROOT_PASSWORD} && mc mb -p local/${DEFAULT_BUCKET}"
+EOF
+kubectl wait --for=condition=complete job/"${NAME}-init" -n "${NAMESPACE}" --timeout=120s
+echo "MinIO installation completed."

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -316,6 +316,30 @@ If a Prometheus Operator is deployed in your cluster, you can enable a PodMonito
 
 If running on OpenShift, make sure your account has permissions to create PodMonitor resources under the monitoring.coreos.com/v1 apiVersion.
 
+## Agentic Harness
+
+The chart can optionally deploy the Agentic Unified Harness alongside SonarQube Server: an Agent
+Orchestrator and one or more sandboxed Agentic Job Runtimes (today, just `hunter`). Enable it with
+`agenticHarness.enabled=true` (requires `jdbcOverwrite.enabled=true` — enforced at install time)
+— see the `agenticHarness` block in `values.yaml` for the full set of options.
+
+- The orchestrator always persists to the same database as SonarQube itself; there is no separate
+  DB configuration for it.
+- Object storage (`agenticHarness.orchestrator.storage`) and SCM connectivity are customer-provided
+  infrastructure — the chart does not deploy or manage either, only configures the orchestrator to
+  reach them.
+- `sonar.hunteragent.orchestrator.url` is wired automatically (via `sonarProperties`) to point at
+  the orchestrator Service, unless you've already set that key yourself.
+- Each entry under `agenticHarness.runtimes` becomes its own Deployment+Service; add a new agentic
+  job family with a values change only, no template change needed.
+- `agenticHarness.networkPolicy.enabled` defaults to **true**: the orchestrator can reach only
+  SonarQube, the runtimes, and its `egressAllow` list (SCM/storage); each runtime can reach only
+  its `egressAllow` list (LLM/storage) — never SonarQube, SCM, or other runtimes. Because
+  Kubernetes `NetworkPolicy` matches CIDRs, not hostnames, `runtimes.hunter.egressAllow` ships
+  Anthropic's own documented, stable CIDR by default; override it for your real LLM provider, and
+  fill in `orchestrator.egressAllow` for your SCM/storage endpoints (empty by default — there's no
+  universal default for those).
+
 ## OpenShift installation
 
 The chart can be installed on OpenShift by setting `OpenShift.enabled=true`. Among the others, please note that this value will disable the initContainer that performs the settings required by Elasticsearch (see [here](#elasticsearch-prerequisites)). Furthermore, we strongly recommend following the [Production Use Case guidelines](#production-use-case).

--- a/charts/sonarqube/local-testing/README.md
+++ b/charts/sonarqube/local-testing/README.md
@@ -1,0 +1,126 @@
+# Local `kind` testing for the Agentic Harness
+
+Exercises `agenticHarness.enabled=true` end to end against a real cluster, without needing any
+published images or an external Postgres/S3.
+
+## 0. Create the cluster with Calico (required for real NetworkPolicy enforcement)
+
+Stock `kind` (and this repo's custom `kindest/node:v1.35.0-sonar` image) ships `kindnet`, which
+doesn't enforce `ipBlock`/CIDR peers at all — every egress rule this feature needs for external
+endpoints (LLM, and any real external DB/storage) is CIDR-based, so `agenticHarness.networkPolicy`
+can't be meaningfully verified without swapping in a CNI that actually implements `ipBlock`:
+
+```bash
+cat > /tmp/kind-config-calico.yaml << 'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: "192.168.0.0/16"
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker
+  - role: worker
+  - role: worker
+EOF
+kind create cluster --name my-cluster --image kindest/node:v1.35.0-sonar --config /tmp/kind-config-calico.yaml
+
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.1/manifests/calico.yaml
+kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=180s
+```
+
+(adjust worker count / node image to match whatever cluster you're actually replicating)
+
+## 1. Provision Postgres and MinIO in-cluster
+
+```bash
+kubectl create namespace sonarqube --dry-run=client -o yaml | kubectl apply -f -
+
+NAME=external-postgres NAMESPACE=sonarqube \
+  VALUES_FILE=charts/sonarqube/local-testing/postgres-values.yaml \
+  ./.github/scripts/setup_external_postgres.sh
+
+NAMESPACE=sonarqube ./.github/scripts/setup_external_minio.sh
+```
+
+Confirm the actual Service names/ports match what's in `agentic-harness-kind-values.yaml`
+(Bitnami chart defaults, derived from the release names above — verify, don't assume):
+
+```bash
+kubectl get svc -n sonarqube
+```
+
+## 2. Build and load the orchestrator + hunter-runtime images
+
+```bash
+cd ../sonarqube-unification/agentic-workflows
+./gradlew :private:agent-orchestrator:agent-orchestrator-app:bootJar
+
+docker build -t agentic-orchestrator:local private/agent-orchestrator/agent-orchestrator-app
+docker build -t agentic-hunter-runtime:local private/integration-harness/mocks/runtime
+
+kind load docker-image agentic-orchestrator:local --name <your-kind-cluster-name>
+kind load docker-image agentic-hunter-runtime:local --name <your-kind-cluster-name>
+```
+
+## 3. Install the chart
+
+```bash
+helm upgrade -i -n sonarqube sonarqube ../../.. \
+  -f agentic-harness-kind-values.yaml
+```
+
+(path is relative to this folder — adjust if running from elsewhere)
+
+## 4. Verify
+
+```bash
+kubectl get pods -n sonarqube
+kubectl logs -n sonarqube deploy/sonarqube-sonarqube-agentic-orchestrator
+```
+
+## 5. Run the reference test flows
+
+`run-e2e-tests.sh` runs the reference harness's own `demo.sh`/`pressure.sh`/`backpressure.sh`
+(`agentic-workflows/private/integration-harness/scripts/`) against this real deployment,
+completely unmodified — it wraps `docker compose exec` calls with a shim that translates them to
+`kubectl exec` against the matching pod, and manages its own `kubectl port-forward` to SonarQube.
+
+```bash
+./run-e2e-tests.sh demo           # one job, full trace: create -> dispatch -> clone -> push -> LLM -> fire-back
+N=8 ./run-e2e-tests.sh pressure   # N concurrent jobs through the real flow, final status tally
+N=6 ./run-e2e-tests.sh backpressure  # burst against a single runtime replica: expect 1x202, (N-1)x429
+./run-e2e-tests.sh all            # runs all three in sequence
+```
+
+If `agentic-workflows` isn't checked out as a sibling of `helm-chart-sonarqube` under the same
+parent directory, set `HARNESS_DIR` explicitly. `NAMESPACE` (default `sonarqube`) and
+`SQ_LOCAL_PORT` (default `9000`) are also overridable.
+
+**Reaching a real LLM**: the reference runtime's `LLM_URL` (see `agentic-harness-kind-values.yaml`)
+points at `https://api.anthropic.com/v1/messages`. With no API key configured this legitimately
+gets an HTTP 401 back — that still counts as a working call and the job reports `SUCCEEDED`. On a
+network that TLS-inspects outbound traffic (common on corporate networks), the runtime needs that
+network's CA cert imported into its JRE trust store or you'll see `SSLHandshakeException`/`PKIX
+path building failed` instead of a clean 401 — mount a `.crt`/`.pem` at `/custom-ca` on the runtime
+container (see `mocks/runtime/entrypoint.sh`) and make sure `containerSecurityContext.runAsUser`
+matches the image's actual non-root uid (the mock runtime uses uid 10001, not the chart's uid-1000
+default — see the comment above `runtimes.hunter.containerSecurityContext` in `values.yaml`),
+since the JRE trust store is chowned to that specific uid for writability.
+
+**Verified with Calico installed** (step 0): the runtime really can reach only Anthropic's CIDR and
+nothing else (confirmed — a request to `api.anthropic.com` gets a real HTTP response, a request to
+an arbitrary other host times out), and the runtime is really reachable only from the orchestrator
+(confirmed — an unrelated pod's request times out, the orchestrator's succeeds). Stock `kindnet`
+doesn't enforce `ipBlock` peers at all, so none of this is verifiable without Calico.
+
+**A NetworkPolicy `ipBlock`/CIDR rule can never target a Service's ClusterIP, on any CNI** —
+kube-proxy DNATs the ClusterIP to the backing pod's real IP before policy enforcement sees the
+packet, so the CIDR never matches what's actually on the wire. This bit both the orchestrator's DB
+connection and its direct storage (MinIO) upload, since both are in-cluster Services in this local
+test — fixed by using `egressAllow`'s `podSelector` form (see `values.yaml`'s comment on
+`orchestrator.egressAllow`) instead of `cidr` for those two entries; `agentic-harness-kind-values.yaml`
+already does this. This isn't a kind-specific quirk — it'd bite in production too for anyone
+self-hosting their DB or S3 gateway in-cluster rather than using a genuinely external endpoint.

--- a/charts/sonarqube/local-testing/agentic-harness-kind-values.yaml
+++ b/charts/sonarqube/local-testing/agentic-harness-kind-values.yaml
@@ -1,0 +1,101 @@
+# Test values for exercising the Agentic Harness end to end on a local `kind` cluster.
+# See README.md in this folder for the full setup sequence (provision Postgres/MinIO, build and
+# `kind load` the images referenced below, then `helm install` with this file).
+#
+# Service names below are Bitnami chart defaults for the release names used in README.md's
+# commands (external-postgres / external-minio) — verify with `kubectl get svc -n sonarqube`
+# after running the setup scripts if you used different release names.
+
+# The real distribution built for this harness is an Enterprise build with the hunter-agent
+# capability baked in (see agentic-workflows/private/integration-harness/sonarqube/) — not the
+# public Docker Hub "sonarqube" image, which doesn't have that capability at all.
+edition: enterprise
+image:
+  repository: agentic-sonarqube
+  tag: local
+  pullPolicy: IfNotPresent
+
+monitoringPasscode: local-kind-testing
+
+jdbcOverwrite:
+  enabled: true
+  jdbcUrl: "jdbc:postgresql://external-postgres-postgresql.sonarqube.svc.cluster.local:5432/sonarqube"
+  jdbcUsername: sonarqube
+  jdbcPassword: sonarqube
+
+agenticHarness:
+  enabled: true
+
+  orchestrator:
+    image:
+      repository: agentic-orchestrator
+      tag: local
+      pullPolicy: IfNotPresent
+    storage:
+      endpoint: "http://external-minio.sonarqube.svc.cluster.local:9000"
+      accessKey: minioadmin
+      secretKey: minioadmin
+    # The orchestrator connects directly to the same DB as SonarQube (no override — see
+    # values.yaml comments) and to storage — both are in-cluster Services here, so they need
+    # podSelector entries, not cidr (ipBlock can't target a ClusterIP on any CNI — see
+    # egressAllow's comment in values.yaml). GitHub's CIDR range below is for the demo's own git
+    # clone (REPO_URL defaults to github.com/octocat/Hello-World) — fetch the current list with
+    # `curl -s https://api.github.com/meta | jq .web` and update if clone starts failing again.
+    egressAllow:
+      - podSelector:
+          matchLabels: {app.kubernetes.io/name: postgresql, app.kubernetes.io/instance: external-postgres, app.kubernetes.io/component: primary}
+        ports: [5432]
+      - podSelector:
+          matchLabels: {app: external-minio}
+        ports: [9000]
+      - cidr: 192.30.252.0/22
+        ports: [443]
+      - cidr: 185.199.108.0/22
+        ports: [443]
+      - cidr: 140.82.112.0/20
+        ports: [443]
+      - cidr: 143.55.64.0/20
+        ports: [443]
+      - cidr: 2a0a:a440::/29
+        ports: [443]
+      - cidr: 2606:50c0::/32
+        ports: [443]
+
+  runtimes:
+    hunter:
+      image:
+        repository: agentic-hunter-runtime
+        tag: local
+        pullPolicy: IfNotPresent
+      # No EGRESS_PROXY_HOST set: the runtime image now connects directly when unset (patched to
+      # match NetworkPolicy-based egress control, which has no forward-proxy component — see
+      # mocks/runtime/src/main/java/.../RuntimeApplication.java). No API key configured, so
+      # Anthropic legitimately returns an auth-error body — that still counts as a working call.
+      env:
+        - name: LLM_URL
+          value: "https://api.anthropic.com/v1/messages"
+      # Storage (MinIO) is an in-cluster Service here too — see orchestrator.egressAllow's
+      # comment above for why that needs podSelector, not cidr.
+      egressAllow:
+        - podSelector:
+            matchLabels: {app: external-minio}
+          ports: [9000]
+        - cidr: 160.79.104.0/23
+          ports: [443]
+        - cidr: 2607:6bc0::/48
+          ports: [443]
+      # The mock runtime's Dockerfile declares `USER app` (uid/gid 10001), not the chart's
+      # uid-1000 default — override to match, or the JRE trust store (chowned to app:app for
+      # custom CA import) is unwritable by the actual runtime user.
+      containerSecurityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+
+  # Requires a CNI with real ipBlock/CIDR NetworkPolicy support — stock kindnet doesn't have it
+  # (confirmed: a CIDR rule for the in-cluster Postgres Service's ClusterIP was silently dropped
+  # while an equivalent podSelector rule for the same pod worked), even on this cluster's custom
+  # node image, which enforces podSelector/namespaceSelector peers but not ipBlock ones. Install
+  # Calico (see local-testing/README.md's cluster setup section) to get full enforcement, then this
+  # default (true) is safe to leave as-is.
+  networkPolicy:
+    enabled: true

--- a/charts/sonarqube/local-testing/postgres-values.yaml
+++ b/charts/sonarqube/local-testing/postgres-values.yaml
@@ -1,0 +1,7 @@
+# Values for `setup_external_postgres.sh` (VALUES_FILE=charts/sonarqube/local-testing/postgres-values.yaml)
+# when provisioning a Postgres to back the Agentic Harness kind test. Creates a "sonarqube"
+# database/user matching agentic-harness-kind-values.yaml's jdbcOverwrite block below.
+auth:
+  username: sonarqube
+  password: sonarqube
+  database: sonarqube

--- a/charts/sonarqube/local-testing/run-e2e-tests.sh
+++ b/charts/sonarqube/local-testing/run-e2e-tests.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Runs the Agentic Harness reference test flows (demo/pressure/backpressure — defined in
+# agentic-workflows/private/integration-harness/scripts/) against a real `kind` deployment of
+# this chart with agenticHarness.enabled=true (see README.md in this folder for the setup
+# sequence). The reference scripts assume a docker-compose environment (they exec into services
+# via `docker compose exec`), so this wraps them with a shim that translates those calls into
+# `kubectl exec` against the matching pod — the reference scripts themselves run unmodified.
+#
+# Usage:
+#   ./run-e2e-tests.sh demo|pressure|backpressure|all
+#
+# Env vars:
+#   NAMESPACE       - k8s namespace the chart is installed in (default: sonarqube)
+#   HARNESS_DIR     - path to agentic-workflows/private/integration-harness (default: guessed
+#                     relative to sonarqube-unification checked out as a sibling of this repo)
+#   SQ_LOCAL_PORT   - local port for the SonarQube port-forward (default: 9000)
+#   N               - concurrency for pressure/backpressure (passed through to the reference
+#                      scripts' own N env var — see their own defaults if unset)
+set -euo pipefail
+
+export NAMESPACE="${NAMESPACE:-sonarqube}"
+HARNESS_DIR="${HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../sonarqube-unification/agentic-workflows/private/integration-harness" 2>/dev/null && pwd)}"
+SQ_LOCAL_PORT="${SQ_LOCAL_PORT:-9000}"
+
+if [ -z "$HARNESS_DIR" ] || [ ! -f "$HARNESS_DIR/scripts/demo.sh" ]; then
+  echo "error: can't find agentic-workflows/private/integration-harness — set HARNESS_DIR explicitly" >&2
+  exit 1
+fi
+
+mode="${1:-}"
+case "$mode" in
+  demo|pressure|backpressure|all) ;;
+  *) echo "usage: $0 demo|pressure|backpressure|all" >&2; exit 1 ;;
+esac
+
+docker() {
+  if [ "$1" = "compose" ] && [ "$2" = "exec" ]; then
+    shift 2
+    if [ "$1" = "-T" ]; then shift; fi
+    local svc="$1"; shift
+    local pod container
+    case "$svc" in
+      orchestrator) pod=$(kubectl get pod -n "$NAMESPACE" -l app=sonarqube-agentic-orchestrator -o jsonpath='{.items[0].metadata.name}'); container=agentic-orchestrator ;;
+      hunter-runtime) pod=$(kubectl get pod -n "$NAMESPACE" -l app=sonarqube-agentic-runtime-hunter -o jsonpath='{.items[0].metadata.name}'); container=agentic-runtime ;;
+      *) echo "run-e2e-tests: unmapped service '$svc'" >&2; return 1 ;;
+    esac
+    kubectl exec -i -n "$NAMESPACE" -c "$container" "$pod" -- "$@"
+  else
+    command docker "$@"
+  fi
+}
+export -f docker
+
+pf_pid=""
+cleanup() { [ -n "$pf_pid" ] && kill "$pf_pid" 2>/dev/null || true; }
+trap cleanup EXIT
+
+kubectl port-forward -n "$NAMESPACE" "svc/sonarqube-sonarqube" "${SQ_LOCAL_PORT}:9000" >/tmp/run-e2e-tests-pf.log 2>&1 &
+pf_pid=$!
+for _ in $(seq 1 20); do
+  curl -sf --max-time 1 "http://localhost:${SQ_LOCAL_PORT}/api/system/status" >/dev/null 2>&1 && break
+  sleep 1
+done
+
+cd "$HARNESS_DIR"
+export SQ="http://localhost:${SQ_LOCAL_PORT}"
+export SONAR_TOKEN
+SONAR_TOKEN=$(SQ="$SQ" bash scripts/get-token.sh)
+
+run_demo() { echo "== demo =="; bash scripts/demo.sh; }
+run_pressure() { echo "== pressure (N=${N:-8}) =="; bash scripts/pressure.sh; }
+run_backpressure() { echo "== backpressure (N=${N:-6}) =="; bash scripts/backpressure.sh; }
+
+case "$mode" in
+  demo) run_demo ;;
+  pressure) run_pressure ;;
+  backpressure) run_backpressure ;;
+  all) run_demo; echo; run_pressure; echo; run_backpressure ;;
+esac

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -432,6 +432,40 @@ Create the fully qualified name for the MCP service.
 {{- printf "%s-mcp" (include "sonarqube.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create the fully qualified name for the Agentic Harness orchestrator.
+*/}}
+{{- define "sonarqube.agentic.orchestrator.fullname" -}}
+{{- printf "%s-agentic-orchestrator" (include "sonarqube.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the fully qualified name for an Agentic Harness runtime, parameterized by family name.
+Usage: {{ include "sonarqube.agentic.runtime.fullname" (dict "root" $ "family" $family) }}
+*/}}
+{{- define "sonarqube.agentic.runtime.fullname" -}}
+{{- printf "%s-agentic-runtime-%s" (include "sonarqube.fullname" .root) .family | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The orchestrator always uses SonarQube's own database, so it needs the same connection info in
+the shape its own config expects (CORE_DB_READ_WRITE_ENDPOINT = bare host:port, CORE_DB_NAME =
+bare db name) rather than a single JDBC URL. jdbcOverwrite.jdbcUrl is always a plain values.yaml
+string (never secret-backed — only the password is), so it's safe to parse at template time.
+Assumes jdbcOverwrite.enabled/enable is true; templates/validation.yaml enforces this when
+agenticHarness.enabled is true, since the Agentic Harness has no DB of its own to fall back to,
+same as the main SonarQube pod has none without it.
+*/}}
+{{- define "sonarqube.agentic.dbEndpoint" -}}
+{{- $withoutScheme := regexReplaceAll "^jdbc:[a-zA-Z0-9]+://" .Values.jdbcOverwrite.jdbcUrl "" -}}
+{{- regexFind "^[^/?]+" $withoutScheme -}}
+{{- end -}}
+
+{{- define "sonarqube.agentic.dbName" -}}
+{{- $withoutScheme := regexReplaceAll "^jdbc:[a-zA-Z0-9]+://[^/]+/" .Values.jdbcOverwrite.jdbcUrl "" -}}
+{{- regexFind "^[^?]+" $withoutScheme -}}
+{{- end -}}
+
 {{- define "accountDeprecation" -}}
 {{- $map1 := .Values.setAdminPassword -}}
 {{- $map2 := .Values.account -}}

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -91,7 +91,7 @@ spec:
       env:
         {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 8 }}
     {{- end }}
-    {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
+    {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey .Values.agenticHarness.enabled (not .Values.elasticsearch.bootstrapChecks) }}
     - name: concat-properties
       image: {{ default (include "sonarqube.image" $) .Values.initContainers.image }}
       imagePullPolicy: {{ .Values.image.pullPolicy  }}
@@ -112,7 +112,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp/result
           name: concat-dir
-        {{- if or .Values.sonarProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
+        {{- if or .Values.sonarProperties .Values.sonarSecretKey .Values.agenticHarness.enabled (not .Values.elasticsearch.bootstrapChecks) }}
         - mountPath: /tmp/props/sonar.properties
           name: config
           subPath: sonar.properties
@@ -353,7 +353,7 @@ spec:
           subPath: logs
         - mountPath: /tmp
           name: tmp-dir
-        {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
+        {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey .Values.agenticHarness.enabled (not .Values.elasticsearch.bootstrapChecks) }}
         - mountPath: {{ .Values.sonarqubeFolder }}/conf/
           name: concat-dir
         {{- end }}
@@ -406,7 +406,7 @@ spec:
     {{- with .Values.extraVolumes }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if or .Values.sonarProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
+    {{- if or .Values.sonarProperties .Values.sonarSecretKey .Values.agenticHarness.enabled ( not .Values.elasticsearch.bootstrapChecks) }}
     - name: config
       configMap:
         name: {{ include "sonarqube.fullname" . }}-config
@@ -506,7 +506,7 @@ spec:
       {{- end }}
     - name : tmp-dir
       emptyDir: {{- toYaml .Values.emptyDir | nindent 8 }}
-      {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
+      {{- if or .Values.sonarProperties .Values.sonarSecretProperties .Values.sonarSecretKey .Values.agenticHarness.enabled ( not .Values.elasticsearch.bootstrapChecks) }}
     - name : concat-dir
       emptyDir: {{- toYaml .Values.emptyDir | nindent 8 }}
       {{- end }}

--- a/charts/sonarqube/templates/agentic-networkpolicy.yaml
+++ b/charts/sonarqube/templates/agentic-networkpolicy.yaml
@@ -1,0 +1,132 @@
+{{- if and .Values.agenticHarness.enabled .Values.agenticHarness.networkPolicy.enabled }}
+# Orchestrator: reachable only from SonarQube. May reach SonarQube, each enabled runtime, and its
+# egressAllow list (SCM/storage — see values.yaml comments on why this is CIDR-based, not
+# hostname-based). Nothing else.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sonarqube.agentic.orchestrator.fullname" . }}-network-policy
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "sonarqube.name" . }}-agentic-orchestrator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "sonarqube.name" . }}
+              release: {{ .Release.Name }}
+      ports:
+        - port: {{ .Values.agenticHarness.orchestrator.port }}
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "sonarqube.name" . }}
+              release: {{ .Release.Name }}
+      ports:
+        - port: {{ .Values.service.internalPort }}
+    {{- range $family, $cfg := .Values.agenticHarness.runtimes }}
+    {{- if $cfg.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ include "sonarqube.name" $ }}-agentic-runtime-{{ $family }}
+              release: {{ $.Release.Name }}
+      ports:
+        - port: {{ $cfg.port }}
+    {{- end }}
+    {{- end }}
+    {{- range .Values.agenticHarness.orchestrator.egressAllow }}
+    - to:
+        {{- if .cidr }}
+        - ipBlock:
+            cidr: {{ .cidr }}
+        {{- else if .podSelector }}
+        - podSelector:
+            matchLabels: {{- toYaml .podSelector.matchLabels | nindent 14 }}
+          {{- with .namespaceSelector }}
+          namespaceSelector:
+            matchLabels: {{- toYaml .matchLabels | nindent 16 }}
+          {{- end }}
+        {{- end }}
+      {{- with .ports }}
+      ports:
+        {{- range . }}
+        - port: {{ . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+{{- range $family, $cfg := .Values.agenticHarness.runtimes }}
+{{- if $cfg.enabled }}
+---
+# Runtime "{{ $family }}": reachable only from the orchestrator. May reach only its egressAllow
+# list (LLM/storage) — never SonarQube, SCM, the orchestrator, or other runtimes.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sonarqube.agentic.runtime.fullname" (dict "root" $ "family" $family) }}-network-policy
+  labels: {{- include "sonarqube.labels" $ | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "sonarqube.name" $ }}-agentic-runtime-{{ $family }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "sonarqube.name" $ }}-agentic-orchestrator
+              release: {{ $.Release.Name }}
+      ports:
+        - port: {{ $cfg.port }}
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- range $cfg.egressAllow }}
+    - to:
+        {{- if .cidr }}
+        - ipBlock:
+            cidr: {{ .cidr }}
+        {{- else if .podSelector }}
+        - podSelector:
+            matchLabels: {{- toYaml .podSelector.matchLabels | nindent 14 }}
+          {{- with .namespaceSelector }}
+          namespaceSelector:
+            matchLabels: {{- toYaml .matchLabels | nindent 16 }}
+          {{- end }}
+        {{- end }}
+      {{- with .ports }}
+      ports:
+        {{- range . }}
+        - port: {{ . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/agentic-orchestrator-secret.yaml
+++ b/charts/sonarqube/templates/agentic-orchestrator-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.agenticHarness.enabled (not .Values.agenticHarness.orchestrator.storage.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sonarqube.agentic.orchestrator.fullname" . }}-storage
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+type: Opaque
+data:
+  access-key: {{ .Values.agenticHarness.orchestrator.storage.accessKey | b64enc | quote }}
+  secret-key: {{ .Values.agenticHarness.orchestrator.storage.secretKey | b64enc | quote }}
+{{- end }}

--- a/charts/sonarqube/templates/agentic-orchestrator-service.yaml
+++ b/charts/sonarqube/templates/agentic-orchestrator-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.agenticHarness.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sonarqube.agentic.orchestrator.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agentic-orchestrator
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.agenticHarness.orchestrator.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "sonarqube.name" . }}-agentic-orchestrator
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/sonarqube/templates/agentic-orchestrator.yaml
+++ b/charts/sonarqube/templates/agentic-orchestrator.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.agenticHarness.enabled }}
+{{- $storage := .Values.agenticHarness.orchestrator.storage }}
+{{- $storageSecretName := $storage.existingSecret | default (printf "%s-storage" (include "sonarqube.agentic.orchestrator.fullname" .)) }}
+{{- $storageAccessKeyKey := "access-key" }}
+{{- $storageSecretKeyKey := "secret-key" }}
+{{- if $storage.existingSecret }}
+{{- $storageAccessKeyKey = $storage.existingSecretAccessKeyKey | default "access-key" }}
+{{- $storageSecretKeyKey = $storage.existingSecretSecretKeyKey | default "secret-key" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sonarqube.agentic.orchestrator.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agentic-orchestrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "sonarqube.name" . }}-agentic-orchestrator
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.agenticHarness.orchestrator.annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ include "sonarqube.name" . }}-agentic-orchestrator
+        release: {{ .Release.Name }}
+    spec:
+      {{- if or .Values.image.pullSecrets .Values.image.pullSecret .Values.agenticHarness.orchestrator.image.pullSecrets }}
+      imagePullSecrets:
+        {{- if .Values.image.pullSecret }}
+        - name: {{ .Values.image.pullSecret }}
+        {{- end }}
+        {{- with .Values.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.agenticHarness.orchestrator.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-sonarqube
+          image: {{ include "sonarqube.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with (fromYaml (include "sonarqube.initContainerSecurityContext" .)) }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}{{ include "sonarqube.webcontext" . }}api/system/status" | grep -q '"status":"UP"'; do
+                echo "Waiting for SonarQube to be UP..."; sleep 10;
+              done
+      containers:
+        - name: agentic-orchestrator
+          image: {{ printf "%s:%s" .Values.agenticHarness.orchestrator.image.repository (default "latest" .Values.agenticHarness.orchestrator.image.tag) }}
+          imagePullPolicy: {{ .Values.agenticHarness.orchestrator.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.agenticHarness.orchestrator.port }}
+              protocol: TCP
+          env:
+            - name: SERVER_PORT
+              value: {{ .Values.agenticHarness.orchestrator.port | quote }}
+            # The orchestrator always persists to SonarQube's own database — same connection info,
+            # reshaped for the orchestrator's CORE_DB_* config (see the
+            # sonarqube.agentic.dbEndpoint/dbName helpers for why this can't just envFrom the
+            # existing jdbc-config ConfigMap directly).
+            - name: CORE_DB_READ_WRITE_ENDPOINT
+              value: {{ include "sonarqube.agentic.dbEndpoint" . | quote }}
+            - name: CORE_DB_NAME
+              value: {{ include "sonarqube.agentic.dbName" . | quote }}
+            - name: CORE_DB_USERNAME
+              value: {{ template "jdbc.username" . }}
+            - name: CORE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jdbc.secret" . }}
+                  key: {{ include "jdbc.secretPasswordKey" . }}
+            # Object storage the orchestrator uploads job artifacts to / presigns URLs against.
+            # Customer-provided infrastructure — not deployed by this chart. Credentials always
+            # come from a Secret (existingSecret, or the internal one this chart generates from
+            # storage.accessKey/secretKey) — never rendered as a plaintext env value.
+            - name: AGENTIC_STORAGE_ENDPOINT
+              value: {{ $storage.endpoint | quote }}
+            - name: AGENTIC_STORAGE_REGION
+              value: {{ $storage.region | quote }}
+            - name: AGENTIC_STORAGE_BUCKET
+              value: {{ $storage.bucket | quote }}
+            - name: AGENTIC_STORAGE_PATH_STYLE
+              value: {{ $storage.pathStyleAccess | quote }}
+            - name: AGENTIC_STORAGE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $storageSecretName }}
+                  key: {{ $storageAccessKeyKey }}
+            - name: AGENTIC_STORAGE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $storageSecretName }}
+                  key: {{ $storageSecretKeyKey }}
+            # The orchestrator currently supports pushing to a single Agentic Runtime target; it
+            # has no family-aware routing today, so this always points at the hunter runtime.
+            - name: AGENTIC_RUNTIME_PUSH_URL
+              value: {{ printf "http://%s:%d/jobs" (include "sonarqube.agentic.runtime.fullname" (dict "root" $ "family" "hunter")) (int .Values.agenticHarness.runtimes.hunter.port) | quote }}
+            {{- with .Values.agenticHarness.orchestrator.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.agenticHarness.orchestrator.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.agenticHarness.orchestrator.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.agenticHarness.orchestrator.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.agenticHarness.orchestrator.livenessProbe.timeoutSeconds }}
+          {{- with .Values.agenticHarness.orchestrator.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.agenticHarness.orchestrator.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/agentic-runtime.yaml
+++ b/charts/sonarqube/templates/agentic-runtime.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.agenticHarness.enabled }}
+{{- range $family, $cfg := .Values.agenticHarness.runtimes }}
+{{- if $cfg.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sonarqube.agentic.runtime.fullname" (dict "root" $ "family" $family) }}
+  labels: {{- include "sonarqube.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: agentic-runtime-{{ $family }}
+spec:
+  replicas: {{ $cfg.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "sonarqube.name" $ }}-agentic-runtime-{{ $family }}
+      release: {{ $.Release.Name }}
+  template:
+    metadata:
+      {{- with $cfg.annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ include "sonarqube.name" $ }}-agentic-runtime-{{ $family }}
+        release: {{ $.Release.Name }}
+    spec:
+      {{- with $cfg.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
+      {{- if or $.Values.image.pullSecrets $.Values.image.pullSecret $cfg.image.pullSecrets }}
+      imagePullSecrets:
+        {{- if $.Values.image.pullSecret }}
+        - name: {{ $.Values.image.pullSecret }}
+        {{- end }}
+        {{- with $.Values.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $cfg.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: agentic-runtime
+          image: {{ printf "%s:%s" $cfg.image.repository (default "latest" $cfg.image.tag) }}
+          imagePullPolicy: {{ $cfg.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $cfg.port }}
+              protocol: TCP
+          env:
+            - name: SERVER_PORT
+              value: {{ $cfg.port | quote }}
+            - name: AGENT_FAMILY
+              value: {{ $family | quote }}
+            {{- with $cfg.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ $cfg.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $cfg.livenessProbe.periodSeconds }}
+            failureThreshold: {{ $cfg.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ $cfg.livenessProbe.timeoutSeconds }}
+          {{- with $cfg.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cfg.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sonarqube.agentic.runtime.fullname" (dict "root" $ "family" $family) }}
+  labels: {{- include "sonarqube.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: agentic-runtime-{{ $family }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $cfg.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "sonarqube.name" $ }}-agentic-runtime-{{ $family }}
+    release: {{ $.Release.Name }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/config.yaml
+++ b/charts/sonarqube/templates/config.yaml
@@ -8,6 +8,9 @@ data:
   {{- range $key, $val := .Values.sonarProperties }}
     {{ $key }}={{ $val }}
   {{- end }}
+  {{- if and .Values.agenticHarness.enabled (not (and .Values.sonarProperties (hasKey .Values.sonarProperties "sonar.hunteragent.orchestrator.url"))) }}
+    sonar.hunteragent.orchestrator.url=http://{{ include "sonarqube.agentic.orchestrator.fullname" . }}:{{ .Values.agenticHarness.orchestrator.port }}
+  {{- end }}
   {{- if not .Values.elasticsearch.bootstrapChecks }}
     sonar.es.bootstrap.checks.disable=true
   {{- end }}

--- a/charts/sonarqube/templates/validation.yaml
+++ b/charts/sonarqube/templates/validation.yaml
@@ -27,3 +27,10 @@ It is used to validate the values.yaml file before the installation starts.
         {{- include "sonarqube.fail" "The 'edition' must be either 'developer' or 'enterprise'." -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+* Validates the Agentic Harness has a database to persist to.
+*/}}
+{{- if and .Values.agenticHarness.enabled (not (or .Values.jdbcOverwrite.enabled .Values.jdbcOverwrite.enable)) -}}
+    {{- include "sonarqube.fail" "agenticHarness.enabled requires jdbcOverwrite.enabled=true — the Agentic Orchestrator always persists to SonarQube's own database and has no database of its own to fall back to." -}}
+{{- end -}}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -726,3 +726,141 @@ mcp:
 
   # Set annotations for the MCP pod.
   annotations: {}
+
+# Agentic Unified Harness: an Agent Orchestrator plus one or more sandboxed Agentic Job Runtimes
+# (e.g. Hunter, Remediation), network-segmented so runtimes can reach only an LLM endpoint and
+# object storage, never SonarQube/SCM/each other directly. See SONAR-30824.
+agenticHarness:
+  enabled: false
+
+  orchestrator:
+    image:
+      repository: ""
+      tag: ""
+      pullPolicy: IfNotPresent
+      # pullSecrets:
+      #   - name: my-repo-secret
+
+    port: 8080
+
+    # The orchestrator always persists to the SAME database as SonarQube itself (reuses the
+    # chart's own jdbcOverwrite/internal DB secret) — there is no separate DB config here.
+    # Requires jdbcOverwrite.enabled=true; enforced by templates/validation.yaml.
+
+    # Object storage the orchestrator uploads job artifacts to and presigns URLs against
+    # (MinIO on-prem, S3 in cloud — same client code path either way). This is customer-provided
+    # infrastructure, like SCM below, not something this chart deploys.
+    storage:
+      endpoint: ""          # blank targets real AWS S3; set to a MinIO/S3-compatible URL otherwise
+      region: us-east-1
+      bucket: agentic-jobs
+      accessKey: ""
+      secretKey: ""
+      # existingSecret: ""          # alternative to accessKey/secretKey above
+      # existingSecretAccessKeyKey: "access-key"
+      # existingSecretSecretKeyKey: "secret-key"
+      pathStyleAccess: true
+
+    # Additional environment variables for the orchestrator container (e.g. SCM tokens).
+    env: []
+    # - name: MY_VAR
+    #   value: my-value
+
+    # NetworkPolicy egress allowlist for destinations NetworkPolicy can't reach by hostname (SCM,
+    # storage — see storage.endpoint above). Egress to SonarQube and the runtimes is wired
+    # automatically and does not need an entry here. Keep this in sync with storage.endpoint /
+    # your SCM host — NetworkPolicy matches CIDRs, not hostnames. Empty by default: SCM is
+    # customer-specific, so there's no universal default (e.g. following the demo scripts'
+    # git-clone-from-github.com as-is with networkPolicy.enabled=true needs GitHub's current
+    # range added here yourself — see https://api.github.com/meta).
+    #
+    # Each entry is either `cidr` (for a genuinely external endpoint) or `podSelector` (for a
+    # destination that's itself a Kubernetes Service — e.g. a self-hosted, in-cluster DB or S3
+    # gateway). `cidr`/`ipBlock` cannot target a Service's ClusterIP on any CNI: kube-proxy DNATs
+    # to the backing pod IP before NetworkPolicy enforcement sees the packet, so the CIDR never
+    # matches the pod's real (and unpredictable) IP. `podSelector` matches pods directly instead,
+    # sidestepping that entirely. `namespaceSelector` is optional and defaults to the same
+    # namespace as this release.
+    egressAllow: []
+    # - cidr: 10.0.0.0/8
+    #   ports: [443]
+    # - podSelector:
+    #     matchLabels: {app: my-in-cluster-minio}
+    #   ports: [9000]
+
+    resources: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 0
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: ["ALL"]
+
+    livenessProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      failureThreshold: 6
+      timeoutSeconds: 1
+
+    annotations: {}
+
+  # One entry per agentic job family. Only "hunter" ships today — remediation-agent-orchestrator
+  # has no real implementation yet. Add a new map entry (values-only change, no template change)
+  # once a second family is real.
+  runtimes:
+    hunter:
+      enabled: true
+      image:
+        repository: ""
+        tag: ""
+        pullPolicy: IfNotPresent
+      replicas: 1
+      port: 8081
+      env: []
+      # NetworkPolicy egress allowlist: LLM + storage endpoint, each entry `cidr` or `podSelector`
+      # (see orchestrator.egressAllow's comment for the full explanation and why an in-cluster
+      # Service needs podSelector, not cidr). Defaults to Anthropic's documented, stable inbound
+      # CIDR (i.e. what a client egresses *to*) — https://platform.claude.com/docs/en/api/ip-addresses
+      # — matching this harness's real local test target. Override with your actual LLM provider's
+      # endpoint range in production (e.g. Bedrock/Azure OpenAI/Vertex AI private or regional
+      # endpoints).
+      egressAllow:
+        - cidr: 160.79.104.0/23
+          ports: [443]
+        - cidr: 2607:6bc0::/48
+          ports: [443]
+      resources: {}
+      # Defaults assume a uid-1000 image, matching the reference orchestrator. runAsNonRoot
+      # requires a numeric runAsUser whenever an image declares its user by name (Dockerfile
+      # `USER app` rather than `USER 1000`) — Kubernetes can't resolve a name to verify it's
+      # non-root, so override runAsUser/runAsGroup here to match your own image's actual uid/gid
+      # if it differs (check the image's Dockerfile).
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop: ["ALL"]
+      # Empty by default. Set to wire in a sandboxing RuntimeClass (e.g. gVisor, Kata) once one is
+      # available — no chart change needed later. No real sandboxing exists anywhere in the
+      # current prototype either.
+      runtimeClassName: ""
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        failureThreshold: 6
+        timeoutSeconds: 1
+      annotations: {}
+
+  # NetworkPolicy segmentation for the harness: orchestrator <-> SonarQube/runtimes/SCM/storage;
+  # each runtime <-> LLM/storage only. Separate toggle from the main networkPolicy.enabled above.
+  # Defaults to true (unlike the main one) because runtimes.hunter.egressAllow already ships a
+  # working default for this harness's real LLM target — see there.
+  networkPolicy:
+    enabled: true

--- a/tests/unit-test/agentic_harness_test.go
+++ b/tests/unit-test/agentic_harness_test.go
@@ -1,0 +1,240 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// splitK8sYamlDocs splits terratest's raw multi-document `helm template` output into individual
+// YAML documents, since a single agentic-* template file can render more than one resource
+// (e.g. one Deployment+Service per agentic job family, or one NetworkPolicy per component).
+func splitK8sYamlDocs(output string) []string {
+	var docs []string
+	for _, doc := range strings.Split(output, "\n---\n") {
+		trimmed := strings.TrimSpace(doc)
+		if trimmed != "" {
+			docs = append(docs, trimmed)
+		}
+	}
+	return docs
+}
+
+func mapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func TestAgenticHarnessDisabledByDefault(t *testing.T) {
+	opts := newSQHelmOptions()
+	opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-community-build-empty-tag.yaml"}
+	output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{})
+	require.NoError(t, err)
+	assert.NotContains(t, output, "agentic-orchestrator")
+	assert.NotContains(t, output, "agentic-runtime")
+}
+
+func TestAgenticHarnessRequiresJdbcOverwrite(t *testing.T) {
+	opts := newSQHelmOptions()
+	opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-missing-jdbc.yaml"}
+	_, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agenticHarness.enabled requires jdbcOverwrite.enabled=true")
+}
+
+func TestAgenticOrchestratorDeployment(t *testing.T) {
+	opts := newSQHelmOptions()
+	opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-orchestrator.yaml"}
+	output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-orchestrator.yaml"})
+	require.NoError(t, err)
+
+	var deployment appsv1.Deployment
+	for _, doc := range splitK8sYamlDocs(output) {
+		if strings.Contains(doc, "kind: Deployment") {
+			helm.UnmarshalK8SYaml(t, doc, &deployment)
+		}
+	}
+	require.NotEmpty(t, deployment.Name)
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, "example/agentic-orchestrator:1.0.0", container.Image)
+
+	env := map[string]string{}
+	envFrom := map[string]corev1.EnvVarSource{}
+	for _, e := range container.Env {
+		if e.ValueFrom != nil {
+			envFrom[e.Name] = *e.ValueFrom
+		} else {
+			env[e.Name] = e.Value
+		}
+	}
+	// jdbcUrl is jdbc:postgresql://postgres.example.svc:5432/sonarqube?currentSchema=public —
+	// the orchestrator needs the bare host:port and db name, not the full JDBC URL.
+	assert.Equal(t, "postgres.example.svc:5432", env["CORE_DB_READ_WRITE_ENDPOINT"])
+	assert.Equal(t, "sonarqube", env["CORE_DB_NAME"])
+	assert.Equal(t, "sonarqube", env["CORE_DB_USERNAME"])
+	// The orchestrator has no family-aware routing today, so it always pushes to the hunter runtime.
+	assert.Equal(t, "http://sonarqube-sonarqube-agentic-runtime-hunter:8081/jobs", env["AGENTIC_RUNTIME_PUSH_URL"])
+	// Storage credentials must always come from a Secret, never a plaintext value.
+	_, hasPlainAccessKey := env["AGENTIC_STORAGE_ACCESS_KEY"]
+	assert.False(t, hasPlainAccessKey, "AGENTIC_STORAGE_ACCESS_KEY must not be a plaintext env value")
+	require.Contains(t, envFrom, "AGENTIC_STORAGE_ACCESS_KEY")
+	assert.Equal(t, "sonarqube-sonarqube-agentic-orchestrator-storage", envFrom["AGENTIC_STORAGE_ACCESS_KEY"].SecretKeyRef.Name)
+	assert.Equal(t, "access-key", envFrom["AGENTIC_STORAGE_ACCESS_KEY"].SecretKeyRef.Key)
+}
+
+func TestAgenticOrchestratorStorageSecret(t *testing.T) {
+	t.Run("plain values are wrapped into an internal Secret", func(t *testing.T) {
+		opts := newSQHelmOptions()
+		opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-orchestrator.yaml"}
+		output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-orchestrator-secret.yaml"})
+		require.NoError(t, err)
+
+		var secret corev1.Secret
+		helm.UnmarshalK8SYaml(t, output, &secret)
+		assert.Equal(t, "mykey", string(secret.Data["access-key"]))
+		assert.Equal(t, "mysecret", string(secret.Data["secret-key"]))
+	})
+
+	t.Run("existingSecret suppresses the internal Secret entirely", func(t *testing.T) {
+		opts := newSQHelmOptions()
+		opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-existing-secret.yaml"}
+		_, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-orchestrator-secret.yaml"})
+		assert.Error(t, err, "expected no internal storage Secret when existingSecret is set")
+
+		output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-orchestrator.yaml"})
+		require.NoError(t, err)
+		assert.Contains(t, output, "name: my-s3-secret")
+	})
+}
+
+func TestAgenticRuntimeDeployment(t *testing.T) {
+	opts := newSQHelmOptions()
+	opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-orchestrator.yaml"}
+	output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-runtime.yaml"})
+	require.NoError(t, err)
+
+	// Only "hunter" ships by default — no remediation-family Deployment should exist at all.
+	assert.NotContains(t, output, "agentic-runtime-remediation")
+
+	var deployment appsv1.Deployment
+	for _, doc := range splitK8sYamlDocs(output) {
+		if strings.Contains(doc, "kind: Deployment") {
+			helm.UnmarshalK8SYaml(t, doc, &deployment)
+		}
+	}
+	require.NotEmpty(t, deployment.Name)
+	assert.Equal(t, "example/hunter-runtime:1.0.0", deployment.Spec.Template.Spec.Containers[0].Image)
+	for _, e := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if e.Name == "AGENT_FAMILY" {
+			assert.Equal(t, "hunter", e.Value)
+		}
+	}
+}
+
+func TestAgenticNetworkPolicyEnabledByDefault(t *testing.T) {
+	opts := newSQHelmOptions()
+	// This fixture doesn't touch networkPolicy at all — it should still be on, and the runtime
+	// should get Anthropic's documented CIDR without any egressAllow override.
+	opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-orchestrator.yaml"}
+	output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-networkpolicy.yaml"})
+	require.NoError(t, err)
+
+	policies := map[string]networkingv1.NetworkPolicy{}
+	for _, doc := range splitK8sYamlDocs(output) {
+		var p networkingv1.NetworkPolicy
+		helm.UnmarshalK8SYaml(t, doc, &p)
+		policies[p.Name] = p
+	}
+
+	orchestratorPolicy, ok := policies["sonarqube-sonarqube-agentic-orchestrator-network-policy"]
+	require.True(t, ok, "expected an orchestrator NetworkPolicy, got: %v", mapKeys(policies))
+	// SonarQube + the hunter runtime (podSelector rules); orchestrator.egressAllow is empty by
+	// default, so no CIDR rule beyond DNS.
+	assert.Len(t, orchestratorPolicy.Spec.Egress, 3)
+
+	runtimePolicy, ok := policies["sonarqube-sonarqube-agentic-runtime-hunter-network-policy"]
+	require.True(t, ok, "expected a hunter runtime NetworkPolicy, got: %v", mapKeys(policies))
+	// DNS + Anthropic's documented IPv4/IPv6 CIDR, present without any values override.
+	require.Len(t, runtimePolicy.Spec.Egress, 3)
+	assert.Equal(t, "160.79.104.0/23", runtimePolicy.Spec.Egress[1].To[0].IPBlock.CIDR)
+	assert.Equal(t, "2607:6bc0::/48", runtimePolicy.Spec.Egress[2].To[0].IPBlock.CIDR)
+}
+
+func TestAgenticNetworkPolicyEgressAllowPodSelector(t *testing.T) {
+	// ipBlock can't target a Service's ClusterIP on any CNI (kube-proxy DNATs to the backing pod
+	// IP before policy enforcement sees the packet), so egressAllow also accepts a podSelector
+	// entry for in-cluster destinations like a self-hosted DB or S3 gateway.
+	opts := newSQHelmOptions()
+	opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-egressallow-podselector.yaml"}
+	output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-networkpolicy.yaml"})
+	require.NoError(t, err)
+
+	policies := map[string]networkingv1.NetworkPolicy{}
+	for _, doc := range splitK8sYamlDocs(output) {
+		var p networkingv1.NetworkPolicy
+		helm.UnmarshalK8SYaml(t, doc, &p)
+		policies[p.Name] = p
+	}
+
+	orchestratorPolicy, ok := policies["sonarqube-sonarqube-agentic-orchestrator-network-policy"]
+	require.True(t, ok, "expected an orchestrator NetworkPolicy, got: %v", mapKeys(policies))
+
+	var minioRule, dbRule *networkingv1.NetworkPolicyEgressRule
+	for i := range orchestratorPolicy.Spec.Egress {
+		rule := &orchestratorPolicy.Spec.Egress[i]
+		if len(rule.To) == 0 || rule.To[0].PodSelector == nil {
+			continue
+		}
+		switch rule.To[0].PodSelector.MatchLabels["app"] {
+		case "my-in-cluster-minio":
+			minioRule = rule
+		case "my-in-cluster-db":
+			dbRule = rule
+		}
+	}
+
+	require.NotNil(t, minioRule, "expected a podSelector egress rule for my-in-cluster-minio")
+	assert.Nil(t, minioRule.To[0].NamespaceSelector, "no namespaceSelector override means same-namespace only")
+	assert.Equal(t, int32(9000), minioRule.Ports[0].Port.IntVal)
+
+	require.NotNil(t, dbRule, "expected a podSelector egress rule for my-in-cluster-db")
+	require.NotNil(t, dbRule.To[0].NamespaceSelector)
+	assert.Equal(t, "other-ns", dbRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+	assert.Equal(t, int32(5432), dbRule.Ports[0].Port.IntVal)
+}
+
+func TestAgenticNetworkPolicyCanBeDisabled(t *testing.T) {
+	opts := newSQHelmOptions()
+	opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-networkpolicy-disabled.yaml"}
+	_, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/agentic-networkpolicy.yaml"})
+	assert.Error(t, err, "expected no NetworkPolicy resources when agenticHarness.networkPolicy.enabled=false")
+}
+
+func TestAgenticOrchestratorUrlAutoInjection(t *testing.T) {
+	t.Run("auto-injected when unset", func(t *testing.T) {
+		opts := newSQHelmOptions()
+		opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-orchestrator.yaml"}
+		output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/config.yaml"})
+		require.NoError(t, err)
+		assert.Contains(t, output, "sonar.hunteragent.orchestrator.url=http://sonarqube-sonarqube-agentic-orchestrator:8080")
+	})
+
+	t.Run("operator override wins", func(t *testing.T) {
+		opts := newSQHelmOptions()
+		opts.ValuesFiles = []string{"test-cases-values/sonarqube/test-agentic-harness-custom-orchestrator-url.yaml"}
+		output, err := helm.RenderTemplateE(t, opts, chartPath, releaseName, []string{"templates/config.yaml"})
+		require.NoError(t, err)
+		assert.Contains(t, output, "sonar.hunteragent.orchestrator.url=http://custom-orchestrator:9999")
+		assert.NotContains(t, output, "agentic-orchestrator:8080")
+	})
+}

--- a/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-custom-orchestrator-url.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-custom-orchestrator-url.yaml
@@ -1,0 +1,23 @@
+community:
+  enabled: true
+
+jdbcOverwrite:
+  enabled: true
+  jdbcUrl: "jdbc:postgresql://postgres.example.svc:5432/sonarqube"
+  jdbcUsername: sonarqube
+  jdbcPassword: sonarqube
+
+sonarProperties:
+  sonar.hunteragent.orchestrator.url: "http://custom-orchestrator:9999"
+
+agenticHarness:
+  enabled: true
+  orchestrator:
+    image:
+      repository: example/agentic-orchestrator
+      tag: "1.0.0"
+  runtimes:
+    hunter:
+      image:
+        repository: example/hunter-runtime
+        tag: "1.0.0"

--- a/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-egressallow-podselector.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-egressallow-podselector.yaml
@@ -1,0 +1,32 @@
+community:
+  enabled: true
+
+jdbcOverwrite:
+  enabled: true
+  jdbcUrl: "jdbc:postgresql://postgres.example.svc:5432/sonarqube?currentSchema=public"
+  jdbcUsername: sonarqube
+  jdbcPassword: sonarqube
+
+agenticHarness:
+  enabled: true
+  orchestrator:
+    image:
+      repository: example/agentic-orchestrator
+      tag: "1.0.0"
+    storage:
+      accessKey: mykey
+      secretKey: mysecret
+    egressAllow:
+      - podSelector:
+          matchLabels: {app: my-in-cluster-minio}
+        ports: [9000]
+      - podSelector:
+          matchLabels: {app: my-in-cluster-db}
+        namespaceSelector:
+          matchLabels: {kubernetes.io/metadata.name: other-ns}
+        ports: [5432]
+  runtimes:
+    hunter:
+      image:
+        repository: example/hunter-runtime
+        tag: "1.0.0"

--- a/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-existing-secret.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-existing-secret.yaml
@@ -1,0 +1,22 @@
+community:
+  enabled: true
+
+jdbcOverwrite:
+  enabled: true
+  jdbcUrl: "jdbc:postgresql://postgres.example.svc:5432/sonarqube"
+  jdbcUsername: sonarqube
+  jdbcPassword: sonarqube
+
+agenticHarness:
+  enabled: true
+  orchestrator:
+    image:
+      repository: example/agentic-orchestrator
+      tag: "1.0.0"
+    storage:
+      existingSecret: my-s3-secret
+  runtimes:
+    hunter:
+      image:
+        repository: example/hunter-runtime
+        tag: "1.0.0"

--- a/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-missing-jdbc.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-missing-jdbc.yaml
@@ -1,0 +1,5 @@
+community:
+  enabled: true
+
+agenticHarness:
+  enabled: true

--- a/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-networkpolicy-disabled.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-networkpolicy-disabled.yaml
@@ -1,0 +1,22 @@
+community:
+  enabled: true
+
+jdbcOverwrite:
+  enabled: true
+  jdbcUrl: "jdbc:postgresql://postgres.example.svc:5432/sonarqube"
+  jdbcUsername: sonarqube
+  jdbcPassword: sonarqube
+
+agenticHarness:
+  enabled: true
+  networkPolicy:
+    enabled: false
+  orchestrator:
+    image:
+      repository: example/agentic-orchestrator
+      tag: "1.0.0"
+  runtimes:
+    hunter:
+      image:
+        repository: example/hunter-runtime
+        tag: "1.0.0"

--- a/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-orchestrator.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-agentic-harness-orchestrator.yaml
@@ -1,0 +1,23 @@
+community:
+  enabled: true
+
+jdbcOverwrite:
+  enabled: true
+  jdbcUrl: "jdbc:postgresql://postgres.example.svc:5432/sonarqube?currentSchema=public"
+  jdbcUsername: sonarqube
+  jdbcPassword: sonarqube
+
+agenticHarness:
+  enabled: true
+  orchestrator:
+    image:
+      repository: example/agentic-orchestrator
+      tag: "1.0.0"
+    storage:
+      accessKey: mykey
+      secretKey: mysecret
+  runtimes:
+    hunter:
+      image:
+        repository: example/hunter-runtime
+        tag: "1.0.0"


### PR DESCRIPTION
## Summary
Adds the initial Helm chart resources for the SonarQube Unified Agentic Harness (Agent Orchestrator + per-family Agentic Job Runtimes), gated behind `agenticHarness.enabled`.

- New `agenticHarness` values block: orchestrator (image, storage, egress allowlist) and a `runtimes` map (hunter only for now).
- New templates: `agentic-orchestrator.yaml`/`-service.yaml`/`-secret.yaml`, `agentic-runtime.yaml`, `agentic-networkpolicy.yaml`.
- Orchestrator reuses SonarQube's own DB (parses `jdbcOverwrite.jdbcUrl`, no separate override) and auto-wires `sonar.hunteragent.orchestrator.url` into `sonar.properties` unless already set.
- Fail-fast validation: `agenticHarness.enabled=true` requires `jdbcOverwrite.enabled=true`.
- NetworkPolicy-only egress model (no proxy pod): `egressAllow` entries support either `cidr` (external endpoints) or `podSelector` (in-cluster destinations — `ipBlock` can't target a Service ClusterIP on any CNI).
- `.github/scripts/setup_external_minio.sh` for local MinIO provisioning, mirroring the existing Postgres script.
- `charts/sonarqube/local-testing/` — kind test values file + a consolidated script (`run-e2e-tests.sh`) that runs the reference demo/pressure/backpressure flows against a real deployment.

Verified end to end on a local `kind` cluster with Calico (real NetworkPolicy enforcement, not just rendered YAML): job creation → orchestrator dispatch → git clone → push to runtime → real HTTPS call to `api.anthropic.com` → SUCCEEDED → fire-back → persisted. Confirmed both ingress (runtime reachable only from orchestrator) and egress (runtime can reach only its allowlisted CIDR) restrictions are genuinely enforced, not just spec-correct.

Jira: [SONAR-30859](https://sonarsource.atlassian.net/browse/SONAR-30859) (parent epic [SONAR-30824](https://sonarsource.atlassian.net/browse/SONAR-30824))

## Test plan
- [x] `helm lint charts/sonarqube` (with required base values)
- [x] `go test ./...` in `tests/unit-test` — full suite green, including new `TestAgenticNetworkPolicyEgressAllowPodSelector`
- [x] Full E2E on local `kind` + Calico: demo/pressure/backpressure all pass
- [x] Live-verified NetworkPolicy ingress/egress enforcement (not just rendered YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SONAR-30859]: https://sonarsource.atlassian.net/browse/SONAR-30859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ