### PR TITLE
REL-4795 Release SQS 2025.4.8

### DIFF
--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2025.4.7 # Update this value to the desired version
+  GCLOUD_TAG: 2025.4.8 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.4.8]
+* Update Chart's version to 2025.4.8
+* Upgrade SonarQube Server to 2025.4.8
+
 ## [2025.4.7]
 * Update Chart's version to 2025.4.7
 * Upgrade SonarQube Server to 2025.4.7

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.4.7
-appVersion: 2025.4.7
+version: 2025.4.8
+appVersion: 2025.4.8
 keywords:
   - coverage
   - security
@@ -34,9 +34,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 2025.4.7"
+      description: "Update Chart's version to 2025.4.8"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2025.4.7"
+      description: "Upgrade SonarQube Server to 2025.4.8"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/
@@ -45,9 +45,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2025.4.7-datacenter-app
+      image: sonarqube:2025.4.8-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2025.4.7-datacenter-search
+      image: sonarqube:2025.4.8-datacenter-search
   charts.openshift.io/name: sonarqube-dce
 dependencies:
   - name: postgresql

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2025.4.7`
+Compatible SonarQube Version: `2025.4.8`
 
 Supported Kubernetes Versions: From `1.30` to `1.33`
 Supported Openshift Versions: From `4.11` to `4.17`
@@ -314,7 +314,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2025.4.7-datacenter-search`                                             |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2025.4.8-datacenter-search`                                             |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -370,7 +370,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2025.4.7-datacenter-app`                                                |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2025.4.8-datacenter-app`                                                |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/cirrus-values.yaml
+++ b/charts/sonarqube-dce/ci/cirrus-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 3
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.7-master-datacenter-search"
+    tag: "2025.4.8-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.7-master-datacenter-app"
+    tag: "2025.4.8-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
   webPort: 4023

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -13,7 +13,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.7-master-datacenter-search"
+    tag: "2025.4.8-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -22,7 +22,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2025.4.7-master-datacenter-app"
+    tag: "2025.4.8-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
 

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2025.4.7-datacenter-search
+    tag: 2025.4.8-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -153,7 +153,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2025.4.7-datacenter-app
+    tag: 2025.4.8-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2025.4.8]
+* Update Chart's version to 2025.4.8
+* Upgrade SonarQube Server to 2025.4.8
+
 ## [2025.4.7]
 * Update Chart's version to 2025.4.7
 * Upgrade SonarQube Server to 2025.4.7

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2025.4.7
-appVersion: 2025.4.7
+version: 2025.4.8
+appVersion: 2025.4.8
 keywords:
   - coverage
   - security
@@ -39,17 +39,17 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Chart's version to 2025.4.7"
+      description: "Update Chart's version to 2025.4.8"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2025.4.7"
+      description: "Upgrade SonarQube Server to 2025.4.8"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community
       image: sonarqube:25.8.0.112029-community
     - name: sonarqube-developer
-      image: sonarqube:2025.4.7-developer
+      image: sonarqube:2025.4.8-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2025.4.7-enterprise
+      image: sonarqube:2025.4.8-enterprise
   charts.openshift.io/name: sonarqube
 dependencies:
   - name: postgresql

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Default Versions
 
-SonarQube Server Version: `2025.4.7`
+SonarQube Server Version: `2025.4.8`
 
 SonarQube Community Build: `25.8.0.112029`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2025.4.7
+export TAG=2025.4.8
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -361,7 +361,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-static-hazelcast-values.yaml
@@ -397,7 +397,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -414,14 +414,14 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 79ebd7bbf57a187317e157cba40f13bdfe84874f485f03627495f91dced37a6b
-        checksum/config: 56610911ed0a40a5c2c7fe3e9a6fc47c74d973f75230d5c207bba83fa3476f93
-        checksum/secret: 96155e529acb32789248107bd95042bd83152789f8b72d92c13a5dd524f98f6d
+        checksum/plugins: ace4792e2b9c17e2105f28a0f2990b5a37b1ab06f69de381dae58f6bcaa4ab8a
+        checksum/config: e999148a59823f788190e2ed7d3ba69597d998d3f432b46676e2290cf4cbbb71
+        checksum/secret: b682c9beb8a21622225c72fd7f1c58e80eecd08032845278f2d31deb6a6dbd66
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -439,7 +439,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/application-static-hazelcast-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -478,7 +478,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -512,7 +512,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-static-hazelcast-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -798,7 +798,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-static-hazelcast-values.yaml"
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -836,15 +836,15 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0dc215b9d2d6ac8d217a2eca6405c14eb7d64df95b8b2ce1b6d633f4920f33d6
-        checksum/init-fs: 43542b0e18390167b8f93a8827619bdf38ff66dca64df35d9d445a5599228933
-        checksum/config: 56610911ed0a40a5c2c7fe3e9a6fc47c74d973f75230d5c207bba83fa3476f93
-        checksum/secret: 96155e529acb32789248107bd95042bd83152789f8b72d92c13a5dd524f98f6d
+        checksum/init-sysctl: ae57510d53c588cca6d27c4c38817201f50b0ec09b8ce3ea11f82b4979448c90
+        checksum/init-fs: 46254ac7cc881bcb2868f32381586fcfff025ccfc0df4228237c97b2db69eba9
+        checksum/config: e999148a59823f788190e2ed7d3ba69597d998d3f432b46676e2290cf4cbbb71
+        checksum/secret: b682c9beb8a21622225c72fd7f1c58e80eecd08032845278f2d31deb6a6dbd66
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -859,7 +859,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -900,7 +900,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1037,14 +1037,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-static-hazelcast-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d4b9236bee2184cb15f529c9c8e8e333d28612f241c90c98f18607dde10f9806
-        checksum/config: 469652c2ee476ddf1f0a11a29a258d4c5972e35c2cbdde1c4dbcf1c10158a0a0
-        checksum/secret: c4285c0564cb8a585d3cb1044bebe2c3cc25aba9eb82667a51b10ccbe33d0959
+        checksum/plugins: e853aacbe62d73070baf74a82f3806acbe0b752da4a00d9451ca0770d719542a
+        checksum/config: 633fb583febd6574d6c2303ec1be7394a13d4c4f7db96e2137c9fc459ce87be9
+        checksum/secret: d623dd6c5b3037886c79def5f30dc806502b674a7941767782665dce6bcc3dc4
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b33fc672732b2a5cffba3a4c6c5a0a546d218e382b3a1450d10486e073252d8d
-        checksum/init-fs: 916fb98fcaea457adbc6b4477efc753e06cfe892e82278ee11078f98b26e4481
-        checksum/config: 469652c2ee476ddf1f0a11a29a258d4c5972e35c2cbdde1c4dbcf1c10158a0a0
-        checksum/secret: c4285c0564cb8a585d3cb1044bebe2c3cc25aba9eb82667a51b10ccbe33d0959
+        checksum/init-sysctl: 024711e49b25b72c2478cdfa5ab164691b655c582be7e3b58e67c4a07b79689e
+        checksum/init-fs: 6e29121aff85b6e6434cc09ca31a3a7dea274e63ccf1f665099127b5aad08ab7
+        checksum/config: 633fb583febd6574d6c2303ec1be7394a13d4c4f7db96e2137c9fc459ce87be9
+        checksum/secret: d623dd6c5b3037886c79def5f30dc806502b674a7941767782665dce6bcc3dc4
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -975,7 +975,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2025.4.7-datacenter-app"
+    version: "2025.4.8-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -1029,14 +1029,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: application-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -148,7 +148,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -211,7 +211,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -314,7 +314,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -339,7 +339,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -365,7 +365,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -392,7 +392,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -418,14 +418,14 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e81f48ea4d801009ec6137531fe05412b31a0650b31aec9956a07fca30f7302d
-        checksum/config: 130ca94b1a1ec671088402c62597bf19488e6df6a17e831f1e172db6fc61045f
-        checksum/secret: b46447c8a1578eb3f75215a655a6f4fa21a910e5032e5264177b4ef206758645
+        checksum/plugins: 2bcd36f7878f9daa3ac48cef57f8c4f60227792177cc7e848ef56e4a17ca8501
+        checksum/config: c4ca768a7f6cbce670a92303952ea85786fc84d69b0ac67771d303c1ae6adb33
+        checksum/secret: c4675e5d962dd12dcaf13a0e01e38575db824eb40fd71a4715952968acdfb6b7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-configmap.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -467,7 +467,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -495,7 +495,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -523,7 +523,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -820,7 +820,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -829,7 +829,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -858,15 +858,15 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 411a533eb82cbc08415dbf7e73e5964c49da6dede20ec802de64a29f204bad27
-        checksum/init-fs: 6fe9767bc8524af5283e066dc4be539ed93405e6f33a4f48908b9d851e887a82
-        checksum/config: 130ca94b1a1ec671088402c62597bf19488e6df6a17e831f1e172db6fc61045f
-        checksum/secret: b46447c8a1578eb3f75215a655a6f4fa21a910e5032e5264177b4ef206758645
+        checksum/init-sysctl: 29b9b4708c72f6793baea4c6072c483a8557d8307d6f18538b8a930164687722
+        checksum/init-fs: d313fabb91bffab78d8ce914f5535b1ee4344e217ac17d37f274f9fb65c3d310
+        checksum/config: c4ca768a7f6cbce670a92303952ea85786fc84d69b0ac67771d303c1ae6adb33
+        checksum/secret: c4675e5d962dd12dcaf13a0e01e38575db824eb40fd71a4715952968acdfb6b7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -881,7 +881,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -905,7 +905,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -946,7 +946,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1088,14 +1088,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -148,7 +148,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -323,7 +323,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -349,7 +349,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -376,7 +376,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -385,7 +385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -402,14 +402,14 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 88034d25257df5c8bea3e7e40e3a9651e330462326106388b75609d2888fbb84
-        checksum/config: 3ce3903a397af26f6e7f8799122be5e7db46b0441157ee710072013dfa51b631
-        checksum/secret: 6765d53dc2462169dc1def596af5d193631075a9aa5d5e46cb93e07c8e3f3ab2
+        checksum/plugins: 094a0f918d8f514f9a0ea47628c1b4b2c0b938493e0ce1f04aafe0e371f40ad3
+        checksum/config: 912383795e134b103c45e3d0f6d40402878743061619445f01507f6e644d886f
+        checksum/secret: 0936c09e8a5d97bc44cf4818b1a5ec5f8a063e8a0baf6e487ac0093a577974b5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -427,7 +427,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-secret.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -454,7 +454,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -482,7 +482,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -759,7 +759,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -768,7 +768,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -797,15 +797,15 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3fb8ae011b72997734723f880ed835acce5d9c21bb325f5282c1b6a7cd6a6da2
-        checksum/init-fs: 95ace96ab3eced916fe966ad6909b44c1231ef3b7222180af504043b963e81c9
-        checksum/config: 3ce3903a397af26f6e7f8799122be5e7db46b0441157ee710072013dfa51b631
-        checksum/secret: 6765d53dc2462169dc1def596af5d193631075a9aa5d5e46cb93e07c8e3f3ab2
+        checksum/init-sysctl: 57e8d5054b0b57f1c4e09dea370162919f7ae2c3c81f1505f6f54b7616be20e1
+        checksum/init-fs: 880bbee5f8a1269c6fde0bb3f7d38335f720a52e0fb416b7949842bf3d99fb4b
+        checksum/config: 912383795e134b103c45e3d0f6d40402878743061619445f01507f6e644d886f
+        checksum/secret: 0936c09e8a5d97bc44cf4818b1a5ec5f8a063e8a0baf6e487ac0093a577974b5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -820,7 +820,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -844,7 +844,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -885,7 +885,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1022,14 +1022,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -289,7 +289,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -311,7 +311,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -336,7 +336,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -362,7 +362,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -389,7 +389,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -415,14 +415,14 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 33a43d7eeead083ec464b3ee56af2f6960818b012fdf9525e81d5ef93886f21a
-        checksum/config: 8cedceb8ba476c2f929f751c0d54cb48a8fa18dc15e42f8a68b142671ddbfef5
-        checksum/secret: cd08a0c20b0f1d711fe5dc89c0bde67ae211ada2e4354b9b5ef5f3387344749c
+        checksum/plugins: 14d2a167307c76204296a85c87e8f762fada6bb178579fc6cf65bf0db5e47ad0
+        checksum/config: 88b72dd4e6c450b0662210debbd6142da24fea23a1e9c2f56b8b5fbd6a7a2ee3
+        checksum/secret: 10c759b5e35069684b1ac28033788910562b0f2b2408e466d47c448a1681b156
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -471,7 +471,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -745,7 +745,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -754,7 +754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -783,15 +783,15 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 99884dfc3326ea044680eb777947a51fe7b1ea1f7f2fa4cb4d00c70c51b370fa
-        checksum/init-fs: e7ef1eeadae2a1cdf26488029cf4687c20df083d58777aa70295a9f85841922a
-        checksum/config: 8cedceb8ba476c2f929f751c0d54cb48a8fa18dc15e42f8a68b142671ddbfef5
-        checksum/secret: cd08a0c20b0f1d711fe5dc89c0bde67ae211ada2e4354b9b5ef5f3387344749c
+        checksum/init-sysctl: 177df9c9ab446133192469dad5bbd000efca5b10657f7340d4aca3b26a2ef7af
+        checksum/init-fs: fe1af0fbd79564d954af224c204e758cb968a6e7d5ebe128baffe283f639720a
+        checksum/config: 88b72dd4e6c450b0662210debbd6142da24fea23a1e9c2f56b8b5fbd6a7a2ee3
+        checksum/secret: 10c759b5e35069684b1ac28033788910562b0f2b2408e466d47c448a1681b156
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -806,7 +806,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -847,7 +847,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -984,14 +984,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1023,7 +1023,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.7"
+    helm.sh/chart: "sonarqube-dce-2025.4.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -281,7 +281,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 
@@ -303,7 +303,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 
@@ -328,7 +328,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 
@@ -354,7 +354,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 
@@ -381,7 +381,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -407,14 +407,14 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 81e32c6b7ddded1e8b0b763da139baf2281c094bb7de29ce7ab173b4cb6b23d4
-        checksum/config: 311cc7fed06976196a68558610cba2063057e5e322cdf22c5856761a579c75ef
-        checksum/secret: 6455d22ab91a87db3b74688480db2a71dbf41eccf64a994dd00089de61717512
+        checksum/plugins: 0db8d4ea10f499834ad52ab2aabea6919b7b8e9fac957b7abcd26b7cbc662823
+        checksum/config: 0cce2ffcc276b470859b65a3b39b503b6a75b47ab370faa128bb0702868105ed
+        checksum/secret: 62d19bacd0f412cf37430c5ce8fc793866c63b2ba6f35d11f222f96c5810bbc7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -471,7 +471,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -499,7 +499,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -798,7 +798,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -836,15 +836,15 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b4915a51da32207c8b583375eedde7290a9624a2775fe61aa7bcafb269915734
-        checksum/init-fs: 1935120495ac375c4fb4e23a637827aee0f5bb62e891582f0a8d919efc728311
-        checksum/config: 311cc7fed06976196a68558610cba2063057e5e322cdf22c5856761a579c75ef
-        checksum/secret: 6455d22ab91a87db3b74688480db2a71dbf41eccf64a994dd00089de61717512
+        checksum/init-sysctl: 81af4c375129b393c92b2c1c9ea10b6eea342ea3199c618100b5cffd2b1b75c6
+        checksum/init-fs: 8da6e17082fc047ba95dfb250b9c0227e242a551fd5f880ad84f9b61ef350c7d
+        checksum/config: 0cce2ffcc276b470859b65a3b39b503b6a75b47ab370faa128bb0702868105ed
+        checksum/secret: 62d19bacd0f412cf37430c5ce8fc793866c63b2ba6f35d11f222f96c5810bbc7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -859,7 +859,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -895,7 +895,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -936,7 +936,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1094,14 +1094,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -401,9 +401,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 263d2f13dd366a22f32385a8f840b1f9fd89da4796fa12d82745534de6c204b4
-        checksum/config: 50cc7ef8ea3348a6676357bfb11595c711a286b7f858bd6e693f1bcb3fddd99a
-        checksum/secret: 7a89ddde3ac52bba7ac690f39e23db2437814857736a355694ddeb8b662cd7a1
+        checksum/plugins: 261793d6641722d22a9f8386c821c295913d828b59ba61617bd922e84bec444c
+        checksum/config: 5fbc8f1bbdae734b4f2a084824ba735ceb7222be6182dad5ca2d225a666d1d3a
+        checksum/secret: 49d024ebd1e2ae20e3d3cb95a8aec284c68b803e0544445eb5521bde6458071e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -769,10 +769,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: dee064597f4505f3111ba0a61be4d1db61b15421aa061fcc6c589258b4f75bd3
-        checksum/init-fs: 833d9da4c8ce2d568417695005cb3d88ed7f29beeb1b45bf5d631af7df67e83d
-        checksum/config: 50cc7ef8ea3348a6676357bfb11595c711a286b7f858bd6e693f1bcb3fddd99a
-        checksum/secret: 7a89ddde3ac52bba7ac690f39e23db2437814857736a355694ddeb8b662cd7a1
+        checksum/init-sysctl: 5989e96ca6089203bbf8482c38dd9031f24e667d7d780b147798d4fe48b26728
+        checksum/init-fs: f2c7d1f4dd781eb3ad19da67fc22ea77f33ab648dc865f4a9d95a730fb9b8041
+        checksum/config: 5fbc8f1bbdae734b4f2a084824ba735ceb7222be6182dad5ca2d225a666d1d3a
+        checksum/secret: 49d024ebd1e2ae20e3d3cb95a8aec284c68b803e0544445eb5521bde6458071e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -970,7 +970,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 1095e5c0abc879c3c796c61fff001980b18edf4dd95fdb2ca6bf3e695a1789ed
-        checksum/config: 3590ff241589d9d32888bd5e476beaa345c368575136676dcdb238a2a51153ab
-        checksum/secret: 58076bc557bf33099590c1fbb3906bb6ac791ace5ccebe48ab225a1b4f64b807
+        checksum/plugins: 2f332679f2e540e11be69ebb496b65cce99a36099f8801377f7092a4c3ef5e3d
+        checksum/config: 2d38a82c1d7db3d2e1b111d12e6f2ab3124b3aa56647f1029acceef1edfad37b
+        checksum/secret: a7e8e354180ddcd316223e6e193c9d70df40f30f3680a367dce91bc800ade468
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2d76b7bb982356b24289cdec81edd6d33f750b585fe82779962f22451af91370
-        checksum/init-fs: 1badacb250c55614ed6dec43094f2d538016d1798d1d72ea8f40d7be78360987
-        checksum/config: 3590ff241589d9d32888bd5e476beaa345c368575136676dcdb238a2a51153ab
-        checksum/secret: 58076bc557bf33099590c1fbb3906bb6ac791ace5ccebe48ab225a1b4f64b807
+        checksum/init-sysctl: 982d70ea7095b9b78fc27fc85b6861a6c8d63ee75167b8718c12612514089c8b
+        checksum/init-fs: 0606c3a4659c1dc01bd8c22e904c52afe95762f84800eec64dc3be56b842cdb3
+        checksum/config: 2d38a82c1d7db3d2e1b111d12e6f2ab3124b3aa56647f1029acceef1edfad37b
+        checksum/secret: a7e8e354180ddcd316223e6e193c9d70df40f30f3680a367dce91bc800ade468
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -970,14 +970,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 75f64d741763f7c6e6cd1da2a377ee7124af937a5ade08aeecebe5b738084a58
-        checksum/config: 5761d4af3b8a31bc2f3609e9d51948bc2f552f83eabcf13762b8c754a02010a7
-        checksum/secret: 4dfeac8693d716e39b8eca510c1efd48f77d581100cd43e6c21b8de39b75d79a
+        checksum/plugins: 6e6da65aedcfda10ed780c798382b8abb7435bd7ad54daa74f7b00fa958e3424
+        checksum/config: 903031305231309db1e9d55c9f9448a347e0db8095eb3fd96215396f3750a39c
+        checksum/secret: eba4e13ec8bd61b19e01c8581555307fd1bc22d40afcc3d0e40d1fea7b6b57fb
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 5b8397b72d99a2cd1f521738d139f635b64f2cbc63ce2de00fb70403e98631d1
-        checksum/init-fs: 459a20cae2f9032a7193380728d66d80189fa55971da4a128906d3e4393d4879
-        checksum/config: 5761d4af3b8a31bc2f3609e9d51948bc2f552f83eabcf13762b8c754a02010a7
-        checksum/secret: 4dfeac8693d716e39b8eca510c1efd48f77d581100cd43e6c21b8de39b75d79a
+        checksum/init-sysctl: 9afc7bdd3ce0372885299d93b475c713acf76b69115791de5a9779353e8680ef
+        checksum/init-fs: 8e127e3995baf97c9808f0ca284caf7681269c03350cd5b296cc26266f2d627a
+        checksum/config: 903031305231309db1e9d55c9f9448a347e0db8095eb3fd96215396f3750a39c
+        checksum/secret: eba4e13ec8bd61b19e01c8581555307fd1bc22d40afcc3d0e40d1fea7b6b57fb
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -970,14 +970,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: deprecation-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b433cded2e82274a7e1c64fdce0ec4b144dceca384a7ffeb30130183e6981eb2
-        checksum/config: 6bdc3cc934821b136c2e45fef7ee3c5336c7c218b2b32c57a5b2a260beadbef1
-        checksum/secret: df21eb2db994cbc26b35020892d98028d2df23705cb9348a1108b1d885c8ba4c
+        checksum/plugins: ac69ba220d47c02a457c473fc62b46cf6173b341e9f33cb9f7cea8cf95108ef7
+        checksum/config: 48d310adaf72e2f4192dde7b734a227e717ee9b767e3bd25147933e4854d4c00
+        checksum/secret: 92ffcb394337d7c60c516995898573a03d393a96aac561add42c62d47ef36625
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -462,7 +462,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -736,7 +736,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -745,7 +745,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -774,15 +774,15 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2379342f5e60184a3eca108e168f848a4540890186304ce2db515661e2bae9cb
-        checksum/init-fs: 2fa224cbdc26f0bd966666edcb3e21bd78f84fd264fa2e24ac6bfe254670ff05
-        checksum/config: 6bdc3cc934821b136c2e45fef7ee3c5336c7c218b2b32c57a5b2a260beadbef1
-        checksum/secret: df21eb2db994cbc26b35020892d98028d2df23705cb9348a1108b1d885c8ba4c
+        checksum/init-sysctl: 37b37cf40348b092ef9a5e931e56ecbe2e8493ed145c7747b8461718d9a5f42c
+        checksum/init-fs: 3a9fe6397184e64c72a0b723d97b22fc7687d10fd06427ff66464ebebe6af4f6
+        checksum/config: 48d310adaf72e2f4192dde7b734a227e717ee9b767e3bd25147933e4854d4c00
+        checksum/secret: 92ffcb394337d7c60c516995898573a03d393a96aac561add42c62d47ef36625
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -797,7 +797,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -838,7 +838,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -975,14 +975,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d496119da1e38d90993d9858252f557f2acffd7432f4432f43e312ed023588ef
-        checksum/config: faa43ef7f9f2647b0b22a6797c241044c0e17745f29f7ab2a7109198ecd4061e
-        checksum/secret: 874efe07909b05631c7beb1bd3cbd7ad03f95e45fe339f26dbf06717351988b1
+        checksum/plugins: f18ea124f4bbe84bbff49346a46f11027c41629fa9849a1e47b1c780e70d8a59
+        checksum/config: 54ea64a84d4d4fc0defb2e4c35596ac06d49ccf3f2b07ed9864d5cc6384d0a84
+        checksum/secret: 02005abc59682c7ed471ecac7716c4ff1790663125c0bfd25013cc35f91e03bf
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -735,7 +735,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -744,7 +744,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -773,15 +773,15 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d806baa4e4897185225a44ff13ede9a5acf3a5645dc24398d594029084c69b7a
-        checksum/init-fs: 65e83b3c5475ec09ffdca01218b5abcb43f22ea58efabfd494007039f1211f72
-        checksum/config: faa43ef7f9f2647b0b22a6797c241044c0e17745f29f7ab2a7109198ecd4061e
-        checksum/secret: 874efe07909b05631c7beb1bd3cbd7ad03f95e45fe339f26dbf06717351988b1
+        checksum/init-sysctl: 69bc51dd6f54ddc4107992c9e7bcd107e42d34a2b97634d8df900a0284f88f55
+        checksum/init-fs: e8468946d674c08eac348fe024203a6fda298b66025cbc45ec64d13401f43b8c
+        checksum/config: 54ea64a84d4d4fc0defb2e4c35596ac06d49ccf3f2b07ed9864d5cc6384d0a84
+        checksum/secret: 02005abc59682c7ed471ecac7716c4ff1790663125c0bfd25013cc35f91e03bf
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -796,7 +796,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -837,7 +837,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -979,14 +979,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -400,14 +400,14 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: abb81f5d54a5398a9f8c9d891c9a5b9e6a3e405609d84dcb837f831e0d98dd82
-        checksum/config: 0f56ec09b40005688974debf695a4c5b0775a42c10f7f921d3ea7a78ebd11254
-        checksum/secret: b670aa63c9bda79684bd5b37dc6bc13da54b1f9d09743aa2604841a2c260e2de
+        checksum/plugins: 6a8d03ef02770b18e12f48ddac8a07ec24b084027e6c7180c03bd06946800982
+        checksum/config: 6cb8a13fe9fa2568b8531c15e3159c1d4c3376c5e88398b683a170a54912eec6
+        checksum/secret: 53ff07946bf71de626420e69ab25e6348253eec0d2090081a1dd5a05b6e56bba
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -428,7 +428,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -456,7 +456,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -765,7 +765,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -774,7 +774,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -803,15 +803,15 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 40bc8149120644563907a100e3902782731959ce7f733edf54de3102805036ed
-        checksum/init-fs: 890a94e10b851b8d122fb04822dd46a77b5a0f65ed0e126075eba320d8cbddd8
-        checksum/config: 0f56ec09b40005688974debf695a4c5b0775a42c10f7f921d3ea7a78ebd11254
-        checksum/secret: b670aa63c9bda79684bd5b37dc6bc13da54b1f9d09743aa2604841a2c260e2de
+        checksum/init-sysctl: 6f8c478c622dc34b66de31c174eb666a3871fbd778b3bcbf789f3d808dcfca37
+        checksum/init-fs: 3b10cda979da8bd30ae7a94d03c19e55bb1bdca00345814ace6fca0b1e094314
+        checksum/config: 6cb8a13fe9fa2568b8531c15e3159c1d4c3376c5e88398b683a170a54912eec6
+        checksum/secret: 53ff07946bf71de626420e69ab25e6348253eec0d2090081a1dd5a05b6e56bba
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -826,7 +826,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -867,7 +867,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1004,14 +1004,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: hpa-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e73ebd2bc4c6fa4e175c2ab32d4baeabb398fc06151fb0079680ca1e78f0ffa4
-        checksum/config: 66ac5b4d93e53499637a106abf47695419b1478ceddf60244785c2d9c12f9127
-        checksum/secret: 3202d3cf9baa8ff29775e6213d5a0734e42200ef2353748bb4328f986b2b5fed
+        checksum/plugins: 8f1f5b4da053474f0b94464933e6ccfb95bd52fd8fea11ec7711d9eeb863be6a
+        checksum/config: a58ee5d0e7ea43ce03abbc404b746d81a26c3310244573c49c70f598713cd753
+        checksum/secret: 040a4d7f5251333055214cf711b8cb0c05a5ce97cfb481af89732bed82537fe3
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 1c2539f6a17dedfefd16d8b6dfe5f48647ebec59561a5d3fe512f01d5a562e91
-        checksum/init-fs: b8a978f7f0f48fcd0cdb49bcd9134cb8b0a0708559392b89a73f2773bb434469
-        checksum/config: 66ac5b4d93e53499637a106abf47695419b1478ceddf60244785c2d9c12f9127
-        checksum/secret: 3202d3cf9baa8ff29775e6213d5a0734e42200ef2353748bb4328f986b2b5fed
+        checksum/init-sysctl: c92d07b37d79b4ae0653d6013b648b445d83d0c106be2eca0cd287b4d46c8805
+        checksum/init-fs: 1553da1d6bbcf6acf9749c23799605000d779f5bd3223fc676c300411c2138c8
+        checksum/config: a58ee5d0e7ea43ce03abbc404b746d81a26c3310244573c49c70f598713cd753
+        checksum/secret: 040a4d7f5251333055214cf711b8cb0c05a5ce97cfb481af89732bed82537fe3
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -966,7 +966,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -995,14 +995,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6f2e2e924a329e5fa9ddd6e5b5ea4741b50737696768dbb6c71efe63a19985a2
-        checksum/config: bc68e59dbfb2c4fcd87193786fcec3b70a843249bb76265a86bee38a0feb418c
-        checksum/secret: 588eac8cb0a5e3e9599895e2759d34fc9277241c58c07fcb0114ea140892b112
+        checksum/plugins: e06b08464db2df9cefbe5d5886ccade10a9251c5d7c16e994aa96ef4ccba4b0c
+        checksum/config: ae20469feacd558b8aaf8a6ed6c8746777eb5001eed45388134d2af6cbbbc008
+        checksum/secret: 5c2b97701df06d79601e0ac560b92778abc2c928539a2ecf93eb66b61c0acde2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e395883966e76fd4d46733f2461959105428e571d8c3d3e946cc31eb29881cfb
-        checksum/init-fs: f70d256cf95f7882fb92d6abf9038708e2e7a87e3c8b8b4130a1375c694c4995
-        checksum/config: bc68e59dbfb2c4fcd87193786fcec3b70a843249bb76265a86bee38a0feb418c
-        checksum/secret: 588eac8cb0a5e3e9599895e2759d34fc9277241c58c07fcb0114ea140892b112
+        checksum/init-sysctl: 839c3e42258ab4f82da01d2f9929c035fa265ec4ae1ffb394b8b8709177e027f
+        checksum/init-fs: f8b093c8cce4d6aa94869668e5dc6e89fa4da95ab62411aaa85e76a8c69036dc
+        checksum/config: ae20469feacd558b8aaf8a6ed6c8746777eb5001eed45388134d2af6cbbbc008
+        checksum/secret: 5c2b97701df06d79601e0ac560b92778abc2c928539a2ecf93eb66b61c0acde2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -966,7 +966,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -995,14 +995,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: dd879478f6272778f99b3aad9bbc077a364a12d0187456c67f4e8e30d56deacc
-        checksum/config: f149a2a5591e8afbcb55f71cf2bcbc9e3b292d7fbdc2babd32b572e6015adb09
-        checksum/secret: 6265f98857011310bee6d9512e08c06e9aba1b915e16f85791a150bb84f494ed
+        checksum/plugins: 47d1a8422dc121a84c60222c822020bd7b7b85a7374be82c6c4450e95da4d2e8
+        checksum/config: 88a4d3a282e61a5c76d2604423775b64a799ceeecbbd7e7534f070b3f588681a
+        checksum/secret: 2c74af3e2eda3e672933cae74c70e02deddf3718bbf2ac8ba05fa31137e03b9a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b7323861870ce1257aa2b3a818c9ce5284bcc907cc2bdf47a33d052a6e675129
-        checksum/init-fs: 0c5da838b8cb70f43be562f09b2ab1115df96c04686d94980ec1ca623402d26a
-        checksum/config: f149a2a5591e8afbcb55f71cf2bcbc9e3b292d7fbdc2babd32b572e6015adb09
-        checksum/secret: 6265f98857011310bee6d9512e08c06e9aba1b915e16f85791a150bb84f494ed
+        checksum/init-sysctl: 5b5c633748f9800af255fc33fe10e17d38bb5c514e07024a7f25606fe0dc8a02
+        checksum/init-fs: 4934ef26cc4aaeee9e33f85c1c02fb6310056a38b7521d4e7da26f07442d0dfd
+        checksum/config: 88a4d3a282e61a5c76d2604423775b64a799ceeecbbd7e7534f070b3f588681a
+        checksum/secret: 2c74af3e2eda3e672933cae74c70e02deddf3718bbf2ac8ba05fa31137e03b9a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -966,7 +966,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -1003,14 +1003,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -72,7 +72,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -87,7 +87,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -137,7 +137,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -163,7 +163,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -179,7 +179,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -226,7 +226,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -591,7 +591,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -613,7 +613,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -638,7 +638,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -664,7 +664,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -817,7 +817,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -826,7 +826,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -843,14 +843,14 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: eeafaa35df4da10d65c0cdda50646b4cee7aed53d3f8251063daf5d0c11f5be3
-        checksum/config: 61bb1381e31405a779b62db94c51026fbc6ff194977cc366c0eac1182b0e9262
-        checksum/secret: d9a23e7db9183a64f2eed2ef1563f02fc634d3450a633a7d278495eda157d250
+        checksum/plugins: 8623cdee6c97ab8730a08bc074c123d0fc1a1ae9b9502b9dc1584d0f5328dbb7
+        checksum/config: 8348c85236e426611e6fbbb256e4f46fb5eeac898e189d76083491e896c99bc4
+        checksum/secret: 43059e7efb98b930162de1c3ea42e459d95fee2aef9c9cf40601fea30db2b3e4
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -871,7 +871,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -899,7 +899,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -1173,7 +1173,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -1211,15 +1211,15 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: becad03ede95ff62d274801792d6505a05dfc0fb18664210973d25f4b210bece
-        checksum/init-fs: 2f88d71f62dbb35a093de15f0b69ec14f515c51608ec533b4cf94f96045e2c50
-        checksum/config: 61bb1381e31405a779b62db94c51026fbc6ff194977cc366c0eac1182b0e9262
-        checksum/secret: d9a23e7db9183a64f2eed2ef1563f02fc634d3450a633a7d278495eda157d250
+        checksum/init-sysctl: a9f74118b4c9c70392e050ee94028f427b843b5506ebde6908f18af326d285b1
+        checksum/init-fs: edf692cbd3009e7ef5527a3bddc7b751441f8f7db3b8860e75dd207be1b8680b
+        checksum/config: 8348c85236e426611e6fbbb256e4f46fb5eeac898e189d76083491e896c99bc4
+        checksum/secret: 43059e7efb98b930162de1c3ea42e459d95fee2aef9c9cf40601fea30db2b3e4
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -1234,7 +1234,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1275,7 +1275,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1424,7 +1424,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1626,14 +1626,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -325,7 +325,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -378,7 +378,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -387,7 +387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -404,14 +404,14 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 1cb8d94fb80170bf6f4c8f2dbbafb6ef7965b1ca370c210fe95a7c43fe8d6962
-        checksum/config: cccd8c0fbe86b81d970e77abf6d3481d9c190f190879f8409f6c5ccf682752be
-        checksum/secret: c192ceb4b2bb369a0caadec629845615614f19dc108a3ceb2d5e293cf88512b8
+        checksum/plugins: 68c25027e0e47d9e898d80e6d6df0d10476c27ad17bdf6e2112d50853ae4692b
+        checksum/config: 5dd8cd45592f50ab6c98e4991df81b0cf5cb197105befc8d88a289b2248c8203
+        checksum/secret: 25aa057bbed6abcf10a94d385d9f49b1c333b4a8afcbdea98d1e986e2fab4e2f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/install-plugins-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: install-plugins
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -473,7 +473,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -501,7 +501,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -778,7 +778,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -787,7 +787,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -816,15 +816,15 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 86755bd1fbf6994288ad176364b136a562db3559606ea5011ea678c37b46ad3e
-        checksum/init-fs: bea44aafbdb5541da73536a6093d910193775bd521d60f39aa5eb1ef8a3dae02
-        checksum/config: cccd8c0fbe86b81d970e77abf6d3481d9c190f190879f8409f6c5ccf682752be
-        checksum/secret: c192ceb4b2bb369a0caadec629845615614f19dc108a3ceb2d5e293cf88512b8
+        checksum/init-sysctl: 48af62982e07a33252aa1c6ac785551df62f88fa484edcd98dad003e50c50f94
+        checksum/init-fs: f67739847a67437fe6fadecb5b17bf34c4f94a3dc8c3085a37a73e4b4c7a1dc0
+        checksum/config: 5dd8cd45592f50ab6c98e4991df81b0cf5cb197105befc8d88a289b2248c8203
+        checksum/secret: 25aa057bbed6abcf10a94d385d9f49b1c333b4a8afcbdea98d1e986e2fab4e2f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -839,7 +839,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -880,7 +880,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1017,14 +1017,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0f0b1009468c284d74ed64c993b9855bb7ede32876a67d4d4d0fcebbc1850e10
-        checksum/config: e1c748b382cf6b50edc484d5a829894ae52765116d4027f3f617e13da296c659
-        checksum/secret: d2b9ccd34badcf9f13b4fa11157a17e1f2c2ee4d8f722a21c8ab8874db13eccc
+        checksum/plugins: e0c4a46b9785e8b4110edb38f3df1c89679081f0ce90de693119de7ae1c120ce
+        checksum/config: c76322938437c12d65c0d2f1e94e0b4571fa2c7fff8c780f6e55d94df674fe9a
+        checksum/secret: 28fa20dace13fdc9e821236b42476f3d75b52101ab109fbb1aadb3d6efa2f841
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -769,15 +769,15 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3cd0a71db3476a774e5c5d0fa229b6e8076f521e36dc35a1d15ec5e1c14bdb8b
-        checksum/init-fs: 91031b540104dc9ea261195be83f1a526a3748000d629da8808599406bb95ab0
-        checksum/config: e1c748b382cf6b50edc484d5a829894ae52765116d4027f3f617e13da296c659
-        checksum/secret: d2b9ccd34badcf9f13b4fa11157a17e1f2c2ee4d8f722a21c8ab8874db13eccc
+        checksum/init-sysctl: 5404fae811307c557d585020d598cad2f4adfb15d8f2edbf8e9a7ac489611566
+        checksum/init-fs: 62873c45d163c8e109a1b506f4f9eb3c76e06b96cc388ff7ce9ce11b9060a9d6
+        checksum/config: c76322938437c12d65c0d2f1e94e0b4571fa2c7fff8c780f6e55d94df674fe9a
+        checksum/secret: 28fa20dace13fdc9e821236b42476f3d75b52101ab109fbb1aadb3d6efa2f841
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -792,7 +792,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -833,7 +833,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -970,14 +970,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -67,7 +67,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-database
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -159,7 +159,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -199,7 +199,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -249,7 +249,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -264,7 +264,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -279,7 +279,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -298,7 +298,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -311,7 +311,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -324,7 +324,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -340,7 +340,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -387,7 +387,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -400,7 +400,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -468,7 +468,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -490,7 +490,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -515,7 +515,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -541,7 +541,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -568,7 +568,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -594,14 +594,14 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 34e279a688d2d7ee3cbb26a142bd880dd9a92176a34a12e500b72157cddbfb3e
-        checksum/config: 7bcc102cd389d4db3a5d77706a7a24c3ffb792f0e18f23632a62240ec6c025e2
-        checksum/secret: ad29619e2e324bc23a87e14fea2e01d1f72401c9ffc9ded189500271dae870b0
+        checksum/plugins: 703e2846f0e0455006fa34f9a7f90f5b8b669ffd1757bebce86e3ab91b4eb6e9
+        checksum/config: c3980b17dda7ae3f4a6a2d44b30eafc50070a0a2b6ca1c3a4d3fc3108a576820
+        checksum/secret: 53a2843b5f6079d0681f9e68ee0b2f4aff70765fcf850cd2a0ecc0cf1c8712b1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -622,7 +622,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -650,7 +650,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -924,7 +924,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -933,7 +933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -962,15 +962,15 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f802bb799c150830952441a7e40b12a84273c235a33f936ff11480ed5b055705
-        checksum/init-fs: 9235100dba0ddda43815087a7af1eb5400566d411932f88e8f4a3d149b517271
-        checksum/config: 7bcc102cd389d4db3a5d77706a7a24c3ffb792f0e18f23632a62240ec6c025e2
-        checksum/secret: ad29619e2e324bc23a87e14fea2e01d1f72401c9ffc9ded189500271dae870b0
+        checksum/init-sysctl: 7886cf9f6f1fdf31bea2c5b91cc5b4fc1eb956068d2eac336215e93529c72033
+        checksum/init-fs: 7b348f96b43f988dd8566bdde63419751158feda37fe6cf3173a0839a6d2180d
+        checksum/config: c3980b17dda7ae3f4a6a2d44b30eafc50070a0a2b6ca1c3a4d3fc3108a576820
+        checksum/secret: 53a2843b5f6079d0681f9e68ee0b2f4aff70765fcf850cd2a0ecc0cf1c8712b1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -985,7 +985,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1026,7 +1026,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1163,14 +1163,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -67,7 +67,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-database
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -159,7 +159,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -199,7 +199,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -249,7 +249,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -264,7 +264,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -279,7 +279,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -298,7 +298,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -311,7 +311,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -324,7 +324,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -340,7 +340,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -387,7 +387,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -400,7 +400,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -468,7 +468,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -490,7 +490,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -515,7 +515,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -541,7 +541,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -568,7 +568,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -594,14 +594,14 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 09754254503770830b7d3c0683d42e76dd1a3b8e58750b4e6260b8761d8b82a3
-        checksum/config: 792b41a9dea6536374250da50cd3e2ad7faf8994555c249c8b212b868b401df6
-        checksum/secret: f562e95fa5c018ecb60153d9e5b3efa35643b30dfe767b71bf8dd4f5b5ccb440
+        checksum/plugins: d2f7595cb52980cc45734d4257eebbda6ffabac4306ec1bc51435da64a35a772
+        checksum/config: ff97585f047ad54bb9b6ba87d560035e161dc8b0fc03038ea0efeed54b1503ba
+        checksum/secret: 1c68a4f167186b3e2e314dcc81c0a49cdbf031e14824cd65f0879ea961e4ce6d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -622,7 +622,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -650,7 +650,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -924,7 +924,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -933,7 +933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -962,15 +962,15 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 82013e5017d3f5f67dd0a0bc1474520435db7512c4338bf7f1df3bfce21e54ca
-        checksum/init-fs: 98cd276cd3938af14d047cffa9d3cf2fee2c90a56a377cdb7d34fb12270c73c4
-        checksum/config: 792b41a9dea6536374250da50cd3e2ad7faf8994555c249c8b212b868b401df6
-        checksum/secret: f562e95fa5c018ecb60153d9e5b3efa35643b30dfe767b71bf8dd4f5b5ccb440
+        checksum/init-sysctl: 286ec7dbd4da38b6846223d5e6cee3a803a9c8b6cc068ab7f27d326e7178661f
+        checksum/init-fs: 8236b487d370a72a48dfb4fa9f979df5e4238623fc8f40ef8c9487e6fd864a9e
+        checksum/config: ff97585f047ad54bb9b6ba87d560035e161dc8b0fc03038ea0efeed54b1503ba
+        checksum/secret: 1c68a4f167186b3e2e314dcc81c0a49cdbf031e14824cd65f0879ea961e4ce6d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -985,7 +985,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1026,7 +1026,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1163,14 +1163,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e7f7b59818dbc3f6a93e068d7f03adac732b08edac3f65799d0ff180a6cd98fa
-        checksum/config: 14a1b352242e899cf4ea9799d30c393dc4bb16c20874971ff85d2f88cc47d360
-        checksum/secret: e22288735e50c5a68c64efd49f5b31377f8a7777e6acf691047022a948a582f2
+        checksum/plugins: 44593815c90f5c6378538f2b1f9d5a0238382fc44deb45117609facbae59537d
+        checksum/config: ea5003f50bdbe0150728291b1178df52711f8b018de741bf1467ca5f0a2013c5
+        checksum/secret: d050ef9812c1246163196a0ea1becba502f1a2f25256ca45ae25d99b294869d2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -746,7 +746,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -784,15 +784,15 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 88e498badf8795d36dc8e42d1f3ac5e44163b0c7e3eb5fe69199653fd6520b35
-        checksum/init-fs: d7061ddc09d691dccbaa2896540802b27bfe515f52e916d339ef5705eb503f21
-        checksum/config: 14a1b352242e899cf4ea9799d30c393dc4bb16c20874971ff85d2f88cc47d360
-        checksum/secret: e22288735e50c5a68c64efd49f5b31377f8a7777e6acf691047022a948a582f2
+        checksum/init-sysctl: e24af1cb13191d963153f22a4a2e3d5ac8806314cf8b69624eeb5ec91281214a
+        checksum/init-fs: 42891afd85d33de016c9613070b4ec2ce97861f19b60d27ca478cc34373ede42
+        checksum/config: ea5003f50bdbe0150728291b1178df52711f8b018de741bf1467ca5f0a2013c5
+        checksum/secret: d050ef9812c1246163196a0ea1becba502f1a2f25256ca45ae25d99b294869d2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -807,7 +807,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -848,7 +848,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1000,14 +1000,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4c62337d61946257ada67b34b2ba6dbcb4238a2887e894e8cdc68d5ac312bffb
-        checksum/config: 703aafa84e935bf2727be7cad1e083702f4f09f3864cea97b258f8c00e057ca8
-        checksum/secret: f96ca53218b77594863b94db3d1263b96c681ba4d377e0494a8992c2e1ba1f4a
+        checksum/plugins: 7ceeb990843b3a9b80b12b08cae31dac861e07b4e880d04298ac84361e4a9438
+        checksum/config: 759340e4fe4f6b1ce1d5d6a6b4b1cb744d570c643a81755a8b0094061ad624e9
+        checksum/secret: a53f8f3011e57fc281f953cd18785f4d0b46dbf99f2cf101556521c8a1b8ee0c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -746,7 +746,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -784,15 +784,15 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 74a5403a86b8665d8cd512a8bc0583e5bb2480fc550968de28d8bf9ab43f9b75
-        checksum/init-fs: b8734a321d9d33a62a3fc2df656a10947c2f66b5ce948982b507bf2510a9c20c
-        checksum/config: 703aafa84e935bf2727be7cad1e083702f4f09f3864cea97b258f8c00e057ca8
-        checksum/secret: f96ca53218b77594863b94db3d1263b96c681ba4d377e0494a8992c2e1ba1f4a
+        checksum/init-sysctl: 2824699b6ce6dea9b105beff5833e2ecb7dfe3528f900879066ec36abbbe1281
+        checksum/init-fs: 08e6107b30ec4c0390e3a984124b0182feae8199a4ce50fef755880fa89ffb08
+        checksum/config: 759340e4fe4f6b1ce1d5d6a6b4b1cb744d570c643a81755a8b0094061ad624e9
+        checksum/secret: a53f8f3011e57fc281f953cd18785f4d0b46dbf99f2cf101556521c8a1b8ee0c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -807,7 +807,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -848,7 +848,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1000,14 +1000,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: node-topology-values.yml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -305,7 +305,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -352,7 +352,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -378,7 +378,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -405,7 +405,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -414,7 +414,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -431,16 +431,16 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 7e8c601842c9e1e7937fc218b4a1aa0995c2aa8786f418262899d4b9e48dd418
-        checksum/config: a7b518c532f088a30a56702d61f4afd6410581beeb03408dab3d5a678c6394ee
-        checksum/secret: f2d937fd99d24622a83d10167b0bcbd55cbbe082bec9be12093ad6eb6fa64a04
-        checksum/prometheus-config: c627a1ce9efa8aa201941c0ea36e879b6c5c6d04c54e044020baa096d53f3fd5
-        checksum/prometheus-ce-config: 1637010a2e93569d43e3b80fad27c83f44af44fa9f357fc291fd9cd8ff7ae080
+        checksum/plugins: 728d2053fce32f22242c29d9cb474988c94ed98287eabadb53b462654b13b7d2
+        checksum/config: 9f67a8fafcbe8e5551c7a64f4109474d52816dcfd5104560d6e16a1d4977b9d3
+        checksum/secret: 050826f8d5a99fb4fb00972205a099b4f88873ce2c8227af8e62ac8dd98a9376
+        checksum/prometheus-config: 1b200c5be12690c82afab3b9e39d66e4cc13b530174256e4d5a65c9c4768465e
+        checksum/prometheus-ce-config: d49da699204476856ae871d7f94edb879a5ddd40447e772d2b689798dec0e6d0
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -458,7 +458,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/prometheus-monitoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -533,7 +533,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -825,7 +825,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -834,7 +834,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -863,15 +863,15 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0d64c180d1f486bd1b24062cb76e82f1c04440497ac241968f1b6e02b0a5a377
-        checksum/init-fs: 2a0e0f107a16dbd9849d6a5ff5e0637b83461287df16906a420a1d8f1169b9b4
-        checksum/config: a7b518c532f088a30a56702d61f4afd6410581beeb03408dab3d5a678c6394ee
-        checksum/secret: f2d937fd99d24622a83d10167b0bcbd55cbbe082bec9be12093ad6eb6fa64a04
+        checksum/init-sysctl: 44f3ba190360b289c1e07e96b7debb27e0f2dc2b334592fc60f7c1359b973183
+        checksum/init-fs: 64ebb6221a8235512a6e82c3a17559990b1ecc58322eaa9620d784156d5b37bf
+        checksum/config: 9f67a8fafcbe8e5551c7a64f4109474d52816dcfd5104560d6e16a1d4977b9d3
+        checksum/secret: 050826f8d5a99fb4fb00972205a099b4f88873ce2c8227af8e62ac8dd98a9376
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -886,7 +886,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -927,7 +927,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1101,14 +1101,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -278,7 +278,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -325,7 +325,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -378,7 +378,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -387,7 +387,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -404,14 +404,14 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 123a46c1a844f9e6ed21ac1136d620374ca648c275b409c6e8b50bb7a47d81f7
-        checksum/config: c67ee686394af6d2759c8c2554584b6444c1859fd51bad2aa7efeb256f5a7faa
-        checksum/secret: 7a7a21c9edf162675b447c18d261343a36c483575d0dc32c940efce5c720ecf7
+        checksum/plugins: cdacbcb129fc2243470798e421ca8a7e7d7c340f42fb07d16e6c2934eb6a5a96
+        checksum/config: e045e77be5e718e8081116d6c8cc3f9a140e41eef55ec11ee93014512b5c9179
+        checksum/secret: 8934a0cbdca80775a863cebd7827716cc178b6dc51aa901c80c8b1c80f2d57ca
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-secret-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: install-plugins
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -473,7 +473,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -501,7 +501,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -778,7 +778,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -787,7 +787,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -816,15 +816,15 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 4723491d68120f17a85264f23cec694ae0f3af9fcf97552e5dba51f90d95db98
-        checksum/init-fs: bb914fca75a6780ea2facc4bfbe23cf4856cc616bf7c7a972a816eabc33e8e8a
-        checksum/config: c67ee686394af6d2759c8c2554584b6444c1859fd51bad2aa7efeb256f5a7faa
-        checksum/secret: 7a7a21c9edf162675b447c18d261343a36c483575d0dc32c940efce5c720ecf7
+        checksum/init-sysctl: 8036e044313742315635a96ff18389e398ba3f25307d934d15a1846913063026
+        checksum/init-fs: c527be839c68ea063e27f818a70f3bd086ed725793e8aa7aed215ee3285bf9f4
+        checksum/config: e045e77be5e718e8081116d6c8cc3f9a140e41eef55ec11ee93014512b5c9179
+        checksum/secret: 8934a0cbdca80775a863cebd7827716cc178b6dc51aa901c80c8b1c80f2d57ca
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -839,7 +839,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -880,7 +880,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1017,14 +1017,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -308,7 +308,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -330,7 +330,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -355,7 +355,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -381,7 +381,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 
@@ -408,7 +408,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -417,7 +417,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -434,16 +434,16 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a5ed079a5e48d23184e0cb9cf72258a2c4fb51b1fc7bae413b31e42493170d53
-        checksum/config: fc82393d7fa53f42b3ab798f05b5b85a42a8fcb7820cf4917d5c456ebfaac7fb
-        checksum/secret: ea9ea0b1d81100ac29e1e2617b2ff0cb0a87cf81d20903952d78ecee75a647a7
-        checksum/prometheus-config: 5aac469459b3093ec08829cdd2bb3639f2f03de45e7ca3573e0e1c21976fca2c
-        checksum/prometheus-ce-config: 4153f58de91c3084467e1868faad7745addd147790bdd18d4ce72574439e1380
+        checksum/plugins: 08979de80ad83acdc94c7df310ba1254d5002500b9232167385a2f208b67b375
+        checksum/config: 7872504122e270f3e267e3cde4981732d28e9bf8650308f74194577744783ecd
+        checksum/secret: dbb4855e95e8f7260be362a32826d5d0f8a183d06031422c87c48c76bb43ef8a
+        checksum/prometheus-config: 2f70f33fe1f0530ec92dced374e20a0a955ce61ab980300124b6ab14097ee46c
+        checksum/prometheus-ce-config: 64249edd8135a7538bc8a23e402f738ab7be3edcc0bd325332557ece4f986956
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -461,7 +461,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -499,7 +499,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -543,7 +543,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -577,7 +577,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -872,7 +872,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -881,7 +881,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -910,15 +910,15 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: ea90fe55981488b56b0c36291b896a515db88b77d6ccfdae69380ba64a4bca85
-        checksum/init-fs: 53779af6be8b70155640410d41e3959c034d20ce7333cdddf7ad1ee49d1fb13c
-        checksum/config: fc82393d7fa53f42b3ab798f05b5b85a42a8fcb7820cf4917d5c456ebfaac7fb
-        checksum/secret: ea9ea0b1d81100ac29e1e2617b2ff0cb0a87cf81d20903952d78ecee75a647a7
+        checksum/init-sysctl: 3392d7dff71be87a13daefbb558fffdbb111ed8f8c6f44dfef00c8e5d33f6852
+        checksum/init-fs: c7b01f9a0f6ed3dc2ded91c730850fdbc6452b291f25b15bfbfdeee312c9c25b
+        checksum/config: 7872504122e270f3e267e3cde4981732d28e9bf8650308f74194577744783ecd
+        checksum/secret: dbb4855e95e8f7260be362a32826d5d0f8a183d06031422c87c48c76bb43ef8a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -933,7 +933,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -974,7 +974,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1111,14 +1111,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -322,7 +322,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 
@@ -375,7 +375,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -384,7 +384,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -401,14 +401,14 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 7457a08f5c52a285aa549477d90f1eead201128079f4512db1e4c12a972c9354
-        checksum/config: e135ed5c17c00a1af0eba91bd423f47d82fb1c225bb9f91ff69044c70c6b5680
-        checksum/secret: 1b6bab9c07f09ee0b475b6fa3eb1ae6fd991170c0199f4ed613a435b4ad72a61
+        checksum/plugins: 765ddbfec8a2ad11c30a333c02491798731fac16e02816ac23c7e12cab008f6c
+        checksum/config: 9b82cd1742f4e73098b23f7b8238894e026b4813296f17478c1199c6332d5192
+        checksum/secret: 348f5f013ffe3983a8969d801902a16d75e027351ddfc7357552fc472d5dac70
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -457,7 +457,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -731,7 +731,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -740,7 +740,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -771,15 +771,15 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: db39d6f8844fb5369c676b504303ade76d218cc3da5244805ef4ac445d5f8594
-        checksum/init-fs: b493618a8bee8dbfc671a7fab4073fcf7f9317c3972eec998bd365a89a058b16
-        checksum/config: e135ed5c17c00a1af0eba91bd423f47d82fb1c225bb9f91ff69044c70c6b5680
-        checksum/secret: 1b6bab9c07f09ee0b475b6fa3eb1ae6fd991170c0199f4ed613a435b4ad72a61
+        checksum/init-sysctl: c163f1e67f04d824699133f09caefa22c4c3a12134444da2591f9bd657d1e2b1
+        checksum/init-fs: feb634dedc2c9c9a9e7bed65072f1b6f0a295a94a7dbc8846910c863792ad056
+        checksum/config: 9b82cd1742f4e73098b23f7b8238894e026b4813296f17478c1199c6332d5192
+        checksum/secret: 348f5f013ffe3983a8969d801902a16d75e027351ddfc7357552fc472d5dac70
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -794,7 +794,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -835,7 +835,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -972,14 +972,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -204,7 +204,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -230,7 +230,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -283,9 +283,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0a132376347eb38f79c606af421de30b0dc40d02c4e700cd0fafae7bb20f77bb
-        checksum/config: e376eeab20ac09ae1d6ce4cbc8d1676641a174b48fcc6bd505614a23dcb1da3e
-        checksum/secret: 039aa9013a9e8ca19f3eea7e4103c6f09580768d97e6f159ca81e8bcdaee99b6
+        checksum/plugins: 975f48436b2303a608b7496ec2e74552486dab19d952f3f180e5fd7ce06b45d8
+        checksum/config: df8dc9190827b87447cb92c1d07f18553c829849c473c32ff72f54332c6f0d4f
+        checksum/secret: 395d62b2353e3b67dad57b03ae90b5d03edb055d86067aa8bc281657547ffef4
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -355,7 +355,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -480,7 +480,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -518,8 +518,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: e376eeab20ac09ae1d6ce4cbc8d1676641a174b48fcc6bd505614a23dcb1da3e
-        checksum/secret: 039aa9013a9e8ca19f3eea7e4103c6f09580768d97e6f159ca81e8bcdaee99b6
+        checksum/config: df8dc9190827b87447cb92c1d07f18553c829849c473c32ff72f54332c6f0d4f
+        checksum/secret: 395d62b2353e3b67dad57b03ae90b5d03edb055d86067aa8bc281657547ffef4
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -692,7 +692,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 355a81346a584ffc69f393d8f2d4aded8c837c2bd12e7fe90f967208b7e2a50f
-        checksum/config: fc3f19df24e5ec642cd7ac65931ff166bd524cd517f228c99a83c5355554da3b
-        checksum/secret: b63a5fbefd779930ebb5a9602858659ede6bd6cb1fe1fa66d3680c34d30b60ec
+        checksum/plugins: b51a0cf9c22a31c28fc42ea50055ee1f571d9e52d00d38813818102385db8b70
+        checksum/config: 61d8073d02f4159ecddc0405e1e20c701b5e7ec95f32b1cff748f24b62f938fc
+        checksum/secret: 18a5369ac266d92a6e715d75867634801aa2668aac839f283917930db9ca56ae
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0df99b2e10081a79c53a0a5da0173e5afafa128b5da31f24d1806aedcf3e29af
-        checksum/init-fs: de1adbb830bd0bbd4cc6fd2c2d9af8c632d19a47a09d495e55c5d98dc41dae2c
-        checksum/config: fc3f19df24e5ec642cd7ac65931ff166bd524cd517f228c99a83c5355554da3b
-        checksum/secret: b63a5fbefd779930ebb5a9602858659ede6bd6cb1fe1fa66d3680c34d30b60ec
+        checksum/init-sysctl: 6b7953680f87e0747a83ec0423747bd9ae43d4125621e6fa01ae670636fd4128
+        checksum/init-fs: f72353e1fcb7ebebd7857d83ce93b3f0fb41e02bf5a5077346499a675773a6ce
+        checksum/config: 61d8073d02f4159ecddc0405e1e20c701b5e7ec95f32b1cff748f24b62f938fc
+        checksum/secret: 18a5369ac266d92a6e715d75867634801aa2668aac839f283917930db9ca56ae
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -787,7 +787,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.7"
+    helm.sh/chart: "sonarqube-dce-2025.4.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -86,7 +86,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -275,7 +275,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -304,7 +304,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -333,7 +333,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -362,7 +362,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -393,7 +393,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -419,14 +419,14 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4aea3f229823b6b5220505f7c9209ca5eb7679847c28a514856e0cc2c501bd53
-        checksum/config: da93a23bb71723cd93d5ff6e9faa9e25dd38cac84eeb154f1e7d4809e0e6551e
-        checksum/secret: 87acb1c0bfcc34c2b66ebbbda4ddb4b17d0732a45414a787baaef41214720639
+        checksum/plugins: b50b368c62aa60fc3634996061afc64c054ea884a1859f091c7922a0ac67fcf3
+        checksum/config: d1a1863581e5471f35779cee828cea46ba41c5585dfd259b0c38f3731ef1ac0b
+        checksum/secret: e828f9cfbd2b3a36d645aad61c4f40a7543cf76397d62367163cddd2b9cff489
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -447,7 +447,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -475,7 +475,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -749,7 +749,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -758,7 +758,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -787,15 +787,15 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 09b259c1d93001adda64e7b8d1c55537be38954943c73e6062aafcd9029bdc68
-        checksum/init-fs: 940faf486e9f17b9d437fa32ae36a47aa03c991fc5e883f9222e4f41d70cf383
-        checksum/config: da93a23bb71723cd93d5ff6e9faa9e25dd38cac84eeb154f1e7d4809e0e6551e
-        checksum/secret: 87acb1c0bfcc34c2b66ebbbda4ddb4b17d0732a45414a787baaef41214720639
+        checksum/init-sysctl: 49c3c5614ccc5c9a17fe2b24d2d45239b93d325c50cdfc7705690471bc748c37
+        checksum/init-fs: 7280ee133cb1b01262189a0b3fc51cde76d8bec0f66e584b4f810d4eabb8c754
+        checksum/config: d1a1863581e5471f35779cee828cea46ba41c5585dfd259b0c38f3731ef1ac0b
+        checksum/secret: e828f9cfbd2b3a36d645aad61c4f40a7543cf76397d62367163cddd2b9cff489
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -810,7 +810,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -851,7 +851,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -988,14 +988,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -65,7 +65,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -80,7 +80,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -95,7 +95,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -114,7 +114,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -140,7 +140,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -156,7 +156,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -203,7 +203,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -216,7 +216,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -284,7 +284,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -357,7 +357,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -384,7 +384,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -393,7 +393,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -410,14 +410,14 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e05b9e18c88e9b8a4794d1961aa6075a899f1cb8bbea01791e659d0c64121ae4
-        checksum/config: e442cb7abd8f3c4eaf6d60154a19763a079f08c964307d8b92e20b18172d38f3
-        checksum/secret: e594fd2c0792163661d6f5da0246b95339a057a61330ca141632d07efb3856d3
+        checksum/plugins: 83d35bbfa0559e3920642310fce9f1762488a48e7d16f7be0c645080ff07d5c1
+        checksum/config: ed69ee6bd7a26cfd48f8c750c4659684b67aea020158942a833110c3e72a039e
+        checksum/secret: 5264affbec755d5d183c4415320e1986beae54beb692ccbd1cdfbe95dab14c09
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -438,7 +438,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -466,7 +466,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -740,7 +740,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -749,7 +749,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -778,15 +778,15 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 351ca4a8ca9facd4b87834b98c3d77cfb0a421989134d1acb7689d49399f1ad8
-        checksum/init-fs: 61fdbcf89e53768e7932acfa5732a3d090f3c59b5e0997885de1413bd7701d6a
-        checksum/config: e442cb7abd8f3c4eaf6d60154a19763a079f08c964307d8b92e20b18172d38f3
-        checksum/secret: e594fd2c0792163661d6f5da0246b95339a057a61330ca141632d07efb3856d3
+        checksum/init-sysctl: e3fc993cf118ac17b9029d3fcd4147868865fa6b7cc20c40fa08b81b8acaebc4
+        checksum/init-fs: 88c6305183305d28ec087d8297bf7b0319a16de42f95e77efd4446c6a12417cd
+        checksum/config: ed69ee6bd7a26cfd48f8c750c4659684b67aea020158942a833110c3e72a039e
+        checksum/secret: 5264affbec755d5d183c4415320e1986beae54beb692ccbd1cdfbe95dab14c09
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -801,7 +801,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -842,7 +842,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -979,14 +979,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -209,7 +209,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -222,7 +222,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -290,7 +290,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -312,7 +312,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -337,7 +337,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -363,7 +363,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -390,7 +390,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -416,14 +416,14 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 812a42ee51fad7fb5b918c3d221de6d8727be80d7ce54e7469e2123ff80ede8c
-        checksum/config: 71d71b29db0b6c073d8cef3f3a3c739aff277233981d49bfb4102c1c7807fedf
-        checksum/secret: 4b010797b3adc968dc618d688213e75e7601c0fbe408e5d13b1dd1b30c3f77e0
+        checksum/plugins: fc0237756f82b53bdb9360d1b916ad04aeb5ded9337f019acdb56333735c0fa3
+        checksum/config: 5405a9df5d8c1ead4ae0188a3b66d5acb8de35d52baa7587948f768ad2d74729
+        checksum/secret: 44089cf048a7ff873787827b477aa664861c038ef4e904e8dae153e7a9b0756b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -441,7 +441,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: concat-properties
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -480,7 +480,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -508,7 +508,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -794,7 +794,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -803,7 +803,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -832,15 +832,15 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0e0d4277ae8e0eb7415fa21b1176c5bd31de12cae166a58234529495a1d241ed
-        checksum/init-fs: a5ae3dfebbfaaec3386e047b66a74fbd0dc4d2738b359e60e50ffb551f61371c
-        checksum/config: 71d71b29db0b6c073d8cef3f3a3c739aff277233981d49bfb4102c1c7807fedf
-        checksum/secret: 4b010797b3adc968dc618d688213e75e7601c0fbe408e5d13b1dd1b30c3f77e0
+        checksum/init-sysctl: eb14b48971c675155a9c22cca1e23f9f277fac79a9e188e15c9d5e8ac80dc8be
+        checksum/init-fs: c5f01e13a85c86996c740ed365bdd23fd97cadfb4f00ec13023d171e9d20934f
+        checksum/config: 5405a9df5d8c1ead4ae0188a3b66d5acb8de35d52baa7587948f768ad2d74729
+        checksum/secret: 44089cf048a7ff873787827b477aa664861c038ef4e904e8dae153e7a9b0756b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -855,7 +855,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -896,7 +896,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1029,7 +1029,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -1056,14 +1056,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1095,7 +1095,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.7"
+    helm.sh/chart: "sonarqube-dce-2025.4.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -1115,7 +1115,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2025.4.7-datacenter-app
+        image: sonarqube:2025.4.8-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -85,7 +85,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -100,7 +100,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -119,7 +119,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -289,7 +289,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -311,7 +311,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -336,7 +336,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -362,7 +362,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -389,7 +389,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-app"
+    app.kubernetes.io/version: "2025.4.8-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -415,14 +415,14 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9b3fa2f8430b6fa189b02fd30a67aaf28669d3638a4331c92e6cebac78d388b6
-        checksum/config: 601ce2567e1789e1606600e6f548ce2c4f97cc80ce2be6af5b045992872f98fa
-        checksum/secret: 85000bc13a49da2a6e6c3a92cba270241b45021117d773bafe8c4d0f6fbec5be
+        checksum/plugins: d470a30f446ff016931bd095e043a28d489445f6af379522ecda94077c21e5d9
+        checksum/config: e5a76d76b7fc895aa80fb1804eabb93a525ded7d73da82acde9999a5203057a7
+        checksum/secret: 2b3bd03d509dbf8721695d60d13a328347fa703603e2d95ba98252c92178d151
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -471,7 +471,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -745,7 +745,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -754,7 +754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2025.4.7-datacenter-search"
+    app.kubernetes.io/version: "2025.4.8-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -783,15 +783,15 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e1c85a61af2794d6c67e2f886a40c7925ed4524a14fd85621bb8ff39cf1c98bd
-        checksum/init-fs: 78c68e5b20a0a7aefeed2b22da5ad147244a5bbd5d9bd8ee657c2453f2bc8981
-        checksum/config: 601ce2567e1789e1606600e6f548ce2c4f97cc80ce2be6af5b045992872f98fa
-        checksum/secret: 85000bc13a49da2a6e6c3a92cba270241b45021117d773bafe8c4d0f6fbec5be
+        checksum/init-sysctl: 619db5fd339a1ead760d4cd6ef2eb4520026cb8cd601cbae10569970482e38ca
+        checksum/init-fs: 1fe015a8787797eda17f731560cc786f3b2b4f4d80987cf896d480955c03f896
+        checksum/config: e5a76d76b7fc895aa80fb1804eabb93a525ded7d73da82acde9999a5203057a7
+        checksum/secret: 2b3bd03d509dbf8721695d60d13a328347fa703603e2d95ba98252c92178d151
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -806,7 +806,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2025.4.7-datacenter-app
+          image: sonarqube:2025.4.8-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -847,7 +847,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2025.4.7-datacenter-search"
+          image: "sonarqube:2025.4.8-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -980,7 +980,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -1007,14 +1007,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2025.4.7
+    chart: sonarqube-dce-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-datacenter-app"
+      image: "sonarqube:2025.4.8-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1046,7 +1046,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2025.4.7"
+    helm.sh/chart: "sonarqube-dce-2025.4.8"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -1066,7 +1066,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2025.4.7-datacenter-app
+        image: sonarqube:2025.4.8-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -214,7 +214,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -396,7 +396,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -404,7 +404,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -416,10 +416,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ad64bbcfcd2cbece3d7e3d796662bd6d190ff23920e82451841cd45faf3a3b62
-        checksum/init-sysctl: bc2c475fabd7ba9f1aab5e75320dfd7c8303f213e6dbbe879c24dc7a65873a53
-        checksum/plugins: bca48ab3d37318b1697bc148abf572bf745e10b6eb665501cd31e77520cb01ef
-        checksum/secret: b033c36a68955b35785da7421733d66e8de67065af869fc0fb9a7b87fd0df73c
+        checksum/config: a3c89295f0de5544722b9c7fdd8e890264899dcf25ff8908f96f9e2c4976fb51
+        checksum/init-sysctl: ab5ddd3b1340778b616f5a7f9a44ff6c980be5c17b1e670cf07595fc4693f0e7
+        checksum/plugins: 2291330a857eccb288a00c8192ccff65ba1ebea66544338f93c7d39bc56494fc
+        checksum/secret: d5eeb3c60a6ca58e18aff94296a7b1e48969ac962dd1802f2ec862bbba2cf769
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -429,7 +429,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -445,7 +445,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-configmap.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -474,7 +474,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -492,7 +492,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -525,7 +525,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -542,7 +542,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -671,14 +671,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5b21efd927c83a87e5d45449d7f44d229dc1866bc0cb49b56aab54ca84e1e5e
-        checksum/init-sysctl: 035efc7037eda484cc564ac775b6d52dac4f4fe52743a1350d9e06cc1785aa8c
-        checksum/plugins: 1ee91d69fdaa9ad72f74a7f215cd3bb44af0398f2e8447e63169daf75644f060
-        checksum/secret: 490140d1ff30ee70defe42da4d70b880ba5b40d010165723cb2e3c3d66c6b181
+        checksum/config: b6f041b04f4c9c605218818f9a739a1d3d0602db589c1a65005cc342bc63843d
+        checksum/init-sysctl: 2c636aef3aa9f9c9aa9e60ecbb478b64c94976e9b7b8f08c83e11982a72e3383
+        checksum/plugins: d13969f793ab3ac4c9f052bcc7d3a544189b3ccc7d169ab4641f9e21ad374737
+        checksum/secret: b281f851daeb5282e5da1fb99c1855edbd153bcb3e279032e6fde3ec7d688b11
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ca-certificates-secret.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: ca-certs
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -477,7 +477,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -494,7 +494,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -606,14 +606,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8d1ce5f907427b8c28e0ae1ab1f89930dea28e893580a796f8e7aba300a2a366
-        checksum/init-sysctl: 1543214d403d76adb8d8a60d0d4bb23c4c5ce3ae8ddd6fffcf86586a9507cb4b
-        checksum/plugins: 8762ae8e0b7078b57aff7a7ec8592160ea34ca95bca90f3b2ab2a482a5797097
-        checksum/secret: b2fbc4d7bf7ef8fd9f9620385ea7a14f09307f52897c14104484af17f34fcc0e
+        checksum/config: 0151d6dda987aa5993d7e4d4ceec87f2c9a87b087c04f99eddea1eb2ede831f5
+        checksum/init-sysctl: 40162c8897cd335e189a5c1a6bfc1c267a66defc8fb3843d0fb46fc0bd012981
+        checksum/plugins: bdab68997ee663404dba62bb7f4cb045227e330ab50ea8b5ae629f30139045a4
+        checksum/secret: 586afb8191a7512162b46039b48a16a214cb86b833737c8808400244b8faa6f5
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/change-admin-password-hook-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -588,14 +588,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -625,7 +625,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -638,7 +638,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.7
+        chart: sonarqube-2025.4.8
         release: change-admin-password-hook-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ef22565fb4ef2f82547a1e1f9b02b53cec3e961bcea35833f10d3454602e1189
-        checksum/init-sysctl: f1fb4e5664f6b4627c7b18c1b67c6df494331ec403355fc0a5fbd5413cbeb685
-        checksum/plugins: 64e88dad04308e30a1d6fa0de8a3a8cde101437035d4e2b9e5da9ec99f32a9c5
-        checksum/secret: 5e59c614c53095fa81be2a1c5e9ef9a1a40468c0b2603e7f0d5e7b3a4d56a86d
+        checksum/config: 07213817e88356456402d57ef301c635f60f933ed0cf7c340a6866d932c4f33c
+        checksum/init-sysctl: 8f4e1e768d7be77078e353d8102d3d46d1c7cc51af3462cc505560f8bb663cfc
+        checksum/plugins: e55043c9fa85b4c836bb6d52972cdc338c1d8609bb2343c3cf57e9e1bff7fe62
+        checksum/secret: 56e34dca3ef488edcdaad3ced8cceb510cea9ac1cc670d95a01ecfa042509322
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,7 +574,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -74,7 +74,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -121,7 +121,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 data:
@@ -202,7 +202,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -384,7 +384,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -392,7 +392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -404,10 +404,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 361173a9b3bc608c7d8c68443e4058ec9e066d92c342cd843dbf44bac74f65d5
-        checksum/init-sysctl: 3b64ea1a53714b8b159e36854a9fa1adbbac3e79f73e00b70be4ba7ea320faea
-        checksum/plugins: 2b3c8b0d90dbb1db09a4e09337963c30b57ff2abba2e62de9da26cc42c681659
-        checksum/secret: 6d04ec676ec2676152bdea0d1b9e7a922372f3c47ce4876ed8f505b33a21c868
+        checksum/config: 349fd98c7c328f6a1204d5f2d45d3048e48f5b67da1219efa0ea230507b8ec34
+        checksum/init-sysctl: e3dc9f6bfd48e8d6ae8f5886a565cdceb6cc2e0d7d7e243dc1657aaefa4f82e7
+        checksum/plugins: caa48063aa5ebce90b315270adbc6b434dd81d89fdd92ae339006bae1f4dc46d
+        checksum/secret: 934f3b3e1f866ab577be601c00457699c212be07c1bd04797e73378a2b42d84c
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -417,7 +417,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -433,7 +433,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -451,7 +451,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -496,7 +496,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -513,7 +513,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -652,14 +652,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2ccae4a12f83c4f1a505baae2a2fcecd6e9f20ea2c1bbddf24e029efe74239c6
-        checksum/init-sysctl: 55995fac294489031b26c78276387da8f943db40cd6dd6e7296d64b881cbd3d2
-        checksum/plugins: 1e1e384293084f8f8237d17fcb944bc32ca36815322ab667556ccfc6b41b155f
-        checksum/secret: 047cf065a65b7e1ff6462d998f72f3bf4788580e1bb8831072d1e7c46e752c46
+        checksum/config: acf985b22afd10120afe077301a3968bf100f082ccc95f59e82cdca1c5759dae
+        checksum/init-sysctl: e45cc95f54ec52922e355e9fbf4cdb6d035fad2d656d1b57d2d353fa20b84b11
+        checksum/plugins: 4c682b1a726da5a277f34b06d6c9e29c8539cf92a6829d22a0a4378cab7196cd
+        checksum/secret: 6bb821ab1f1ce7bb9cad662372d2aa0a6af06b0c6bde9ccfd2823d97c85e95fe
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,7 +574,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: default-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e7c402d01e7abeb5a9d582a6696a92439e5e03f7c4c912ac8f0b00e9f1666145
-        checksum/init-sysctl: c8e3dade53dc234f6f5bd6b3fe3862416a55afd37cfa18fb44ccb914893837d4
-        checksum/plugins: 6bdd69da931fe6b317feb550626ae9ea972ca62858e113bd010a37224945996a
-        checksum/secret: 2537a33c02560b6b3b483bfd6f7e15f4c9171ed7bf27900c54564de2e962a651
+        checksum/config: 2a24d10f0de7f2ba215c6a1648037fe0bd72742d43fe4d681fdacc75d4b3e5eb
+        checksum/init-sysctl: bf7cf6b169798ab83b171031d981a954562ddddf7503d6e0ec79d53f17cce008
+        checksum/plugins: 7aaef05ea539d9d6e7626a71529ee78154b0d6ad06e7207b522b66f47d20dd46
+        checksum/secret: db67d2116c25a896ad44c98a0e22077c92eb5e0a15a2d86b59e5a9c70a80592d
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/default-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,14 +574,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -219,7 +219,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -240,10 +240,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 740d832923e6240c26791bf5a3d67af2e58cbc4336e66e2e40444677086ac370
-        checksum/init-sysctl: b1f2b537a7a64fced9e5da9330184b6c3dcc8152421917cdeb7333ad66bfc2ac
-        checksum/plugins: 9609c92c0bb369c118efed4653e2a90d20ea7697434b7d048372e234b1d4fe46
-        checksum/secret: 0741ee59d658c64d811d06f56dd302d904b9ba1ab0c53294df9759c65ac24ab6
+        checksum/config: 1fdce79b2fd50149c99c36d41ae9367093230a63705cfcdc473aec73363b087c
+        checksum/init-sysctl: 78bc4c567791b487a55b6fbe53c08a7876783d6a536cdea625d1526cde2c11de
+        checksum/plugins: 372cb0d11b7e90f4de084060b0fd68e030567f89d968f17e862b3dfd854f279a
+        checksum/secret: 40ff9c0140160de23a16452f1acf8dea94e572d2a3bfc3330ad5edb9131d8995
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -253,7 +253,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -269,7 +269,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/deployment-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -288,7 +288,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -305,7 +305,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -575,14 +575,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: deployment-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -228,7 +228,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -410,7 +410,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -418,7 +418,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -430,12 +430,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 41d720cf77ee7288d4b0fb5c81caa59a2cf6cc08dac53bc32ff8c4bb70f66418
-        checksum/init-sysctl: dd75628f7f2a0d302c0a747251a6a83316e48fd8926ed7e295f741a5172806d5
-        checksum/plugins: a6c0917bf839adfabb3bd863eec2dc871706d9df360e72993259516f35d8b2bd
-        checksum/secret: fc8611e58af4da75706a720e8f666296e1b6d87dd450412e8f1289997f0c21a2
-        checksum/prometheus-config: 772e7c47b2a9d605df4e2877cba3e199ca7037cddee78233d3cede60784b1f55
-        checksum/prometheus-ce-config: e417055110772705b6d948bf554146fb17a119770f0e306114bbfbe727db2723
+        checksum/config: 021ef71d92442f42d92c1701eb5fea126b5f35d08161743ace8d9149ae20a2a2
+        checksum/init-sysctl: f1f421b615ec201a83fa17ab5028fbec223c428bbc5bc8f2bf22832616e32ea6
+        checksum/plugins: c09439d93bcbda057a56cc8a8ac75247634c3c3c427838079e660b56d83e2bc3
+        checksum/secret: 3f5970ff922033e08979f750482c6ad5e3d3b0e7e0aed7395a43b5465572d7a6
+        checksum/prometheus-config: f028175262f38cedcc0dafaaff812e571b9d379947dd9bbedf0e6a62076a5938
+        checksum/prometheus-ce-config: 87382ef38eb45167f12807608b5a2fbbcceca301d926820905c53a42a07e6876
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -445,7 +445,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -461,7 +461,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/duplicated-env-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -486,7 +486,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -536,7 +536,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -559,7 +559,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -693,14 +693,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -231,7 +231,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
     app.kubernetes.io/name: host-path-values.yaml
@@ -433,11 +433,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c1fbdd323f248af5f36a5aaca83457b26fd0f6690872e00ce28937e81fc18efd
-        checksum/init-fs: 15d322fe0b482cdd7dd5317b2ebec2776fbc169afdbbe683ff2548187dacb133
-        checksum/init-sysctl: d0adab53a061e898957a97960f7204512aeb7d77c0272eee28581f4ad3e0218c
-        checksum/plugins: 7c4584110adaa1c9c580fcad69c8c400d525f040db1d174cdd64cae82b787bb8
-        checksum/secret: 4c68af601e64b240db8c38ff1931d0184c1178a19a4cd8cb2992c6c34d8725f3
+        checksum/config: e0d4d254fd9e20066bf6c8b0e21e23c0329edc3c2911ff93a6ba3d2f296574b7
+        checksum/init-fs: b750968dff67dd9526fefbee0fb679ee6cea4bf368f60c9cc3b8c6084b25fe25
+        checksum/init-sysctl: 4747dc7258da24558417729d39f602761e1d2bd7246cdc9f4338f3b7a32dbe74
+        checksum/plugins: a472c62440b7310f437c621e1ffa93288c7fed595614a38ffd47f02efa8cc0bf
+        checksum/secret: dd038d7426323db9ed8519c792f2b7cec29771679adb6e56c13816bce7e23ad5
       labels:
         app: sonarqube
         release: host-path-values.yaml
@@ -533,7 +533,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -649,7 +649,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: host-path-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: db3e5cb04d0f67066f475163f075aab19bafd7b6af2f4c62eb2da857885f3193
-        checksum/init-sysctl: 4991ed46c30bc2a0fd9f36b48d4e00b1d6a3a793182c902d6e12434fe7728ef2
-        checksum/plugins: d4b0a43f9b3777295b5a4318521a31f5db938004c5752836dbc9d4426fa40156
-        checksum/secret: baa37409426f86d916025bb931636f46445cf21a3a2cec027295cf6d4f258a83
+        checksum/config: ed703be000d8213f55e4ee9104a6002f4ca34eef12d266a274d9c9a1dfe6605a
+        checksum/init-sysctl: b9fbf876bf99f6f36f088fdcf1752955bb37b5fadf89452ef14213c0c7784e07
+        checksum/plugins: caac57ebebf6138caf8c7c107d2686baad3201b6148b4e3faf7c69e7c52ef50f
+        checksum/secret: 071da479b8b33ed14fc71979733c1c54294050fb24799b1e9566ac8b1034998f
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/http-routes-default-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -599,14 +599,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c59b073e091fb142e8d7c19a5eb8725d6cd707c8ce4a1354770a0490eb77fa58
-        checksum/init-sysctl: ea02a58f2b6fcce2ba762638417ae5ff43924ed3f5af6a19ee45d69019fcd61a
-        checksum/plugins: 241904e580826c00cdad0fd3c82b357bb60e8e08d60fec03401638aab6c2f7ab
-        checksum/secret: 367538c3f4301b7366ae8ccae702f2e0b61259c6ef5186dd7f934653b1ad86e2
+        checksum/config: c105cf75e38d524e6c219194479edfd59970d051993c0d3ff02e58c5aa7c107f
+        checksum/init-sysctl: 3f1f5c038dd889547b492bae9b25d233d83ef7c56b13f02e09e67edf21c6b715
+        checksum/plugins: bdb66c48e5b84c72c3de5f585d16f58a2360c7e55c6f6c05b3c2773e25593cdd
+        checksum/secret: 6db8738e6cf5fc2fa85ec6574b86bff16262406da0ed218e7a08f849a97d1d4c
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/http-routes-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -599,14 +599,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d33c1a7a7b3c03cb89e7579d6b8676869ae27ae9d2055e2373a6bdba22db19a6
-        checksum/init-sysctl: 02f51cff6b5971ec80ad3497195829f11eb1f72a32a3bd8eb98e6ca2e2bdb1a0
-        checksum/plugins: 32864113c51fe83344eb7aa5df671568c64a61f31460590edda253d0f5ea0896
-        checksum/secret: f2e089ec56cc952b90da8bf567574a64ac55cd4cf87707a0cf7a948e15e9f16e
+        checksum/config: e59292e784723fe882709449996af13015937bf94146def1d3f2a635b0f657a3
+        checksum/init-sysctl: 4542f9cc42ae1c8e41ee839ed640a69d2c3f1aa9da9e4541642a7e6dbda0f410
+        checksum/plugins: ce206b41ad3e7a56f089ef27aa861951cb88df52706233fe64357a81fb917b0e
+        checksum/secret: 4c475cc206ad71f19711e8f6e492d5f9fdd9995b45193ef3d023a42350179abd
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ingress-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -570,7 +570,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -607,14 +607,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -39,7 +39,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -149,7 +149,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -514,7 +514,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -822,7 +822,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -830,7 +830,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -842,10 +842,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4e233b101e4a7b132211e2b3f1acfbd3bed93978e6747eb17c0c21a3a65222a3
-        checksum/init-sysctl: 9883debb421b83ea1cc8f4153d70d8684b26db4fa6a02d1dc877b423d42799f6
-        checksum/plugins: 78f91a1ced642ff29d7111a0f8ff0b644a775620f956f0236d3a0b1e89f1716c
-        checksum/secret: 2cb9399b713340a7cd747cfbea8758ad7c67368320a5f1ec2ffeebd89307ce3a
+        checksum/config: b9ae95dc029768532de59414b91f097166f1c5a005a4dad75e837bb29339d271
+        checksum/init-sysctl: 9f55760cc281e9980883b9df52b7d28ef0585dd1f0001380771cab72b1540791
+        checksum/plugins: d9d6143e761573d2575a30615750c1ee5c6ded3c7b33e1b98aa43ba275e110c9
+        checksum/secret: c4801ade218a416fc3f1dc3821df1b63ce917311b1d3ae264a49336a50fb534c
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -855,7 +855,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -871,7 +871,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/ingress-with-controller.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -890,7 +890,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -907,7 +907,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -1028,7 +1028,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1230,14 +1230,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -201,7 +201,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -383,7 +383,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -391,7 +391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -403,10 +403,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b78aba4b89250ba407310a3d205a9e119a10e9a16d14c90e2256f5316798e4fd
-        checksum/init-sysctl: 25ef500f0ff97d8d29dce37d5b808c5fc2815a13e92ee665e7a4f31dde85020f
-        checksum/plugins: 8c865355ee44f63e6aae92e128cbb3db2d5de8ff672d47d75666d017304a3b91
-        checksum/secret: 6615880f27f759d411087c1568257ecec3486462c58b7e4c6a0c6ccc03936ee6
+        checksum/config: abb1729e9188f97ad21997223e0b66f68fb4ae4b115af38e8827fe6823509a09
+        checksum/init-sysctl: 196aa8bc5aea8b0e60b2820e64ef680ec3d816353ef42d60b07e8ae4532b7523
+        checksum/plugins: 4fcccb618e77cbde7c0c8d82d1902211b4896db3f0adb005bc81b1347901af14
+        checksum/secret: 5d97e9be57e60f78dabdec1766bf85157577265057626b37fb09ea8b78d25220
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -416,7 +416,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/install-plugins-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -450,7 +450,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -494,7 +494,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -511,7 +511,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -626,14 +626,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 706a04a6c87e8f57af43b7206d1e9e662c1c8a55c5f9c33da8eae7e5d3a1816c
-        checksum/init-sysctl: 2713a28ca85faf86f96387c081616b640b1105e1cd6dcf86d0ae6e98016d33aa
-        checksum/plugins: 69ea6b905c704a74980e7ea3c6baded7c8f0d07dd95f9f7fcfe9045cd553f0fd
-        checksum/secret: 18e7c3031540270050baf125ed959652e52fb9c9f79aa4739ff302f40bff9183
+        checksum/config: 2a7ba226378334a61c5d0173f0d57ab861e2ce8f505670df74ad55c125a2b531
+        checksum/init-sysctl: d4c4f3c476f980c88eca9beb9bd3e33d7c67cac2f4130cb50a7b7e0f81dcee35
+        checksum/plugins: 4a6a1e6313a11800780e747014e54fd52326a712d4653aad0fbb471c9baac4f4
+        checksum/secret: 99032a035301c4688090c23c3b7f1a25751b1463b4602903fcb2b23ac094ab19
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/jdbc-config-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -574,14 +574,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-database
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -145,7 +145,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -160,7 +160,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -252,7 +252,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -320,7 +320,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -502,7 +502,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -510,7 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -522,10 +522,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 01160477170d1efd919e7d2bfdf28e7fe39ebde44f303655b3e37687dcc4a27f
-        checksum/init-sysctl: 6c0759aae9f11723a24756dea738b7143bde5ebf68ce5a8d98d34affad7ffb99
-        checksum/plugins: 35ad4a001d070a97d427e417c263eed867dc0d4443af06ecaed5b776baa5a336
-        checksum/secret: 230b63d2032ea9ff225f48f5030f41ceaf281d99389f98ab42a51a01b8968c5a
+        checksum/config: a6b338eca998416ed197ffc1ea61c8cc90e6ed9d964db35f73761aa1e8b82825
+        checksum/init-sysctl: f7040fa37ff979389fdcae226dd7969db50a1633d0699a02c97c7a4f30bd3352
+        checksum/plugins: 908808052dc11acc0bd22724d942cc89533716b3e263c88d69f888f105b38533
+        checksum/secret: 9287ee72c38774fd261c31407dc57b531f7a5ba48162103df8a1c2260786deec
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -535,7 +535,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -551,7 +551,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/networkpolicy-new-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -587,7 +587,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -696,14 +696,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-database
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -145,7 +145,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -160,7 +160,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -179,7 +179,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -239,7 +239,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -252,7 +252,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -320,7 +320,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -502,7 +502,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -510,7 +510,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -522,10 +522,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0b100c2c7f5b325d895b18380ffea270ce3e486ef25d97b0f614bb44254aa820
-        checksum/init-sysctl: c385692e3b833707440c29b3ebd3432a7fc7a0cc1577ff8aebc53f425c29ab49
-        checksum/plugins: a925b11d161430cbf8b977abf22dd9a2e4e9f40c68b34704a3e2367d967369e1
-        checksum/secret: b7ee86f5d5f46a258c4de5f0aaefb9ee3ffb595fd1387f42a907edee48d6767a
+        checksum/config: 6bedafef0eb3c2f612eec4b8029c98f075f41a4ccf5cf14ae3b51c97eadd54fe
+        checksum/init-sysctl: 9146608e0c77417d455c31b885f6a48e38c301e3bac5655ec511d25a8eb3c1d7
+        checksum/plugins: b9677a1502d85b7067819d08182a8e512eb51dd76f997632cc1c48f876781f13
+        checksum/secret: 7255c9701e8a9d24069c296ff17e796033d39da332b7add730e02c3319a796e6
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -535,7 +535,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -551,7 +551,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/networkpolicy-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -587,7 +587,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -696,14 +696,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -245,7 +245,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -427,7 +427,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -435,7 +435,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -447,12 +447,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 004f8223ec9cdad53b36a54841a3719c6a41b0faffd00c713bf73258168fe1bc
-        checksum/init-sysctl: 90e62916255a9c30b46da039c1c3e349d81237babf577e59c7c1d5622c1896ea
-        checksum/plugins: 36fe7ba95cd72fd58b3c7b655341b81f660b35f596b2e02b5ace5e421a09a700
-        checksum/secret: 71aaad325cf03bacd343f09c6bb6b0ccc127ed61d68c029a43e91add37dc6ec2
-        checksum/prometheus-config: 99b56534349126d3843f009c65d2121c7c78a261ec3bbf42a533f1e27fcee63f
-        checksum/prometheus-ce-config: 36f8e3412afb0bce086c87023ff7e48bbd0bfb8393f87ca8119e409d3fe17446
+        checksum/config: d7dab269989a425c6ca3e3035a4f14df88b70e7756c3ac646cf470898715e737
+        checksum/init-sysctl: 1d51809fe594360788f12ecd2f66a98120e202a25c408d7835d05c5a65abe3ba
+        checksum/plugins: eff9e55d392f3c56945b573e91b43aba0196e9d2b66910150e1d0e2137a8da43
+        checksum/secret: 8f5d0da01713249d08b41ff91122056f2accda572441399f3a8cafb7d815f0e2
+        checksum/prometheus-config: 32eb3887a78ea22081a45b124279716a9f0f9514ba9044a341b70f7d627e953f
+        checksum/prometheus-ce-config: b329e4e5d997abf52123097db80afc53a620e7183cee97ab864f592c95b2f4f6
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -462,7 +462,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -478,7 +478,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/non-default-security-context-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -496,7 +496,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -538,7 +538,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -582,7 +582,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -605,7 +605,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -738,14 +738,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -775,7 +775,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -788,7 +788,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.7
+        chart: sonarqube-2025.4.8
         release: non-default-security-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -83,7 +83,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -151,7 +151,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -333,7 +333,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -353,9 +353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e3733c0cee02a60e3207051c9c701b57984fd34e92393677fa10a5baf7ea6f83
-        checksum/plugins: a1beb6f674f548434f170ab0985ae4bd9611426da59901f4ef77982fe60d39e5
-        checksum/secret: f3f78da1e40c10ad7c2a7be67dc497d0127601a801d64c4daa1b3f2b78b1c98c
+        checksum/config: 5379183b06fa7d57e4bcaaa31ae89a179951ad9d70bd57f0a905d72cfce520c1
+        checksum/plugins: 932a11054b7c0cdfa07aa7abf9b948e8bb2bf6e62a385ce65be83f90b99c9d67
+        checksum/secret: a4343d6dabb6b06a62072403066b51af09a56538c866b2df761786b6bda20209
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -365,7 +365,7 @@ spec:
         {}
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -380,7 +380,7 @@ spec:
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/openshift-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -397,7 +397,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_JDBC_PASSWORD
@@ -496,7 +496,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -522,14 +522,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: openshift-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -380,7 +380,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -388,7 +388,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -400,10 +400,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2e56ef253452ef542cd83be02ed7a64771e50db97295c0cc303d062030b34a66
-        checksum/init-sysctl: 1074f090bec05f8f4913e8eaa5422398b4a74b969f7342bf23cf70cf8c010570
-        checksum/plugins: c44809e1997ce1f45a4f1c2bc9bf72b5ed9c9ee7a76c60d67937f44b99b54e42
-        checksum/secret: eb4134a38d9bff32ad89adccc0409acc0324e84eae995a6966d199c88cec2378
+        checksum/config: bb8a5b3a03a38a16a33583c5a7e01bc3e6315581cdb8c046101aaa9b2e8767d2
+        checksum/init-sysctl: 9234e86c65deb6b330edd8e7cfdd321e9d3cc17db152036cde206dd424fe2e3e
+        checksum/plugins: d7659621f08cb6137d985dc698c597fe6a355afb9bd08b06527893d81aeef14a
+        checksum/secret: 7e5a0d27d0b1201a3d9e598bdab160a493aeec8a6032e8c036e0b4e057cf1ae3
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -413,7 +413,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -429,7 +429,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/prometheus-monitoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -448,7 +448,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -465,7 +465,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -601,14 +601,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -201,7 +201,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -383,7 +383,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -391,7 +391,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -403,10 +403,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0171e8b43a516e79254efca7860b35f833dadbb5c6c9c7db2c5ed1cd0f3537d3
-        checksum/init-sysctl: ae9a6baf9216f753c59a220b405256ff6a3e17289a677b7f55c06b0b478d519b
-        checksum/plugins: c2689ec13b563bb62b1454900dec8278f02fb2c6e34f1ba037d9d95326e033df
-        checksum/secret: e0116efa8f5f3d4b24abd2576bb58a2f037b2d2ca233504c8fae9c9cd463bca3
+        checksum/config: 131223af8ef1b45e8ff941741c78da154e6846531f5cd7942b1f3c3522c41dbf
+        checksum/init-sysctl: 27acecca37f6053946e93862b028416fdc8bfeb21ff47615754891120de11d98
+        checksum/plugins: d49daa0b23ead43fc11f587fc6d53500f7ae4d81150b7b46078a6e51e0efa645
+        checksum/secret: a08b67df3925a04095a0584e7be2b49c5c2141bac2a5f94721d44c0616b3b667
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -416,7 +416,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -432,7 +432,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-secret-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -450,7 +450,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -494,7 +494,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -511,7 +511,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -626,14 +626,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -162,7 +162,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -231,7 +231,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -421,7 +421,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -433,12 +433,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7544e0956136c1ad117f6d5930779d024d2f71d8909a67c6db3f29d915ab5bf4
-        checksum/init-sysctl: e0c471ebf035b53692029042f57b7da2c6b4ba20804e69671c10d18b0e502c11
-        checksum/plugins: a97c5dece92d4c25ece80a2601b7c681714cedc2e744d9610e442a0a49b19e49
-        checksum/secret: b18633e1a52ee790ec399eb7f4c05f7090530419195cb170e00637457d5b5be2
-        checksum/prometheus-config: e36369c70fa1ea0a289270e086117a93c58e8f92d53882ca223a0f68268c6e70
-        checksum/prometheus-ce-config: 301cca8e1456f81fbe51c5d6600e26fd8f943cfe19b9a3519ce5029d60833fdd
+        checksum/config: 2f408f08c98dbbd396800eeba16774a743260d5e477cac87709e1551fc562e5a
+        checksum/init-sysctl: f104a87e7c239a3651ed0aef73c77be8d724bd23526ae8cb466876e172222168
+        checksum/plugins: f9ba7ff7d56a848aece8c5dfde4519ad25663e369357faf7702ba8c9895d4163
+        checksum/secret: ff24b6dd62e9420399087ca9250fc69f5f8fc345a36a7e506a77b11a3c8d1faa
+        checksum/prometheus-config: 348efc3f23db490dd446380337764fb4d647e8b131cc02dcd4dc7c82706273d7
+        checksum/prometheus-ce-config: 029547b525959185e147d76597a9bb021046be7d3cd9cebbc92ad372ec593f04
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -448,7 +448,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -464,7 +464,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/proxies-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -482,7 +482,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -524,7 +524,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -568,7 +568,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -591,7 +591,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -724,14 +724,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -233,7 +233,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -415,7 +415,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -423,7 +423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -435,11 +435,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e81a34a0bbd0833a79f5443e405262013642e3763310aceed245846df28b9f86
-        checksum/init-fs: dfb1aae90a5630230a0145ca41492bba6b75eb6e553b1c0bcceacac445cbaafc
-        checksum/init-sysctl: 6e050e7f33e8aa560fcd0b42343361cf2b91ab2dc21e9b0143db34cbb5e75d93
-        checksum/plugins: ee3eb0a9a234d6be76254473e578a95def8e4200d604fb2dda5cca95284ce20b
-        checksum/secret: 2c0ddb08b0d2ace2e84be760122b17ea4da3fd4e831861d51abd080bacce51f8
+        checksum/config: c9eac639d927013f1c31d57ef7cb6786fdd4eb67d06da68149452f8180f0f36d
+        checksum/init-fs: bb681cef3d118bf6e689638b99b7c688811aa173dd6cd44e3c1d0187adca02a8
+        checksum/init-sysctl: 608a454cb510f5d809cfddf69b161779c767b2fea9b1f49852f49066b972c553
+        checksum/plugins: 66478eb2f3f310395b9a896e455da7b331ece6b9e7df017c83d7c36ed6175167
+        checksum/secret: 177e1278d656a5059319337b5c89297e2aab0cae240d7a0ee30313f7df4da876
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -449,7 +449,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -465,7 +465,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/pvc-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -483,7 +483,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -518,7 +518,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -535,7 +535,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -650,14 +650,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -34,7 +34,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -49,7 +49,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -81,7 +81,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: secret-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -155,7 +155,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -176,7 +176,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -196,10 +196,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 722f42e09bf5df0f4b8afa2f9fdc55c88d896fa355b8993db4d9057aa275b9f3
-        checksum/init-sysctl: 634b86b2609d8e39c7784719f83eff812ba4561005c1458037119f2a644c2334
-        checksum/plugins: 29db22c35b35e67e27d31f7267a77bdbcc946d73399b713515f51c3b09374cf9
-        checksum/secret: 93eeb4b460d14436afa450d2c0f73bbe49e32c3ecb45b40c871a4ad06adf5b11
+        checksum/config: 513ced0e764e4cf07b194a98db47de81d747b50ba964296cb1e6004ca152ffe1
+        checksum/init-sysctl: 216e42df27fe902c42ee743c347413844b92da6ec5e071173c1eedea9525f503
+        checksum/plugins: 6bda6c7baf0fd81f2a9aeac93076d55bc07ab5a47e1e0096ca1d2458fb7d770f
+        checksum/secret: 82df6125933d3ed4d7a4eed018ec782516fa7c397e73928a8a77e32038006433
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -209,7 +209,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -228,7 +228,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -245,7 +245,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -354,14 +354,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -391,7 +391,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -404,7 +404,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.7
+        chart: sonarqube-2025.4.8
         release: secret-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: service-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
 data:
@@ -198,7 +198,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -387,7 +387,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -395,7 +395,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -407,10 +407,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8eeac47c9da8b9ef2c09f866d92b3dff6cc289c4eed2d0956f604c7303653f39
-        checksum/init-sysctl: 96ec3148b35cf380caa7b77e966c423f1a7930671f42fb0a58d971992f50fd89
-        checksum/plugins: 13bc4bb3f0cff72a9b5a15369305d4bc4182678f904fc76c7ca3295606edced3
-        checksum/secret: 3aab1441a5bbb94d9b269ea8d4b1740bd499414328b9d319ab809dab2966bb68
+        checksum/config: 3365a091f298cc2981394f90da088c036908b4c0028e3dd26f7a6fd74e7a13aa
+        checksum/init-sysctl: 07e6cf51d6d1c1c3a31ca5d59b91e06f3fa32d8489b3d0a66fe4612e64780420
+        checksum/plugins: 41e2807e81620a9be9653d3a3ae96818d47c23a5f599a3069d7d1ac34def79f1
+        checksum/secret: 019a3f26c1e06cc11d366bad49ed3ed32f3f63c12562b30268135b165dea2fd6
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -420,7 +420,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -436,7 +436,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/service-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -455,7 +455,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -472,7 +472,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -581,14 +581,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -37,7 +37,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: df8452d74bd2e5c4dd4e3c9eea63dd7665ddebe2d2e80eb2592c789a62680aa8
-        checksum/init-sysctl: 0080366cbf2c1221b2e17e75b8b84e0ed59f6210f9dae05a65cc2dec4bd22656
-        checksum/plugins: 5e1c212671ee26fd6387ece37414c73f66fb43a8def003366ff5b27310d168c8
-        checksum/secret: 547007bb80547e9a0b2c35d953935b0a2c0a7da695c5b6109389118c74a4de68
+        checksum/config: dd74552051174729592cb565732b952780ff8c1615c217d52490a2a4e0475daf
+        checksum/init-sysctl: 9094b3e4dea1c545133e1e947ae5db44e6e43f8bccd6f115bedbc6019db1ccfd
+        checksum/plugins: 73be391f4048cb522eb3aab3ab91a6715e4d6cb939ad4ed45cabcd9afbb809a2
+        checksum/secret: 09b3934a9a2271c01a7efec5c9b0dccd37f422cf7859d1ffdf215d08a068849e
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/serviceaccount-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -588,14 +588,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -241,7 +241,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -254,10 +254,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 98bbe708c327183d2b3b9166eb6b64a53a387ed034793520c94fc51c57ec486d
-        checksum/init-sysctl: a0b5ffbe4e8a34de1d666b67e3a636f4ceb347658d9a1c3daf0616a886e3bcf8
-        checksum/plugins: 746ac4e518eb54b21a1dc9045390da698fa5b2ffeb7b87e598bef1c89feadfbe
-        checksum/secret: 836b2faeb78526ad01882c91841a792dd02180343514da6858dee413fdd456b6
+        checksum/config: 42ae0f142ab0711c43cd55cc85cb16707dad0f41a12e888e29552589b8ad0a77
+        checksum/init-sysctl: 4687161a3d72da4e155efa95889727b9bd3058b7f8e2839a80d142b25c1a3353
+        checksum/plugins: 05e21e2e87cc0bd7093cb0a54995afad8b1859f583befe9365d7d2447c5c690b
+        checksum/secret: 7c57ae9bfa7c6cf868f0aa956bf34b73747b58b810613de2f75a70e4f62e99ae
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -267,7 +267,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -283,7 +283,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-deployment-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -302,7 +302,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -319,7 +319,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -585,7 +585,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -612,14 +612,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -649,7 +649,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -661,7 +661,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.7
+        chart: sonarqube-2025.4.8
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -672,7 +672,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.4.7-enterprise
+        image: sonarqube:2025.4.8-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 63ee0c5cbe10eae4317741a6065d65ca389f501d23618b5daa0277b01622195b
-        checksum/init-sysctl: e1b4d7b7baed853b0571fe378e65874fac383b47834426412a0f1c6790f130e6
-        checksum/plugins: e4918951471a8182b81a0f86ff414adac3ce4804c45f04c2849561f8a0d63ed8
-        checksum/secret: f7e7a92d7409b1974467621dd0bb5024803aa77c1a42ba3497a690d25b84490a
+        checksum/config: 52b600b0d3c4150f9148462b8e38b4f61f5b6330e1bfc8c8f3ceb2f6432448ec
+        checksum/init-sysctl: 2811376ece5f81f366d1bd267b608c7a94c70e047f86996bb7e76041adc0b298
+        checksum/plugins: caea2a14f32fc24d7727536499598247d7c1325e08d229cad5316f67da3aae08
+        checksum/secret: 291d38e3baa7b9e53fdf06b5d4c104c90cd0bc751195e7c2b5c22c09885c6b54
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-sts-deprecated-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -584,7 +584,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -611,14 +611,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -648,7 +648,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -660,7 +660,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.7
+        chart: sonarqube-2025.4.8
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -671,7 +671,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.4.7-enterprise
+        image: sonarqube:2025.4.8-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -37,7 +37,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -52,7 +52,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -71,7 +71,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -84,7 +84,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -212,7 +212,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -394,7 +394,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -402,7 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -414,10 +414,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d86bc13b5c9b36edf6b910f14cdb9e38f638ff78f8d899e62ca68ab85f140b23
-        checksum/init-sysctl: b86757d9ae01944d25de194622f4d4ff5bcab481e5c1319547b467a7cf7639f6
-        checksum/plugins: bbf07535ee03b40ea37b6517ceaad192fcc37463f2d57f03b37fa8c8511d640f
-        checksum/secret: 557990b9bfadf12a3ec6c7b32620824d08942e4e2900b9a5c99185751b15b6e2
+        checksum/config: 5ccfda732e8f17d187faa05c008e0294d79ee14a96a37ec222c5b934412dcc69
+        checksum/init-sysctl: 2a0ab9fb80a3032bd36c20e0a5181af1f21bdee3f0dac00b5e8ef815dee646f9
+        checksum/plugins: 30d569717b06d9f83b2950282e2471daa600cd2add76a94e2b52d3473b695f0c
+        checksum/secret: 7d805dc73157b0ba0cd825c37b3a3ee620fb3db0ff502993a3d4ff485cf18d2d
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -427,7 +427,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -443,7 +443,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/sonar-web-context-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -462,7 +462,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -479,7 +479,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -584,7 +584,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -611,14 +611,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -648,7 +648,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -660,7 +660,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2025.4.7
+        chart: sonarqube-2025.4.8
         release: sonar-web-context-values.yaml
         heritage: Helm
       annotations:
@@ -671,7 +671,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2025.4.7-enterprise
+        image: sonarqube:2025.4.8-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -23,7 +23,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -57,7 +57,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -231,7 +231,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -413,7 +413,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -421,7 +421,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2025.4.7-enterprise"
+    app.kubernetes.io/version: "2025.4.8-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -433,11 +433,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 52c373fb88ee03029f466a871c32600377d4c86037dd67e535bbffcbdfa329d5
-        checksum/init-fs: bef4dbd75e2173dba4baf51e565838c16cf2e1c8fbc0fb1162286f41a013d0a5
-        checksum/init-sysctl: 01ca0a2d6d63bcb588553e7c75f93825a1f5aaa78fa0dc6a616702d9d64c89e4
-        checksum/plugins: 3e4a804821474a127069b8d0df150cf13e9de700d5922a7a22b03217dbf6942b
-        checksum/secret: 97ee9bbc43c6dfe7e8deedc33ede02c2741760740cef9292487143881a173655
+        checksum/config: 1761da3168eaa86ff588c19361612bc28f5c7a28cf3c2d3095b4cdcdf524cdc4
+        checksum/init-fs: 64bdbc72747846114d0518f61d3c23c36e02185a2c3a3686085a74b39ff2680c
+        checksum/init-sysctl: 0a1587b01086de184ed235f6ad6d930dc4c5af263fdcf291bf4d3e6d4734f36d
+        checksum/plugins: d5db7a4514682451505ead1033f86959f68db49348a41fac46dc9270113a9778
+        checksum/secret: b583fa585b9734784ceb2db162284a7b501e2961629faffe7fad7b77e02ee5a0
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -448,7 +448,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: "wait-for-db"
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -468,7 +468,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args: ['set -o pipefail;for i in {1..200};do (echo > /dev/tcp/template-refactoring-values.yaml-postgresql/5432) && exit 0; sleep 2;done; exit 1']
         - name: init-sysctl
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -490,7 +490,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -529,7 +529,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2025.4.7-enterprise
+          image: sonarqube:2025.4.8-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -546,7 +546,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2025.4.7
+              value: 2025.4.8
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -661,14 +661,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2025.4.7
+    chart: sonarqube-2025.4.8
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2025.4.7-enterprise"
+      image: "sonarqube:2025.4.8-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -133,7 +133,7 @@ func TestShouldUseImageTag(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2025.4.7-enterprise"
+	expectedContainerImage := "sonarqube:2025.4.8-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -219,7 +219,7 @@ func TestDeveloperEdition(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2025.4.7-developer"
+	expectedContainerImage := "sonarqube:2025.4.8-developer"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2025.4.7-enterprise
+  tag: 2025.4.8-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Releases:**
    - Release SQS 2025.4.8 updating `sonarqube` and `sonarqube-dce` charts and app versions to `2025.4.8`
- **Fixtures:**
    - Regenerated helm unit test compatibility fixtures for version `2025.4.8`

<sub>This will update automatically on new commits.</sub>