### PR TITLE
 REL-4802 Release SonarQube Server 2026.4.0

### DIFF
--- a/.github/workflows/azure-marketplace.yml
+++ b/.github/workflows/azure-marketplace.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  SQ_VERSION: 2026.3.1
-  SQ_IMAGE_VERSION: 2026.3.1
+  SQ_VERSION: 2026.4.0
+  SQ_IMAGE_VERSION: 2026.4.0
 
 jobs:
   build-azure-staging-app:

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2026.3.1 # Update this value to the desired version
+  GCLOUD_TAG: 2026.4.0 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/azure-marketplace-k8s-app/manifest.yaml
+++ b/azure-marketplace-k8s-app/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: sonarqube
 publisher: "SonarSource"
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
-version: 2026.3.1
+version: 2026.4.0
 helmChart: "./sonarqube-azure"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"

--- a/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2 # Or v1 depending on your Helm version
 name: sonarqube-azure
-version: 2026.3.1
-appVersion: 2026.3.1
+version: 2026.4.0
+appVersion: 2026.4.0
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
 type: application
 dependencies:
   - name: sonarqube 
-    version: 2026.3.1
+    version: 2026.4.0
     repository: "file://../../charts/sonarqube" # Reference to the local SonarQube chart

--- a/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
@@ -22,4 +22,4 @@ global:
       sonarqube:
         registry: __ACR_REGISTRY_PLACEHOLDER__
         image: sonarqube
-        tag: 2026.3.1-enterprise
+        tag: 2026.4.0-enterprise

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
+* Upgrade SonarQube Server to 2026.4.0
 * Upgrade SonarQube Community build to 26.6.0.123539
 * Add `searchNodes.extraInitContainers` and `applicationNodes.extraInitContainers` to allow per-node-type extra init containers
 * Deprecate root-level `extraInitContainers` in favour of the node-specific values

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -3,7 +3,7 @@ name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
 version: 2026.4.0
-appVersion: 2026.3.1
+appVersion: 2026.4.0
 keywords:
   - coverage
   - security
@@ -38,6 +38,8 @@ annotations:
     - kind: changed
       description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
+      description: "Upgrade SonarQube Server to 2026.4.0"
+    - kind: changed
       description: "Upgrade SonarQube Community build to 26.6.0.123539"
     - kind: added
       description: "Add searchNodes.extraInitContainers and applicationNodes.extraInitContainers for per-node-type extra init containers"
@@ -61,9 +63,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2026.3.1-datacenter-app
+      image: sonarqube:2026.4.0-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2026.3.1-datacenter-search
+      image: sonarqube:2026.4.0-datacenter-search
     - name: sonarqube-mcp
       image: sonarsource/sonarqube-mcp:1.22.0.3040
   charts.openshift.io/name: sonarqube-dce

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2026.3.1`
+Compatible SonarQube Version: `2026.4.0`
 
 Supported Kubernetes Versions: From `1.32` to `1.35`
 Supported Openshift Versions: From `4.17` to `4.20`
@@ -565,7 +565,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.3.1-datacenter-search`                                             |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.4.0-datacenter-search`                                             |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -623,7 +623,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.3.1-datacenter-app`                                                |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.4.0-datacenter-app`                                                |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/ci-values.yaml
+++ b/charts/sonarqube-dce/ci/ci-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 3
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.1-master-datacenter-search"
+    tag: "2026.4.0-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.1-master-datacenter-app"
+    tag: "2026.4.0-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
   webPort: 4023

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -7,7 +7,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.1-master-datacenter-search"
+    tag: "2026.4.0-master-datacenter-search"
     pullPolicy: Always
     pullSecrets:
       - name: pullsecret
@@ -17,7 +17,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.3.1-master-datacenter-app"
+    tag: "2026.4.0-master-datacenter-app"
     pullPolicy: Always
     pullSecrets:
       - name: pullsecret

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2026.3.1-datacenter-search
+    tag: 2026.4.0-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -164,7 +164,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2026.3.1-datacenter-app
+    tag: 2026.4.0-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
+* Upgrade SonarQube Server to 2026.4.0
 * Upgrade SonarQube Community build to 26.7.0.124771
 * Add CA certificate support with multi-cert bundling to `install-plugins` init container for plugin downloads from servers using self-signed or private CA certificates
 * Fix multi-cert CA bundle handling in `install-oracle-jdbc-driver` init container

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -3,7 +3,7 @@ name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
 version: 2026.4.0
-appVersion: 2026.3.1
+appVersion: 2026.4.0
 keywords:
   - coverage
   - security
@@ -43,6 +43,8 @@ annotations:
     - kind: changed
       description: "Upgrade Chart's version to 2026.4.0"
     - kind: changed
+      description: "Upgrade SonarQube Server to 2026.4.0"
+    - kind: changed
       description: "Upgrade SonarQube Community build to 26.7.0.124771"
     - kind: added
       description: "Add CA certificate support with multi-cert bundling to install-plugins init container"
@@ -55,9 +57,9 @@ annotations:
     - name: sonarqube-community
       image: sonarqube:26.7.0.124771-community
     - name: sonarqube-developer
-      image: sonarqube:2026.3.1-developer
+      image: sonarqube:2026.4.0-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2026.3.1-enterprise
+      image: sonarqube:2026.4.0-enterprise
     - name: sonarqube-mcp
       image: sonarsource/sonarqube-mcp:1.22.0.3040
   charts.openshift.io/name: sonarqube

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Default Versions
 
-SonarQube Server Version: `2026.3.1`
+SonarQube Server Version: `2026.4.0`
 
 SonarQube Community Build: `26.7.0.124771`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2026.3.1
+export TAG=2026.4.0
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/google-cloud-marketplace-k8s-app/data-test/schema.yaml
+++ b/google-cloud-marketplace-k8s-app/data-test/schema.yaml
@@ -7,7 +7,7 @@ x-google-marketplace:
   publishedVersion: "$TAG"
   publishedVersionMetadata:
     releaseNote: >-
-      SonarQube Server 2026.3.x google cloud marketpalce release test schema.
+      SonarQube Server 2026.4.x google cloud marketpalce release test schema.
   images:
     '':
       properties:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -364,7 +364,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -403,7 +403,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -616,7 +616,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -631,7 +631,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -672,7 +672,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -826,7 +826,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: application-static-hazelcast-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -549,7 +549,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -757,7 +757,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2026.3.1-datacenter-app"
+    version: "2026.4.0-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -818,7 +818,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -347,7 +347,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -371,7 +371,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -405,7 +405,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-plugins
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -450,7 +450,7 @@ spec:
                   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
                   key: PLUGINS-NO-PROXY
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -480,7 +480,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -701,7 +701,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -716,7 +716,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -749,7 +749,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -790,7 +790,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -949,7 +949,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -352,7 +352,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -389,7 +389,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -550,7 +550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -587,7 +587,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -602,7 +602,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -635,7 +635,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -676,7 +676,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -830,7 +830,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -563,7 +563,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -578,7 +578,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -619,7 +619,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -773,7 +773,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -357,7 +357,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -396,7 +396,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -616,7 +616,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -631,7 +631,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -667,7 +667,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -708,7 +708,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -883,7 +883,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -549,7 +549,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -759,7 +759,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -549,7 +549,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -759,7 +759,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -554,7 +554,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -569,7 +569,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -764,7 +764,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -553,7 +553,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -568,7 +568,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -609,7 +609,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -768,7 +768,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -353,7 +353,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -583,7 +583,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -598,7 +598,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -639,7 +639,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -793,7 +793,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -549,7 +549,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -784,7 +784,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -549,7 +549,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -785,7 +785,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -549,7 +549,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -792,7 +792,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -769,7 +769,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -796,7 +796,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -954,7 +954,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -991,7 +991,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -1006,7 +1006,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1047,7 +1047,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1415,7 +1415,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -596,7 +596,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -611,7 +611,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -652,7 +652,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -806,7 +806,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -314,7 +314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -341,7 +341,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -499,7 +499,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -536,7 +536,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -551,7 +551,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -592,7 +592,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -746,7 +746,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
@@ -358,7 +358,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -481,7 +481,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -680,7 +680,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -695,7 +695,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -736,7 +736,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -890,7 +890,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-tls-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
@@ -376,7 +376,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -485,7 +485,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -649,7 +649,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -686,7 +686,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -701,7 +701,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -742,7 +742,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -896,7 +896,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
@@ -376,7 +376,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -485,7 +485,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -647,7 +647,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -684,7 +684,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -699,7 +699,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -740,7 +740,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -894,7 +894,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -479,7 +479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -506,7 +506,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -701,7 +701,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -716,7 +716,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -757,7 +757,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -911,7 +911,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -479,7 +479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -506,7 +506,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -701,7 +701,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -716,7 +716,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -757,7 +757,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -911,7 +911,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -527,7 +527,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -564,7 +564,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -579,7 +579,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -620,7 +620,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -789,7 +789,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -527,7 +527,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -564,7 +564,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -579,7 +579,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -620,7 +620,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -789,7 +789,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -357,7 +357,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -383,7 +383,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -606,7 +606,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -643,7 +643,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -658,7 +658,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -699,7 +699,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -890,7 +890,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -596,7 +596,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -611,7 +611,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -652,7 +652,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -806,7 +806,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -360,7 +360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -386,7 +386,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -468,7 +468,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -653,7 +653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -690,7 +690,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -705,7 +705,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -746,7 +746,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -900,7 +900,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -551,7 +551,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -566,7 +566,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -607,7 +607,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -761,7 +761,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -563,7 +563,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -578,7 +578,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -619,7 +619,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -773,7 +773,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -345,7 +345,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -372,7 +372,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -567,7 +567,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -582,7 +582,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -623,7 +623,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -777,7 +777,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -336,7 +336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -363,7 +363,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -521,7 +521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -558,7 +558,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -573,7 +573,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -614,7 +614,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -768,7 +768,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -366,7 +366,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -405,7 +405,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -612,7 +612,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -627,7 +627,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -668,7 +668,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -845,7 +845,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -899,7 +899,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.3.1-datacenter-app
+        image: sonarqube:2026.4.0-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -563,7 +563,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -578,7 +578,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -619,7 +619,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -796,7 +796,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -850,7 +850,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.3.1-datacenter-app
+        image: sonarqube:2026.4.0-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: topology-spread-constraints-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-app"
+    app.kubernetes.io/version: "2026.4.0-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -520,7 +520,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: topology-spread-constraints-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.3.1-datacenter-search"
+    app.kubernetes.io/version: "2026.4.0-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -557,7 +557,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -572,7 +572,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.3.1-datacenter-app
+          image: sonarqube:2026.4.0-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -613,7 +613,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.3.1-datacenter-search"
+          image: "sonarqube:2026.4.0-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -775,7 +775,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: topology-spread-constraints-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-datacenter-app"
+      image: "sonarqube:2026.4.0-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -187,7 +187,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -226,7 +226,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -244,7 +244,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-plugins
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -291,7 +291,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -326,7 +326,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -478,7 +478,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -207,7 +207,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -226,7 +226,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -355,7 +355,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -327,7 +327,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -172,7 +172,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -190,7 +190,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -235,7 +235,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -391,7 +391,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -313,7 +313,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,7 +169,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -188,7 +188,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -314,7 +314,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -173,7 +173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -200,7 +200,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -275,7 +275,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -432,7 +432,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -338,7 +338,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -339,7 +339,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -346,7 +346,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -629,7 +629,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -969,7 +969,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -365,7 +365,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -170,7 +170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -195,7 +195,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -214,7 +214,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -347,7 +347,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
@@ -175,7 +175,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -270,7 +270,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -295,7 +295,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -314,7 +314,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -444,7 +444,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-tls-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
@@ -193,7 +193,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -299,7 +299,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -318,7 +318,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -450,7 +450,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
@@ -193,7 +193,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -299,7 +299,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -318,7 +318,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -448,7 +448,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -226,7 +226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -251,7 +251,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -270,7 +270,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -226,7 +226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -251,7 +251,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -270,7 +270,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -190,7 +190,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -217,7 +217,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -235,7 +235,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -277,7 +277,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -321,7 +321,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -477,7 +477,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -121,7 +121,7 @@ spec:
       initContainers:
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -263,7 +263,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -340,7 +340,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -365,7 +365,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -221,7 +221,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -263,7 +263,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -307,7 +307,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -463,7 +463,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -204,7 +204,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -222,7 +222,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -257,7 +257,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -389,7 +389,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -327,7 +327,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -175,7 +175,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -194,7 +194,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -320,7 +320,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -327,7 +327,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -183,7 +183,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -202,7 +202,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -351,7 +351,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -406,7 +406,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.3.1-enterprise
+        image: sonarqube:2026.4.0-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -350,7 +350,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -405,7 +405,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.3.1-enterprise
+        image: sonarqube:2026.4.0-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -350,7 +350,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -405,7 +405,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.3.1-enterprise
+        image: sonarqube:2026.4.0-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.3.1-enterprise"
+    app.kubernetes.io/version: "2026.4.0-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -264,7 +264,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.3.1-enterprise
+          image: sonarqube:2026.4.0-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2026.3.1-enterprise"
+      image: "sonarqube:2026.4.0-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-test/sonarqube_schema_test.go
+++ b/tests/unit-test/sonarqube_schema_test.go
@@ -110,7 +110,7 @@ func TestShouldUseImageTag(t *testing.T) {
 
 	actualContainers := rendered.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
-	assert.Equal(t, "sonarqube:2026.3.1-enterprise", actualContainers[0].Image)
+	assert.Equal(t, "sonarqube:2026.4.0-enterprise", actualContainers[0].Image)
 }
 
 func TestCustomCommunityTag(t *testing.T) {
@@ -156,7 +156,7 @@ func TestDeveloperEdition(t *testing.T) {
 	rendered := renderSQStsTemplate(t, "test-cases-values/sonarqube/test-developer-edition.yaml", newSQHelmOptions())
 	actualContainers := rendered.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
-	assert.Equal(t, "sonarqube:2026.3.1-developer", actualContainers[0].Image)
+	assert.Equal(t, "sonarqube:2026.4.0-developer", actualContainers[0].Image)
 }
 
 func findVolumeByName(volumes []v1.Volume, name string) *v1.Volume {

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2026.3.1-enterprise
+  tag: 2026.4.0-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Release Version:**
    - Updated SonarQube Server to `2026.4.0` across all Helm charts and supporting manifests.
    - Synchronized `Chart.yaml` app versions and image tags to `2026.4.0` for `sonarqube` and `sonarqube-dce`.
- **Documentation:**
    - Updated `README.md` and `CHANGELOG.md` files to reflect the new `2026.4.0` release compatibility.
- **CI/CD & Testing:**
    - Updated Azure and GCP marketplace release versions to `2026.4.0` in workflow and configuration files.
    - Regenerated unit test fixtures to match the new image tags and versions.


<sub>This will update automatically on new commits.</sub>