### PR TITLE
REL-4794 Release SonarQube Server 2026.1.4

### DIFF
--- a/.github/workflows/azure-marketplace.yml
+++ b/.github/workflows/azure-marketplace.yml
@@ -17,8 +17,8 @@ concurrency:
 
 env:
   PSQL_VERSION: 11.14.0
-  SQ_VERSION: 2026.1.3
-  SQ_IMAGE_VERSION: 2026.1.3
+  SQ_VERSION: 2026.1.4
+  SQ_IMAGE_VERSION: 2026.1.4
 
 jobs:
   build-azure-staging-app:

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2026.1.3 # Update this value to the desired version
+  GCLOUD_TAG: 2026.1.4 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/azure-marketplace-k8s-app/manifest.yaml
+++ b/azure-marketplace-k8s-app/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: sonarqube
 publisher: "SonarSource"
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
-version: 2026.1.3
+version: 2026.1.4
 helmChart: "./sonarqube-azure"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"

--- a/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2 # Or v1 depending on your Helm version
 name: sonarqube-azure
-version: 2026.1.3
-appVersion: 2026.1.3
+version: 2026.1.4
+appVersion: 2026.1.4
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
 type: application
 dependencies:
   - name: sonarqube 
-    version: 2026.1.3
+    version: 2026.1.4
     repository: "file://../../charts/sonarqube" # Reference to the local SonarQube chart

--- a/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
@@ -22,7 +22,7 @@ global:
       sonarqube:
         registry: __ACR_REGISTRY_PLACEHOLDER__
         image: sonarqube
-        tag: 2026.1.3-enterprise
+        tag: 2026.1.4-enterprise
       postgresql:
         registry: __ACR_REGISTRY_PLACEHOLDER__
         image: bitnamilegacy/postgresql

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.1.4]
+* Upgrade Chart's version to 2026.1.4
+* Upgrade SonarQube Server to 2026.1.4
+
 ## [2026.1.3]
 * Upgrade Chart's version to 2026.1.3
 * Upgrade SonarQube Server to 2026.1.3

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.1.3
-appVersion: 2026.1.3
+version: 2026.1.4
+appVersion: 2026.1.4
 keywords:
   - coverage
   - security
@@ -36,9 +36,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.1.3"
+      description: "Upgrade Chart's version to 2026.1.4"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.1.3"
+      description: "Upgrade SonarQube Server to 2026.1.4"
     - kind: fixed
       description: "Fix http-route rendering when using multiple hostnames"
   artifacthub.io/links: |
@@ -49,9 +49,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2026.1.3-datacenter-app
+      image: sonarqube:2026.1.4-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2026.1.3-datacenter-search
+      image: sonarqube:2026.1.4-datacenter-search
   charts.openshift.io/name: sonarqube-dce
 dependencies:
   - name: ingress-nginx

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2026.1.3`
+Compatible SonarQube Version: `2026.1.4`
 
 Supported Kubernetes Versions: From `1.32` to `1.35`
 Supported Openshift Versions: From `4.17` to `4.20`
@@ -448,7 +448,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.1.3-datacenter-search`                                             |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.1.4-datacenter-search`                                             |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -504,7 +504,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.1.3-datacenter-app`                                                |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.1.4-datacenter-app`                                                |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/ci-values.yaml
+++ b/charts/sonarqube-dce/ci/ci-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 3
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.3-master-datacenter-search"
+    tag: "2026.1.4-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.3-master-datacenter-app"
+    tag: "2026.1.4-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
   webPort: 4023

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -7,7 +7,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.3-master-datacenter-search"
+    tag: "2026.1.4-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -16,7 +16,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.3-master-datacenter-app"
+    tag: "2026.1.4-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
 

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2026.1.3-datacenter-search
+    tag: 2026.1.4-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -153,7 +153,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2026.1.3-datacenter-app
+    tag: 2026.1.4-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.1.4]
+* Upgrade Chart's version to 2026.1.4
+* Upgrade SonarQube Server to 2026.1.4
+
 ## [2026.1.3]
 * Upgrade Chart's version to 2026.1.3
 * Upgrade SonarQube Server to 2026.1.3

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.1.3
-appVersion: 2026.1.3
+version: 2026.1.4
+appVersion: 2026.1.4
 keywords:
   - coverage
   - security
@@ -41,9 +41,9 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.1.3"
+      description: "Upgrade Chart's version to 2026.1.4"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.1.3"
+      description: "Upgrade SonarQube Server to 2026.1.4"
     - kind: fixed
       description: "Fix http-route rendering when using multiple hostnames"
   artifacthub.io/containsSecurityUpdates: "false"
@@ -51,9 +51,9 @@ annotations:
     - name: sonarqube-community
       image: sonarqube:26.1.0.118079-community
     - name: sonarqube-developer
-      image: sonarqube:2026.1.3-developer
+      image: sonarqube:2026.1.4-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2026.1.3-enterprise
+      image: sonarqube:2026.1.4-enterprise
   charts.openshift.io/name: sonarqube
 dependencies:
   - name: ingress-nginx

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Default Versions
 
-SonarQube Server Version: `2026.1.3`
+SonarQube Server Version: `2026.1.4`
 
 SonarQube Community Build: `26.1.0.118079`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2026.1.3
+export TAG=2026.1.4
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -304,7 +304,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-static-hazelcast-values.yaml
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -357,14 +357,14 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 7edc9c659020d3ac311a54e74d3acf000729cf7be36146650610f257e63cc3c8
-        checksum/config: 5f7139f7f894f9ff312dc73096275961bf59dc756fc537263ee76466f6ecfc86
-        checksum/secret: 70ca5c5b5e99c804552da8cbd7cc7412884cda4e64d5c38ceb8578e8a6b2a0a8
+        checksum/plugins: d1fc8f91cded96e13b80378193e1b2f7acbb682a3ab364c2602df7d078542442
+        checksum/config: 61f12cbc694e2101275a7f9c51f5fa11649efcf92d414b295c7361bc89307069
+        checksum/secret: 6cffa9913bf0113ac2f9d57ed4f4c2a0aabf956f34cf1a53a5e2caf5930312e8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -403,7 +403,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -437,7 +437,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-static-hazelcast-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-static-hazelcast-values.yaml"
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -600,15 +600,15 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 41873282b5501328a6c4dbdea318e913bb0b950f4b383d3788238ee3cec2690c
-        checksum/init-fs: ced30e474445db721b60a496adc726188cfd0b32c530a3cd7ceb7a2a55fdaac7
-        checksum/config: 5f7139f7f894f9ff312dc73096275961bf59dc756fc537263ee76466f6ecfc86
-        checksum/secret: 70ca5c5b5e99c804552da8cbd7cc7412884cda4e64d5c38ceb8578e8a6b2a0a8
+        checksum/init-sysctl: 1871a49a870afe5c4a908885249417923d17a5647b6c2ad26ccd76b74f0985ca
+        checksum/init-fs: 922d3e51fc5b244e73d9521ceced55e0abcb562936e0c0b40e794564d4a77fee
+        checksum/config: 61f12cbc694e2101275a7f9c51f5fa11649efcf92d414b295c7361bc89307069
+        checksum/secret: 6cffa9913bf0113ac2f9d57ed4f4c2a0aabf956f34cf1a53a5e2caf5930312e8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -623,7 +623,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -664,7 +664,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -801,14 +801,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-static-hazelcast-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4e09e430114b6badef9855b78684b3cc969474641c02803fa3af8a41ec93c832
-        checksum/config: b5bbf354025787f9b25383d38fc792732852bd610b0fa937613e55c36a2596a9
-        checksum/secret: 3e03479aef50cd00587250c5f8276e1081a026ccd8abb57562c58cf9fea39968
+        checksum/plugins: ae55c3cdea14effe517ddba55160e00b7295567199220ecab0d90564113026ec
+        checksum/config: d3bad94cfadc207780a1b92267664630fbe300ebd7d4fd0052a322fe9dc593db
+        checksum/secret: 401afe5e26d1605ca1d95199c879d2429bcf80e0bf65721953923d67eacf7b80
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3561190c621475e9f9b4622895094545bf7cd38670b33ec48ab5155e876ce488
-        checksum/init-fs: e3c254973e2c2129cb5738d4ef35be99d4897a5f675ed8100f0b7767c790277f
-        checksum/config: b5bbf354025787f9b25383d38fc792732852bd610b0fa937613e55c36a2596a9
-        checksum/secret: 3e03479aef50cd00587250c5f8276e1081a026ccd8abb57562c58cf9fea39968
+        checksum/init-sysctl: 514a7a9d55716d8225375f63b517931a32b6960b5de8a3c528be86fed3619b45
+        checksum/init-fs: 38ad88e496ef53175e0eb981b5faf53a05589a36a7d5f68b34b1d8b46c8bbfcd
+        checksum/config: d3bad94cfadc207780a1b92267664630fbe300ebd7d4fd0052a322fe9dc593db
+        checksum/secret: 401afe5e26d1605ca1d95199c879d2429bcf80e0bf65721953923d67eacf7b80
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -739,7 +739,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2026.1.3-datacenter-app"
+    version: "2026.1.4-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -793,14 +793,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: application-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -235,7 +235,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -282,7 +282,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -308,7 +308,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -344,7 +344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -361,14 +361,14 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e4c24eebf6f4c550fd852e57f649d6ae70da467039bee5aa622337c76370601a
-        checksum/config: 5a59e7829c78a6156c4f695a1eec0e3e2190d2c55fa66f757e8b17b6f93bd6a5
-        checksum/secret: 6a9d1fdf5f34edf9e33ef6ca15835252f7c0336a8e0eb92858c73b731fd1951d
+        checksum/plugins: 5670e870fedb956de335e2bf55ed769b0870eb0c0c64d943b60c93546fbc1c28
+        checksum/config: 474eeb80d29aaf56c7b27d2d6191cd8b04a396a4ce07f0bad55e56bf3f613977
+        checksum/secret: 81f2ac9c142074b193f45e52e478a90fb89975085fd0bac1fdbfab2cbdbde32f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -392,7 +392,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -420,7 +420,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -448,7 +448,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -584,7 +584,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -593,7 +593,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -622,15 +622,15 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 1ac558ad36922022ef2954e620d09aece93c22270c69eea1480948e0f2d7b45b
-        checksum/init-fs: 718a3a24b8fac9ef7ec14bb6ee626431aecdbdc728beeab626a09a34044f0a71
-        checksum/config: 5a59e7829c78a6156c4f695a1eec0e3e2190d2c55fa66f757e8b17b6f93bd6a5
-        checksum/secret: 6a9d1fdf5f34edf9e33ef6ca15835252f7c0336a8e0eb92858c73b731fd1951d
+        checksum/init-sysctl: 98ede473b4dcd18c0325abd166a9e1b6c874f2d7b4eb83cdc36d40385bc9efe0
+        checksum/init-fs: 0a941b06f678df534fa8ac4c9aa4bc1b2dd1435e3c5a67c6ec9d83dfec66327f
+        checksum/config: 474eeb80d29aaf56c7b27d2d6191cd8b04a396a4ce07f0bad55e56bf3f613977
+        checksum/secret: 81f2ac9c142074b193f45e52e478a90fb89975085fd0bac1fdbfab2cbdbde32f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -645,7 +645,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -669,7 +669,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -710,7 +710,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -852,14 +852,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -241,7 +241,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -266,7 +266,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -319,7 +319,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -345,14 +345,14 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f1fed1f27820b642d873550b949ae291e95479a93717822d68fdece1e6ccb16d
-        checksum/config: 9ab3da18e87baba2809f2606d5faafbfc68c8c88a47ba824d5043fdb57489fdd
-        checksum/secret: e43b62f7d36993721c9df1581a9f674a56a3c69c0099d0c47f8b5394c98e68fb
+        checksum/plugins: 2e870772dd81f64a7313f6988e5eb5f28e778c3113dc29c30f1b5c6d7619be4e
+        checksum/config: e4c6b63e6745651a3d4115f5ab8e6d44b8c919c4c6447d812191194212125221
+        checksum/secret: e23cb7c661d69a4ab7d68382dfeb763bc4fc88d6f8a870adee44697abdc9a42c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -379,7 +379,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -407,7 +407,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -523,7 +523,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -561,15 +561,15 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b42bad3fea3b6ae9a16cc8f504769a3e25ba1104cf7a7cfb1fe816130cea6142
-        checksum/init-fs: db80cf11647864bc322815cc9742d299a94bb013465a8c7502f7f659aef84920
-        checksum/config: 9ab3da18e87baba2809f2606d5faafbfc68c8c88a47ba824d5043fdb57489fdd
-        checksum/secret: e43b62f7d36993721c9df1581a9f674a56a3c69c0099d0c47f8b5394c98e68fb
+        checksum/init-sysctl: 58fb8abc5b17059d2c59a008d7c851a000db4cbf7fc5dc15f7163831efcf8fb0
+        checksum/init-fs: 9e2d4e6b25997492365dbe5fb724a77e0928bccf3e5ff35c81f533117c763365
+        checksum/config: e4c6b63e6745651a3d4115f5ab8e6d44b8c919c4c6447d812191194212125221
+        checksum/secret: e23cb7c661d69a4ab7d68382dfeb763bc4fc88d6f8a870adee44697abdc9a42c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -584,7 +584,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -608,7 +608,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -649,7 +649,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -786,14 +786,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4af3898a5975a0afff18e3021496df85a00af47fa04ea983e99a4bcd96981522
-        checksum/config: 13cbc117ac8b9da74fe505e15ad0d468228762209fda08791b07be0ad1efe4a3
-        checksum/secret: 4058accd055c67217a90a0c67bc8819b22b7b638600a08fc806df2a640964620
+        checksum/plugins: 0d44e22e47a7d49600c31c54dde3bcfd7a95f1309f310b5ec1513f58eafab519
+        checksum/config: 8722a55a9b742dbcfb936ea2302d49f8f493e54d46fdeec4618ae891d16c199a
+        checksum/secret: f1cc9229e52b7c409668343f6f37b8a294ecbf9380353e819c85615f068467ff
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 778fa5c253e269dcf0bf2af2588ccfa4e3b6f3babe425a234870a1608ab4d94d
-        checksum/init-fs: ffec3ce16ea35607f578fb85f8cdf898b82bb90cef9573c4b857806375f4d4d2
-        checksum/config: 13cbc117ac8b9da74fe505e15ad0d468228762209fda08791b07be0ad1efe4a3
-        checksum/secret: 4058accd055c67217a90a0c67bc8819b22b7b638600a08fc806df2a640964620
+        checksum/init-sysctl: e1f75b92bb7f01447b23b5b20f77502a75d191912fb0d496fecb4bc25fb4c984
+        checksum/init-fs: 30a649d9c6bdcb726b5fd1c06221c82a6b12c834b9607381c549a0bc414271ea
+        checksum/config: 8722a55a9b742dbcfb936ea2302d49f8f493e54d46fdeec4618ae891d16c199a
+        checksum/secret: f1cc9229e52b7c409668343f6f37b8a294ecbf9380353e819c85615f068467ff
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -787,7 +787,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.3"
+    helm.sh/chart: "sonarqube-dce-2026.1.4"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 
@@ -246,7 +246,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 
@@ -271,7 +271,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -350,14 +350,14 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: dae54ca53a4b7a089a049ade5c2504a44d1e86993e52195d856f2ba2dbf18bc7
-        checksum/config: cb919207e848397c8fb56fd4f8dcbd3349b196d66725c2261ab26275d43b2dd0
-        checksum/secret: fcad10bad0fef70ed9aca89f5df2cff9e24a0b3993bf8533ec2206557045fd24
+        checksum/plugins: ba0f0e5021639f82a39996ffa7906ca42d35dcbd94b5540b5befa594fd2d1550
+        checksum/config: 80384d2c6636d64ec270ea295218e2f353c23da42b0562a41b839dea36c32093
+        checksum/secret: 1929efab6342ef2e89ecd64ca94fa41311ac4540452a3b7b7aa5e03f4ce4b159
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -396,7 +396,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -424,7 +424,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -600,15 +600,15 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 49c2a376e81035850e9432a871b19cf5b555a3ed60f9ac8f7d0fe0fb807ae6d5
-        checksum/init-fs: 0ca688349e5d5152fb6e714f43613ec0212ffb8cf84ce342413b74ab91fa235f
-        checksum/config: cb919207e848397c8fb56fd4f8dcbd3349b196d66725c2261ab26275d43b2dd0
-        checksum/secret: fcad10bad0fef70ed9aca89f5df2cff9e24a0b3993bf8533ec2206557045fd24
+        checksum/init-sysctl: d55f12bead0245567bd401585d1a9f9299eb57088368165b3eedfa32d0a44dbc
+        checksum/init-fs: 9f14bf6ab655c9e348ea972de4dc7c4933477ee49cc8b1af4dff97950fa8b84f
+        checksum/config: 80384d2c6636d64ec270ea295218e2f353c23da42b0562a41b839dea36c32093
+        checksum/secret: 1929efab6342ef2e89ecd64ca94fa41311ac4540452a3b7b7aa5e03f4ce4b159
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -623,7 +623,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -659,7 +659,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -700,7 +700,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -858,14 +858,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 579ee93a8f614ddcef551ca573ac254c9814a7d9f24f24e7ed324795c4ec626e
-        checksum/config: f47a96caf76fcd1b8d7329138f193cb0ace27e8fca5ceb231a60f048c73f94b2
-        checksum/secret: feba401980aee5ed4cc491f4bfbefd36f7dc9edd0e5be953ed2ada6def7c3245
+        checksum/plugins: 20cfcb9767bf274f16597d45621c44f7af5a4a21f1c71c9958aa7cb4d744d1af
+        checksum/config: 813bc64fb839c3a891acd4ed5bf4584f360aa5a516adb03e22933fd04aa0084a
+        checksum/secret: 2f43d18cbf7ada195c8f58144a4a6284ff00026b27919c449c34d30c485aa32a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 6a4d0598b465c32570a0d820e618de12c1cb9e7fdba96dedaaad19c8f21344d0
-        checksum/init-fs: 93c2c161a78bddf35f08e3cd27ad081921b270096d8b28b4f62b315a0144948b
-        checksum/config: f47a96caf76fcd1b8d7329138f193cb0ace27e8fca5ceb231a60f048c73f94b2
-        checksum/secret: feba401980aee5ed4cc491f4bfbefd36f7dc9edd0e5be953ed2ada6def7c3245
+        checksum/init-sysctl: a4017b1815b5fdad75a155f9f251876cdad77d0d17e6a276016c3f8736879717
+        checksum/init-fs: b7c6d9dd6d57e64bc2afe8cbce52e33a5e1c042f2d3fcb5a358dc411f3506ea1
+        checksum/config: 813bc64fb839c3a891acd4ed5bf4584f360aa5a516adb03e22933fd04aa0084a
+        checksum/secret: 2f43d18cbf7ada195c8f58144a4a6284ff00026b27919c449c34d30c485aa32a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -734,7 +734,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d179e179ff798b5c4f5b7bc34e75d363e6de5136deba972c6066016e36f3425c
-        checksum/config: 921a38b8e9b0fcdb74e0a07985b7825ecc1d17edd49cdc549057da981bb8831f
-        checksum/secret: e44977b935c6f973305a03e5db43cc571bce16a29d0575bb49897a48c0826915
+        checksum/plugins: 04576cb5645e4cf4df043ad99e4c8d8b06f949f143408fb1ecd0bb7d115f55ee
+        checksum/config: 2deb48f82fd7072af0747631a732a89276b92bc7bf481917ef3ab11c78008d90
+        checksum/secret: 62e35a5f49c57cbb068de8c4ed67e59b77ca8b19bbc844406e6d3154cc484506
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 70f5f76a81ba7ea2316001616e47bc754615d20314cac53d1e2ab1d8ca2bb29b
-        checksum/init-fs: 712fcabe4db842bfb6b8760a3ac0e28bd2d50dfa63df703d9d601fd0d602077b
-        checksum/config: 921a38b8e9b0fcdb74e0a07985b7825ecc1d17edd49cdc549057da981bb8831f
-        checksum/secret: e44977b935c6f973305a03e5db43cc571bce16a29d0575bb49897a48c0826915
+        checksum/init-sysctl: 927b3128f388147226afbdfe102b31876578df132947aed13380a3ce236e7a07
+        checksum/init-fs: 0a5d3cac0c6af160e3f4651eaea0406e24696a911360973519bc3dddffc54d28
+        checksum/config: 2deb48f82fd7072af0747631a732a89276b92bc7bf481917ef3ab11c78008d90
+        checksum/secret: 62e35a5f49c57cbb068de8c4ed67e59b77ca8b19bbc844406e6d3154cc484506
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -734,14 +734,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4b6ef8f14f9efc3887b58111d85ee0caa8660bfe7aa894cea7c6fff9921c671a
-        checksum/config: c6617a5072d298697606fbbea5a15fa2216079ac7976f6147655398692b44471
-        checksum/secret: 7b4649837fff03b7544eafd7fd31da16c838262e94e464de6f3be4b3e8bb185d
+        checksum/plugins: a432260f02e5eb36cf68c69ac23963908096a9a1293c0086004205e150531604
+        checksum/config: c327ef91c4dfa1d3b2c194861c614d1dd25d753cf712abfddb85b04c142ea924
+        checksum/secret: 4cdca6ed8a05be3bd005bdf8679e393debde4ce74838b8db050d825fd1cc95a7
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b0005eeb083605fe5b8e168044cc789e5cb653b46b5afd608c468af7cff66c31
-        checksum/init-fs: e0c1f7262be05461673e8b429df85b7c61319f791b2decab3cd526d350a0d080
-        checksum/config: c6617a5072d298697606fbbea5a15fa2216079ac7976f6147655398692b44471
-        checksum/secret: 7b4649837fff03b7544eafd7fd31da16c838262e94e464de6f3be4b3e8bb185d
+        checksum/init-sysctl: db9b4e32436e22c212f8d475f659ce66b5e29af13a82960ff6f818ca52452a5d
+        checksum/init-fs: fa8990179f6a60c302582a6113ecfdef5973911f828dd470932ca43effce6e62
+        checksum/config: c327ef91c4dfa1d3b2c194861c614d1dd25d753cf712abfddb85b04c142ea924
+        checksum/secret: 4cdca6ed8a05be3bd005bdf8679e393debde4ce74838b8db050d825fd1cc95a7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -734,14 +734,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: deprecation-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ef0de2f7d81be59c8911c930933a55ff2395b0b3483f5245bbf37dd6bd63dc37
-        checksum/config: c8e4e18d19060244390a95afc33774b3207d555ea7a248af83064eccae5056a5
-        checksum/secret: 38ce70647daacdf8b823987cb35bcbfd80950e76f0791b122e5038e64bc0808f
+        checksum/plugins: ee00a4bd9a11461fa496875ea35f33976f06e1dcde63aefbbb8b52120b7779a5
+        checksum/config: 5c695ac4789d47dedf0f22204e39565e6c8cbf419a11c064696a1258d216ff21
+        checksum/secret: e37a53ef11c53fbbb1b99f722ec771f98273df71f981244ccd98a019d1f7153a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -387,7 +387,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -500,7 +500,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -538,15 +538,15 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 5889b4dad26b6f99033966af750cbb4da609e037b9cfff6a2b3acf9f0aea7c7e
-        checksum/init-fs: 13cc3c1051c9a3a7a2c0d4bdb23309f6525f45ffdb71a0827ab39accb45935d9
-        checksum/config: c8e4e18d19060244390a95afc33774b3207d555ea7a248af83064eccae5056a5
-        checksum/secret: 38ce70647daacdf8b823987cb35bcbfd80950e76f0791b122e5038e64bc0808f
+        checksum/init-sysctl: e1f0e8eee496627493bfef859853fd25c8a53d23b9154d1f01e44265d44724e1
+        checksum/init-fs: a3e15ee8f25711be933b01ab6a913dbe725726ddfcd69cb868022adf8e362e43
+        checksum/config: 5c695ac4789d47dedf0f22204e39565e6c8cbf419a11c064696a1258d216ff21
+        checksum/secret: e37a53ef11c53fbbb1b99f722ec771f98273df71f981244ccd98a019d1f7153a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -561,7 +561,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -602,7 +602,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -739,14 +739,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b575948064e848de8127a6eacb243e5017161971f138385767372ea1c0d1c549
-        checksum/config: 9247af8b0698e767bdcaa5f6e190f40acb99fd65378adac4d230fb6a676358ee
-        checksum/secret: 8a5b81eaa5cc41779919ca418f305d9b69b9c1ddc54fbcc8d84d8a847995590e
+        checksum/plugins: 11d7c5f88b7321ddbcfdbe4ce55a73b3232534eab6d3800bdfd91b28e2df4066
+        checksum/config: 22d6488ac6d3e4472eb569b0fff1334ac19c3549844a7dc403171fd2052de1cd
+        checksum/secret: 86caee6eeebe2ab52728b4d7d8410d31f9ee4c45a3002fa9d1f804b590f22215
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -499,7 +499,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -537,15 +537,15 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b733fbbc72f7e7f059d63cb85703a2833ebf19ad460bd5e8a5d9f7afb75268f7
-        checksum/init-fs: 7b2e058a67ffff703fccd02615e453502ffdc09584e1adacb85c03fe899a159e
-        checksum/config: 9247af8b0698e767bdcaa5f6e190f40acb99fd65378adac4d230fb6a676358ee
-        checksum/secret: 8a5b81eaa5cc41779919ca418f305d9b69b9c1ddc54fbcc8d84d8a847995590e
+        checksum/init-sysctl: 9311935cec8d291b3c873cfee360e5030fd31742de12230e4d5c7f611e99ad44
+        checksum/init-fs: 47ea4b19b97942ce10ce8ea7e1560ce41c9a8ab2a2b13e4a5dace0ec8656af20
+        checksum/config: 22d6488ac6d3e4472eb569b0fff1334ac19c3549844a7dc403171fd2052de1cd
+        checksum/secret: 86caee6eeebe2ab52728b4d7d8410d31f9ee4c45a3002fa9d1f804b590f22215
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -560,7 +560,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -601,7 +601,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -743,14 +743,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -343,9 +343,9 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 05c7b82d539f328f3fd423db0531505b395227b15e4900cf84a31af230529558
-        checksum/config: 22986ea90d31b44155322a403a3a67db46d917cfebff44b350af46056e1cf209
-        checksum/secret: cbc436e1ada1437d88442e9ccca926ad4c4e19509a9f7b9691e671c8e9262707
+        checksum/plugins: c61139e94d81ca9420774748b034ee05897163176d5aad1becd37d41600a0d79
+        checksum/config: 2301786a62d348d53cf28b86656f1944b1e72a49925dbd7eaa06bd3dbf31f363
+        checksum/secret: 247cccbc5b70eea913b0164d3e5366e47c558f0a01c8d1566164fe44cb838343
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -353,7 +353,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -381,7 +381,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -529,7 +529,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -567,15 +567,15 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 037062ea665b6ad4f991f9fdd5532899dd0b18a6889663e2a8b26543df3f93a2
-        checksum/init-fs: 475d7074c2bb9aa0e9d4240713160f81c40b26c52ff93b2891399976e22f5d80
-        checksum/config: 22986ea90d31b44155322a403a3a67db46d917cfebff44b350af46056e1cf209
-        checksum/secret: cbc436e1ada1437d88442e9ccca926ad4c4e19509a9f7b9691e671c8e9262707
+        checksum/init-sysctl: a1b088d6e4dee9ef205f0edec98ba264759094b8c5c6a1b498537cbcf9091310
+        checksum/init-fs: 2315dc4fccefafd333bcc1a2f5524d8f0159c5ec986260bd237e8cfd9fa68f64
+        checksum/config: 2301786a62d348d53cf28b86656f1944b1e72a49925dbd7eaa06bd3dbf31f363
+        checksum/secret: 247cccbc5b70eea913b0164d3e5366e47c558f0a01c8d1566164fe44cb838343
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -590,7 +590,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -631,7 +631,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -768,14 +768,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: hpa-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5d23607a02451fed81cf889d2731d93e4122e4c498e1d429523e6302a6df7df3
-        checksum/config: d0bcd811e6b3d55363c7ce59efd0830b8a03e83eb77d20b659d66da89e43d463
-        checksum/secret: 218fbf485211bc50daff841c189ab23c8b0681e8edb00074766db7cffc403229
+        checksum/plugins: 02eeeaea6c7a0741c1b3abb101d32022c7d499c6afdac061220dc653f32413de
+        checksum/config: 5a5a358e11f0cd46832adcda03f21055ae4eaa3cfeec25534af97ba7be687e3e
+        checksum/secret: f68f5f85ff11b422bc35bc660d2261ec282185dc890dee7ebc48dff9fd2adf2a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d4e5bd54d6d5f766bd2d467c7cee239e505d93c6b21a7c1dbdf1d7bc9f10c8e1
-        checksum/init-fs: 05145afd5964bd23dd21e6778dff9113bad14420675ae54df1d8ab32790fabae
-        checksum/config: d0bcd811e6b3d55363c7ce59efd0830b8a03e83eb77d20b659d66da89e43d463
-        checksum/secret: 218fbf485211bc50daff841c189ab23c8b0681e8edb00074766db7cffc403229
+        checksum/init-sysctl: 49ec40bf755677ea2d964a589c2b2d7b91a161b9e32a322ef37720bfdb2b3d87
+        checksum/init-fs: caeac0fe88ca27c46faaad809b0d505f9aa7f007b1b1ecd706488efbde9ed199
+        checksum/config: 5a5a358e11f0cd46832adcda03f21055ae4eaa3cfeec25534af97ba7be687e3e
+        checksum/secret: f68f5f85ff11b422bc35bc660d2261ec282185dc890dee7ebc48dff9fd2adf2a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -759,14 +759,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e3bc93862ee9d707be1eb3493751dbfb30974d7913a2d8337fc0f933b5bd82e4
-        checksum/config: 1102f6e9dc4b6bbf2cbe2e4a6f82125d3a73ff02786fc5a7f1a0bba63aad9d38
-        checksum/secret: b4b2bd0f360f9c638d46de3cc61d68a040cd6350f5bf92548a26d5627ff31114
+        checksum/plugins: 49a12f7f405e9930e9e484ba482f9a269e9f83a69f50af9cf13cd711a00ac84d
+        checksum/config: abe8f8916610f55c3e3df5a8529117154ae8e7b578ba2b81d7e5e6a3b39929a4
+        checksum/secret: 9e07ea0b872cef13e85602462c0ff14b6ba3b1c0a71bf9e1eb96d7e70e6191aa
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 69b2e0fd8b7d44104700252c62e055bac7a9f941b091d75be02408e66638ce81
-        checksum/init-fs: 4ec06bdc78d95edb0ebfb4f4271961dd9a9495be4d11a53f0be624e9941afd06
-        checksum/config: 1102f6e9dc4b6bbf2cbe2e4a6f82125d3a73ff02786fc5a7f1a0bba63aad9d38
-        checksum/secret: b4b2bd0f360f9c638d46de3cc61d68a040cd6350f5bf92548a26d5627ff31114
+        checksum/init-sysctl: 32a8a682936fbf46ec8dbf3570bcb4730111c45f0b19ac574223327028afaf32
+        checksum/init-fs: 5c8799a154e369e78c8b93c385204bd80eecd782214426a4bf55b42566462c4f
+        checksum/config: abe8f8916610f55c3e3df5a8529117154ae8e7b578ba2b81d7e5e6a3b39929a4
+        checksum/secret: 9e07ea0b872cef13e85602462c0ff14b6ba3b1c0a71bf9e1eb96d7e70e6191aa
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -760,14 +760,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9dab13ee339f692227e3d17e4cdad5424d7781bc2beb5438632edab1bfc3f977
-        checksum/config: 2b313e4ff282fb8d6c6861e8d14fe183889b116f3c2bd81a5615b42d656b8853
-        checksum/secret: 7fa19f7057038591b75e570ad2ea74eb5851de5e44838b8fca45f515f1a8b894
+        checksum/plugins: a6c19d582a12bf81a07036166f351b9ee426946c7a706217b06b63077553f8b0
+        checksum/config: a246858f9eadaa3b99f7c4561eaddb3470a63cb42a3bd4cb62601e950f8cb717
+        checksum/secret: f97174c11a88b1070dba37f7cc22ba18a8e2b9f43ec9585cf1e3bfd1cb4a2859
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 4d7748ae4d6e4ee20a6d538bad4b79a2be6a38fc391c2d16c6a95122c58af30c
-        checksum/init-fs: 488b74ae17e75e2b184221f1ba584590eca91b29d059475e8a3c1f1b336a9fc7
-        checksum/config: 2b313e4ff282fb8d6c6861e8d14fe183889b116f3c2bd81a5615b42d656b8853
-        checksum/secret: 7fa19f7057038591b75e570ad2ea74eb5851de5e44838b8fca45f515f1a8b894
+        checksum/init-sysctl: 97de2a7d780b0920aae7654dd01287a22a65fe2deac86351e7fb3a82d3bc9fb2
+        checksum/init-fs: 8ec1a1b4878ae94a052b60a8d8d02eb2bd4c155423faa418547d356945b0751e
+        checksum/config: a246858f9eadaa3b99f7c4561eaddb3470a63cb42a3bd4cb62601e950f8cb717
+        checksum/secret: f97174c11a88b1070dba37f7cc22ba18a8e2b9f43ec9585cf1e3bfd1cb4a2859
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -767,14 +767,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -84,7 +84,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -99,7 +99,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -134,7 +134,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -223,7 +223,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -534,7 +534,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -556,7 +556,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -581,7 +581,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -607,7 +607,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -769,7 +769,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -786,9 +786,9 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 7aa8817cc955f3ea1f1f89f640090af04bf6754faa6607319de0d5e579d54c68
-        checksum/config: 45d22eb04eb72521b5081bf5a351c65b9ac497e76e6f3c872712aa7e50f8fd7d
-        checksum/secret: 32f08188dd38c53e4054ce2a147813c733702def711b003c4f9220f14296b21f
+        checksum/plugins: 9a7af5019a4f2b7bc758e211bd309d85d8ecc28accd5e008e01e1c34b866cc5b
+        checksum/config: e9963911bbca810098d1864dcb925f8413f1d3b60e774412fc55a53577a78918
+        checksum/secret: 51eb9cd0bfa7f9fb650784a63686d110c77302c249023c973e5e416655dffab5
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -796,7 +796,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -824,7 +824,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -937,7 +937,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -946,7 +946,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -975,15 +975,15 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 8afda8aa2100b9e747601440b811fb2920af8a08af9f69f3c9b2aa0847b69c3a
-        checksum/init-fs: 1c3bea3815417e965939745a771ff600735b083583cb6dc4821b069e94e1ee4d
-        checksum/config: 45d22eb04eb72521b5081bf5a351c65b9ac497e76e6f3c872712aa7e50f8fd7d
-        checksum/secret: 32f08188dd38c53e4054ce2a147813c733702def711b003c4f9220f14296b21f
+        checksum/init-sysctl: 3b2117d2a7b31541557fe8ef6a46e517e9f5b5f7bf5991fcc825e9727316a757
+        checksum/init-fs: f32b431731e2f777c180a2049b0ab73577fa76e0279bcd300895e2390ed442d1
+        checksum/config: e9963911bbca810098d1864dcb925f8413f1d3b60e774412fc55a53577a78918
+        checksum/secret: 51eb9cd0bfa7f9fb650784a63686d110c77302c249023c973e5e416655dffab5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -998,7 +998,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1039,7 +1039,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1188,7 +1188,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1390,14 +1390,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 294c7e79b98520d8d665b9739c80dfffd8e7b40701cb0389d697912464fb8e22
-        checksum/config: 361a4ce52b1ff52b9e0ae84dc81850b4d4ac4f073738c123939b7ab33bfa5e13
-        checksum/secret: 36985d290372c6bcbcea83913aa1e5aa22d3813532a0b68d5a54d81384ea80cb
+        checksum/plugins: 4ae403212d8c805d77822a2c1430d4cd0c19e462ef06c055fa74875a9497bda1
+        checksum/config: 6e29b940ef3a6b681fff94c4ea7f689ce7e8c418717c641adefbd75e4c3d6623
+        checksum/secret: 48c8accae67077a6b3a889fa4e2346912f91b5386d9e485222309b24051633be
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -580,15 +580,15 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b108576d6467fe439c91a02baae369f3c534dacc9c3576a0908699f475dbb45e
-        checksum/init-fs: 62141a398b94bc0c340b70c3a543643a15546dfbac7f297d9c9c7cbd23c0f804
-        checksum/config: 361a4ce52b1ff52b9e0ae84dc81850b4d4ac4f073738c123939b7ab33bfa5e13
-        checksum/secret: 36985d290372c6bcbcea83913aa1e5aa22d3813532a0b68d5a54d81384ea80cb
+        checksum/init-sysctl: c2c24dc68df02cf20b26b0ea1f2ce55f8c4fad4854502849cb9b9eb47a639738
+        checksum/init-fs: 6c1072f93c8c1c13d6e6675cc90ffae3de8a339e8805fbc3e1a8bf17ea363edd
+        checksum/config: 6e29b940ef3a6b681fff94c4ea7f689ce7e8c418717c641adefbd75e4c3d6623
+        checksum/secret: 48c8accae67077a6b3a889fa4e2346912f91b5386d9e485222309b24051633be
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -603,7 +603,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -644,7 +644,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -781,14 +781,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -178,7 +178,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -227,7 +227,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -252,7 +252,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -314,7 +314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -331,9 +331,9 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 87e91f433144672eaa23f2b0c8f85ec961f3ad9db3ee8af966ab7618c9960f83
-        checksum/config: 39df50151043e16d239760550b431c6b99f6117db06027b3001a5304072949f1
-        checksum/secret: 3f34ab5d7f3952a0bd0616981c82aa76fa6ef1da339f08c51c2a6502fcd9e37e
+        checksum/plugins: 73f786e03633c5df240f231bd13d26dd32b6c4b2eaeab7d944d04e276be6047e
+        checksum/config: 59998f2072d91c458bcda53c79c8b6c42320279418fcd2a0c5fac266fddb99c9
+        checksum/secret: e95fc1dbb0369064c45d62f703f54fff83fdaf5fd7d9b60099e7345063a36c68
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -341,7 +341,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -369,7 +369,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -482,7 +482,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -491,7 +491,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -520,15 +520,15 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: be1ecfe96e0106c6a194a7327a2f88f2ccb22dbbe1a27322196355d7c49a6bf8
-        checksum/init-fs: 504af5b60afd86471b1a30e9ccfdc99a4d81d27d93086ea9cd76bccea66a2509
-        checksum/config: 39df50151043e16d239760550b431c6b99f6117db06027b3001a5304072949f1
-        checksum/secret: 3f34ab5d7f3952a0bd0616981c82aa76fa6ef1da339f08c51c2a6502fcd9e37e
+        checksum/init-sysctl: b479a1bcc3bafa33aba6a107be5b21d188e4c857346307332111256806706d71
+        checksum/init-fs: 152a912b4a12d6cfa3de43f446ef3069a814a949b437e1444c701e990d791105
+        checksum/config: 59998f2072d91c458bcda53c79c8b6c42320279418fcd2a0c5fac266fddb99c9
+        checksum/secret: e95fc1dbb0369064c45d62f703f54fff83fdaf5fd7d9b60099e7345063a36c68
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -543,7 +543,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -584,7 +584,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -721,14 +721,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: dcdebc7c1724b3ad140eb955894d0acce03be4e740d0d53a058d6e6212db164c
-        checksum/config: a93897ce5b2929b6e09904e77c9aa371fbc28f737494dceed233436345c056bb
-        checksum/secret: f16553f98b39930140b45f12c94b05ca4b34f91ae216ba6dbefd907b819d8344
+        checksum/plugins: d549023aa3dfcadad1ae7fcc696271c0d07cde1ed413f8ffd5cdb38c1d2ee21d
+        checksum/config: bcc51079117fb6d2131c1ede8cb9111575c99a6e694b9f256875d4a286526b4d
+        checksum/secret: 2840697af6410e76dbb957cea16edf481427348c8a84b9782c997fe96c266613
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -502,7 +502,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -681,15 +681,15 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b18543261649da4f7d174b9006181efd03f77d860f0550e03282d1c726ffb9e2
-        checksum/init-fs: 7410b5333596307cf326cee81d3cea70472e9f2401a2df1c77556b20683e7914
-        checksum/config: a93897ce5b2929b6e09904e77c9aa371fbc28f737494dceed233436345c056bb
-        checksum/secret: f16553f98b39930140b45f12c94b05ca4b34f91ae216ba6dbefd907b819d8344
+        checksum/init-sysctl: a3863766084ea72ced96aa96bb55ad9ea58d86a1026e622f5bf555cfe5dc7acd
+        checksum/init-fs: 73cd1273f15f610932708960add9fc384243b4e407ca8bf285c0522cfc2d3501
+        checksum/config: bcc51079117fb6d2131c1ede8cb9111575c99a6e694b9f256875d4a286526b4d
+        checksum/secret: 2840697af6410e76dbb957cea16edf481427348c8a84b9782c997fe96c266613
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -704,7 +704,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -745,7 +745,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -882,14 +882,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4ef153e0fc1a1b95336288206c85af09bc11333ccba090574e7fbb1d793bfe20
-        checksum/config: 590fe3d755209d5634c869f322f9817585407649f07cbc99fef2c22e31fc73b8
-        checksum/secret: 746df893924b55c5248558b760e63b24acd91829c3cab0f1249b336b87282018
+        checksum/plugins: 0d36ed7f6dfe4776563e0289eb3ed95e1ec0de3ffc94e5cff4e988bcbbd2e18d
+        checksum/config: b08482db94ed5019176c248458c5659359b5f372671fbcf37eba85dd1d8fe1bb
+        checksum/secret: 2aa88bc6b5287ae26fdfdd60293c8f67e90bd5ecdd5064dfd60e7a5e14cbdfba
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -502,7 +502,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -681,15 +681,15 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: c47380b89894cd389be46e89be6cab8870718bf4ad57f392ca0b4cb1c77bcafd
-        checksum/init-fs: c4f08f1e6759d33738c019cfd1a97c2100f20645d5e79b11570de24a2f24fc8d
-        checksum/config: 590fe3d755209d5634c869f322f9817585407649f07cbc99fef2c22e31fc73b8
-        checksum/secret: 746df893924b55c5248558b760e63b24acd91829c3cab0f1249b336b87282018
+        checksum/init-sysctl: d4655df024b2ad2d5f80c8396612cf60cc27b86d57901c986893bed3d0988c72
+        checksum/init-fs: 73e97797a4d879c914c425f275743d061d5e7c6ccf23d8bec2c17690a189a4ed
+        checksum/config: b08482db94ed5019176c248458c5659359b5f372671fbcf37eba85dd1d8fe1bb
+        checksum/secret: 2aa88bc6b5287ae26fdfdd60293c8f67e90bd5ecdd5064dfd60e7a5e14cbdfba
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -704,7 +704,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -745,7 +745,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -882,14 +882,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f99fda9a24acd876ffe1ec95a49be66200cf53ffeb0ce958daaca85b9bcb55f5
-        checksum/config: 1c83d692aea2045c528254a1b6020d36c781899c4e2f84596d7df9383d535b7c
-        checksum/secret: 2d97317900bed72d3b4ff4b63968563e0b3ba5d81ba7de6bb18c28ff5463d4a1
+        checksum/plugins: 08cb8d519a3395a9d246744b3f5a3b570541aaa7b287f72d3ad56b709c88e622
+        checksum/config: 17519bf9d6e00a3ddc20c3799989345f657f908b5588695c080ea81a2f3351c6
+        checksum/secret: 71c83330be73ae966b982ba316e64e44a6fbe03255e465249247b33e80198931
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -519,7 +519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -548,15 +548,15 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 1a8c4990a48741261b8af5167fb0cc4e9d09bf93b6b064b9806aee1c98459c25
-        checksum/init-fs: 8e80f172fe157e469fb493c424c9df80f2f6d83f41980e827c635a15f7a981af
-        checksum/config: 1c83d692aea2045c528254a1b6020d36c781899c4e2f84596d7df9383d535b7c
-        checksum/secret: 2d97317900bed72d3b4ff4b63968563e0b3ba5d81ba7de6bb18c28ff5463d4a1
+        checksum/init-sysctl: 030e68a7226798097fdbc080eddcb4f2284ab8a841d477be3f6ac78da950420f
+        checksum/init-fs: 2ba6dd2ae8efb8e4a92cb8046d0bd0a67e49e2acb8931d6af739a3af0461ab51
+        checksum/config: 17519bf9d6e00a3ddc20c3799989345f657f908b5588695c080ea81a2f3351c6
+        checksum/secret: 71c83330be73ae966b982ba316e64e44a6fbe03255e465249247b33e80198931
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -571,7 +571,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -612,7 +612,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -764,14 +764,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6bda6130fe4acfb78f15ecc0f921884f020ccc94c33da77f538c41b7eb004de9
-        checksum/config: 5854e9c6b7c1ca7b6d5280cdde56f564fd37aae8ba8ed068a968485091190c91
-        checksum/secret: 80260c2ddf551e8a460c8f8a9d89164f43fa3e7017b54406c055162fca8c5b3f
+        checksum/plugins: 38b7a97c9a9654a1e7b8a570914b9e65ae02d77653e7b49492410c45da8306de
+        checksum/config: e8db6a2bf24ea9f1c86044535b621c55f403eafca92cb53d1ff25e69e32b8c65
+        checksum/secret: 653929dfec01b475b81de87c11936985731259dc6dbf1724177dea2be12c49d9
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -519,7 +519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -548,15 +548,15 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e851dae437d3e059fbf52685c88f2f7b5fdac1114fc9b3aed70864e918329c5f
-        checksum/init-fs: 8ac228c5228bc6bad95308e907fc359fe9a4abbbf3d63f356d7a6cb15da42dbe
-        checksum/config: 5854e9c6b7c1ca7b6d5280cdde56f564fd37aae8ba8ed068a968485091190c91
-        checksum/secret: 80260c2ddf551e8a460c8f8a9d89164f43fa3e7017b54406c055162fca8c5b3f
+        checksum/init-sysctl: e5df27c1e733770af7595e02dd79247971b240312183d64dc10985424fe82ae6
+        checksum/init-fs: 2513f1ffce6d698aaf62ea8bba315cc19ac15c2e7fea6cb8c6352039af344fa2
+        checksum/config: e8db6a2bf24ea9f1c86044535b621c55f403eafca92cb53d1ff25e69e32b8c65
+        checksum/secret: 653929dfec01b475b81de87c11936985731259dc6dbf1724177dea2be12c49d9
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -571,7 +571,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -612,7 +612,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -764,14 +764,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: node-topology-values.yml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -248,7 +248,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -270,7 +270,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -295,7 +295,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -357,7 +357,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -374,16 +374,16 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 522555f32c58224d0eab761252d72ba358f7e6cd8b9524d27267b3b22d63ed2a
-        checksum/config: ea352af45264493d9e375faaf4eabd9e91a300e76b3096b8681ec1a2d2a9fb5d
-        checksum/secret: e3706ea7618fab2709b1846193597573b56c010c91baf88c7c8728505519ed1e
-        checksum/prometheus-config: a615b6c41e4e01f63470a839f88467fcac0cb751ff7a0abeb90ce1c3cd4bb283
-        checksum/prometheus-ce-config: d4f834aa0ae408fb71abd2c60bb7024f9284a2b33f25e28ef105629f6cb472ce
+        checksum/plugins: 39fb94762d8d1c86a74845654e64902b8a6d3de6818de8021a007799fc833b4d
+        checksum/config: e029e4ad0aad1861e6b1e23aafd54d1ecde0a99661a962a68e2e70fc118d344e
+        checksum/secret: 8fa9025911909efea48badc690a68ce043456e7a1412beea673b1d07af9761cd
+        checksum/prometheus-config: 0129ac46620bb29d056f73ffa26d25cef7de190ea036d11f5dd707aff3a9ef59
+        checksum/prometheus-ce-config: 1866f739268881db50ee9095bbc1e982347702b8a427cde58679b1ce52cc57d1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -589,7 +589,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -598,7 +598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -627,15 +627,15 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2dcbca0a8fbce1580ae6b6b6a9ac027f3ef00928397d60970eef75643a4a8c4b
-        checksum/init-fs: da4b12af4c758cce2a27befd56e1ec5277c5f288aee2df3f7b717e571641c224
-        checksum/config: ea352af45264493d9e375faaf4eabd9e91a300e76b3096b8681ec1a2d2a9fb5d
-        checksum/secret: e3706ea7618fab2709b1846193597573b56c010c91baf88c7c8728505519ed1e
+        checksum/init-sysctl: b3650fe0a51d6e8c5340412848c333eceaf82f7a66cd981796ce2320f02cdd64
+        checksum/init-fs: 8b9543bc05b41f513a39428af1c1c26e079945ba60d714d0a925ac9cc9d426ff
+        checksum/config: e029e4ad0aad1861e6b1e23aafd54d1ecde0a99661a962a68e2e70fc118d344e
+        checksum/secret: 8fa9025911909efea48badc690a68ce043456e7a1412beea673b1d07af9761cd
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -650,7 +650,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -691,7 +691,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -865,14 +865,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9dd8dab83ea5b86f8a802654ab7a12702c93218a5211a3b39c3afb01957b6394
-        checksum/config: 7fccae061f4f2cfb300e994bde8597ce9d647a5403e96871a1aff43bbb58ef49
-        checksum/secret: 57dfcf9db8d09e9ae11c07233e2204aec8081da27e344c699c861fc62ff93f33
+        checksum/plugins: cbb34030209a8931234f2c0f41674a9d238774d54411ce2eb649587da0a9bd68
+        checksum/config: fb84ed4d21df1fad1009d886fdad64257fa4a9cdc249ce6d30483d2970e415af
+        checksum/secret: ea259faa3a48de50b7511ae670cafad85a1aeadf78f1c7149e57ca000f264334
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -580,15 +580,15 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f8b7a610b3d7803c7b045bd299f883f4c7ee9fb20810c24c57b2c8a8ece47132
-        checksum/init-fs: 6ae1ea076acdd7ee38d9fb1bd082670728da0bd27050a9f0369f80c3cf0a978b
-        checksum/config: 7fccae061f4f2cfb300e994bde8597ce9d647a5403e96871a1aff43bbb58ef49
-        checksum/secret: 57dfcf9db8d09e9ae11c07233e2204aec8081da27e344c699c861fc62ff93f33
+        checksum/init-sysctl: 3476d073a3aa5480f098f4778d620361268c1748a47fd165e4ea30f84651d0e6
+        checksum/init-fs: 151d5e35256f9bb9949bd48129162d85116be170013e527a485c1b4ab2af4131
+        checksum/config: fb84ed4d21df1fad1009d886fdad64257fa4a9cdc249ce6d30483d2970e415af
+        checksum/secret: ea259faa3a48de50b7511ae670cafad85a1aeadf78f1c7149e57ca000f264334
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -603,7 +603,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -644,7 +644,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -781,14 +781,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -251,7 +251,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 
@@ -273,7 +273,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -360,7 +360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -377,16 +377,16 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 823841936a4d43917854bac5103c53f915891dc3aec3b4d39c7dd64d2501cc21
-        checksum/config: 995f2482ac61b754b298b84578bad446145b9a1cec69bae6ff1c753abe573c4c
-        checksum/secret: 8ae58c5d5dd412a128f26d8089427acc484d209e2acd27412fa4062c5c01da4e
-        checksum/prometheus-config: 8d998144e7d260af3d53dbf61ce7f8cb0ca1907539323e5a03345a7794cf3ce4
-        checksum/prometheus-ce-config: f5bfd4e2fb13d2a7b7e55a6aa89c130c4d607a370b4ebf389f863ba2d97079e0
+        checksum/plugins: 74dc9870b152a4c4b864df96dbedc291dbaa9d61c3496207674be8758ad9b76e
+        checksum/config: 5fa2f5ff3e7af46a9cd554be170b3f1b21b7c977092b3950b81d40a05038ea39
+        checksum/secret: 36ca85a5a332e79d6d3a6c524c5155fbbafd998001d8d8e8db2d720825dfd9b8
+        checksum/prometheus-config: e57f2438f1bfedf4e95c1c187621450aee7c1c3997f567bc6cfc970238648ad6
+        checksum/prometheus-ce-config: 57b24b022a2847e509f17f717b39de27e0fa473f77a006e7945298d247ed9183
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -468,7 +468,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -502,7 +502,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -636,7 +636,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -645,7 +645,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -674,15 +674,15 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 91a2f56bf3ce8dc989a9512f4f109244f4e38ee065e90fcd6c3924f382e4fb77
-        checksum/init-fs: e9ce6377135f54261065f50bd304b4a217d55b8ca8eefbf9cc4da8ae253a56ff
-        checksum/config: 995f2482ac61b754b298b84578bad446145b9a1cec69bae6ff1c753abe573c4c
-        checksum/secret: 8ae58c5d5dd412a128f26d8089427acc484d209e2acd27412fa4062c5c01da4e
+        checksum/init-sysctl: 96d5d3a5150f86f8eaaf6e057cb48fc5c8b9e9f4e374aa51e848b229238103cf
+        checksum/init-fs: da3c2e41ef4f892763426067a67a2536be08ae00e49b269964bce4bec62f5abe
+        checksum/config: 5fa2f5ff3e7af46a9cd554be170b3f1b21b7c977092b3950b81d40a05038ea39
+        checksum/secret: 36ca85a5a332e79d6d3a6c524c5155fbbafd998001d8d8e8db2d720825dfd9b8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -697,7 +697,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -738,7 +738,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -875,14 +875,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 26b6a81690f04b0e0cb0782ac8bf295e0a77f5ae78bfebbd8bfabbb9a1f61566
-        checksum/config: a1b2db52aab4ae8c13ee70f109c91f3ffc04b6ea1359f2530a26ac57d093c623
-        checksum/secret: 54795c6f429e6617ebcfe7f6c5e14b7e90aba15d38847ee16967186ca357ef85
+        checksum/plugins: de1f275b1626ba2a4520e8d18014296225ac2f9a3c5b47c84270c1a8a5656ad3
+        checksum/config: 67932e647d637a675b38baa5248a3175a088f26861ee32f4ec848ac18d27773b
+        checksum/secret: 490ce24bc4fbdd4aefca52b7e500c6f1cfdf9834a2a7cb0cec45aebc0a7f4d73
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -535,15 +535,15 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 67175995df4e9c8b43d47e439f7ea23209e1a7c141ca6ba314671871292ce33d
-        checksum/init-fs: e20cc400888b9237e3ed6510c5ed7ca96248f9104d70926ebe182d7cfa40d273
-        checksum/config: a1b2db52aab4ae8c13ee70f109c91f3ffc04b6ea1359f2530a26ac57d093c623
-        checksum/secret: 54795c6f429e6617ebcfe7f6c5e14b7e90aba15d38847ee16967186ca357ef85
+        checksum/init-sysctl: b6ab7b11453f39c8e1f42250225b7cef85ee8f0aee6254ba1422cd8df9add444
+        checksum/init-fs: 2c3bd400da0059f11b8b8006147539132ed8ef4c2f4118855efdf80cfaef411d
+        checksum/config: 67932e647d637a675b38baa5248a3175a088f26861ee32f4ec848ac18d27773b
+        checksum/secret: 490ce24bc4fbdd4aefca52b7e500c6f1cfdf9834a2a7cb0cec45aebc0a7f4d73
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -558,7 +558,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -599,7 +599,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -736,14 +736,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -204,7 +204,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -230,7 +230,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -283,9 +283,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 3d5861a9f144f67dca4185f22e6ab027d1e63e85bcd3a8dc3517a1513f62797f
-        checksum/config: 1f277013a332d746852a06d93424a78313956bf200dbf442931919071d260528
-        checksum/secret: f622ea178bbf44e9c6a5c02f8ff111c809fa2189618de2dc24dbd360091902f8
+        checksum/plugins: adfb811156e20c8de3f04bf0259050e2233a7d636e0ebd0a2195b9378e81d7d6
+        checksum/config: ee5cc29b456032f9eec7eea44a6003e85c8538c1ea329a4030d6e8c85e334b62
+        checksum/secret: f2aa2020e15270576ae0b3a7028abc04a6e590390eb8aaf251d4d11d0d982b02
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -355,7 +355,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -480,7 +480,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -518,8 +518,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: 1f277013a332d746852a06d93424a78313956bf200dbf442931919071d260528
-        checksum/secret: f622ea178bbf44e9c6a5c02f8ff111c809fa2189618de2dc24dbd360091902f8
+        checksum/config: ee5cc29b456032f9eec7eea44a6003e85c8538c1ea329a4030d6e8c85e334b62
+        checksum/secret: f2aa2020e15270576ae0b3a7028abc04a6e590390eb8aaf251d4d11d0d982b02
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -692,7 +692,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: f9a9fc2cab78d088e4ee0b3c3f0805c6135dc5998fe16f1d2385727dc3f0377e
-        checksum/config: 49c558f8db0f1b47ccc1a8858405f1d3c40b9271b4c38bfc6049b0b092e55bf3
-        checksum/secret: 2b993c83150287d8647cf14571e49c1ab439c06d8f03df43e3ba6480137bbd77
+        checksum/plugins: 31feb3725a3b968f86b0c52abeee12601df0dae19b9dba861fdc04ebb1a969e2
+        checksum/config: e9cb0092ef8e479c06149a758a3589dcd1f2d55a9961b0c2c10033ad17ec8e67
+        checksum/secret: f331e28fd7b447331693e0eca0a4116e4e33e59d6c3a2d8a5139308b4affb926
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: bde350c957c2155969a39508bb7cd1c612c30e90a3affbd1e6068016d68bb2dd
-        checksum/init-fs: ab0c530e6c52abc86eeaf64f282e3bfea01ec10a6e1e5eb86142a0ddc1f87d53
-        checksum/config: 49c558f8db0f1b47ccc1a8858405f1d3c40b9271b4c38bfc6049b0b092e55bf3
-        checksum/secret: 2b993c83150287d8647cf14571e49c1ab439c06d8f03df43e3ba6480137bbd77
+        checksum/init-sysctl: e39a8d143b7d37fe57b253d54d15f685a4aceeac796160fdb00be85fc06e33c0
+        checksum/init-fs: 8d65166b06caba6c553e2411cafd77f94545b52224bcc6663bdb8afd25850c56
+        checksum/config: e9cb0092ef8e479c06149a758a3589dcd1f2d55a9961b0c2c10033ad17ec8e67
+        checksum/secret: f331e28fd7b447331693e0eca0a4116e4e33e59d6c3a2d8a5139308b4affb926
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -787,7 +787,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.3"
+    helm.sh/chart: "sonarqube-dce-2026.1.4"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -247,7 +247,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -276,7 +276,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -305,7 +305,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -336,7 +336,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -345,7 +345,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -362,9 +362,9 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 49fce9e12a2e49360d7779180295c2798913e19d7d0ebae7eb79a2f5b0c10eb5
-        checksum/config: c6335e32cccbd27b881f7c5c58e53c51510592bf6d3cd9feb6d6751005f9bc91
-        checksum/secret: 59894903adf64f7cab3743645f5c22c2e7db0aff30307d0685f603ff73bcdd7f
+        checksum/plugins: c6fa606aab21919f2dc589ec59a526f05ba32ecb6b460cba7d95374a0bbb4282
+        checksum/config: de77a85c3f823afe097c3cbde1b1cd6f9f6f285ffe0d5ebf476ba41009842951
+        checksum/secret: 4d43e2c364bcbe9ea57b9c03391d3a51fd3ecb6193112f76d55af27572edb971
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -372,7 +372,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -400,7 +400,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -513,7 +513,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -522,7 +522,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -551,15 +551,15 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: dc341a2cb7ebd8c6f02496e45160360ef45add04c919a1e1a555e2da1e7cfa77
-        checksum/init-fs: ff12a18897ed7d76832e6e0b82d23b8c1bbaea8ab954a3cab71c30bf75cc4aec
-        checksum/config: c6335e32cccbd27b881f7c5c58e53c51510592bf6d3cd9feb6d6751005f9bc91
-        checksum/secret: 59894903adf64f7cab3743645f5c22c2e7db0aff30307d0685f603ff73bcdd7f
+        checksum/init-sysctl: 3409389608c34c5b97cddc06d6516588ed6061ea8e9745a0ec8f580dc88665ad
+        checksum/init-fs: cbdab5d49e4416ec07da9ef1a984b26acde2aad9f9ce3809544bfd29a2cd1756
+        checksum/config: de77a85c3f823afe097c3cbde1b1cd6f9f6f285ffe0d5ebf476ba41009842951
+        checksum/secret: 4d43e2c364bcbe9ea57b9c03391d3a51fd3ecb6193112f76d55af27572edb971
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -574,7 +574,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -615,7 +615,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -752,14 +752,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -49,7 +49,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -63,7 +63,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -77,7 +77,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -92,7 +92,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -111,7 +111,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -124,7 +124,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -227,7 +227,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -249,7 +249,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -274,7 +274,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -336,7 +336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -353,9 +353,9 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4e73ce5855dc3b4e478b24264086ec46ab986ff571f5f2f68d1c21565aa900b5
-        checksum/config: a978ca9125b2af0e3f1b6085545921f07618c6d92da178f28bbe5c1cdcd3d596
-        checksum/secret: 8990a06b2074ee33b894789ffcbf3c866de2df50725901dac31c65a7a905de03
+        checksum/plugins: fd30ac28d24ef06e394b51a19b1fee36968be5fea1ab83b8a62e49df70e504ee
+        checksum/config: 06f66c15cac8e5b72edbc3741f5cb881c091f98c76591ebb983116c9327c61d7
+        checksum/secret: 496d6eee18908d8226f7b3ea1d5e8f096b05f7f329e94062bb94f57e28b4a4ab
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -363,7 +363,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -391,7 +391,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -504,7 +504,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -513,7 +513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -542,15 +542,15 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b6fecd0f82b4d0e953a56b798b8a757dfc759ccaaab0e868272b5e06ee5f45a7
-        checksum/init-fs: 4e3be764e09e792971754d1cdf8998f2b75dbe5f06b3d89a73c1815a57742980
-        checksum/config: a978ca9125b2af0e3f1b6085545921f07618c6d92da178f28bbe5c1cdcd3d596
-        checksum/secret: 8990a06b2074ee33b894789ffcbf3c866de2df50725901dac31c65a7a905de03
+        checksum/init-sysctl: 523501847ed67ccb1ecfced937a8ff3f911c633c8da77ba09efa86758292ffd1
+        checksum/init-fs: 5d833cc0be667c290ec1ab391910b503080c1a4233be766838d4c434855defb9
+        checksum/config: 06f66c15cac8e5b72edbc3741f5cb881c091f98c76591ebb983116c9327c61d7
+        checksum/secret: 496d6eee18908d8226f7b3ea1d5e8f096b05f7f329e94062bb94f57e28b4a4ab
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -565,7 +565,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -606,7 +606,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -743,14 +743,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -206,7 +206,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -255,7 +255,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -333,7 +333,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -359,14 +359,14 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 09d3e67d9a7dff3b2ef1ad14dd988b03dbb3ba3b5e70bee3e317e6382594d971
-        checksum/config: c114f08cb3090126c070d336ccebbd1ceb1773ee9af9e578e4e19c5904416fd3
-        checksum/secret: 8ff21f33cdacbd08c3707887e3ec940bced1e5dfe82b95327cb2768b28060b3a
+        checksum/plugins: e710bafe26dbe7c72ed0b910d0a9f01533f423a29310dae38516cc01aac35772
+        checksum/config: 65b1217518016c9ed283a0a2e6fcbef943bd1f8f6e139c07a61953f2df6127bd
+        checksum/secret: dc22630d26497260e1c25395281586a8aff554fb283624c6fdb668c2453e32b7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -405,7 +405,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -433,7 +433,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -558,7 +558,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -567,7 +567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -596,15 +596,15 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 42f71bc7f49156dc90959ddc2f3b8ad0c0c7037bf8db5caea572369d3602c69c
-        checksum/init-fs: 6fbfe2cdb5b8729f68d9c87b7b42b68ce8ce264c0604cf4716ff8cd439b5c532
-        checksum/config: c114f08cb3090126c070d336ccebbd1ceb1773ee9af9e578e4e19c5904416fd3
-        checksum/secret: 8ff21f33cdacbd08c3707887e3ec940bced1e5dfe82b95327cb2768b28060b3a
+        checksum/init-sysctl: 94db325c9557a24c0c13a6d6fe4ac7f5775b0aa3bed35b77a8064e4b6f754e4f
+        checksum/init-fs: c41b6243fadc153dda8d8a0bba03ab43bc1f4e2b4f1537305b84c191ea80498f
+        checksum/config: 65b1217518016c9ed283a0a2e6fcbef943bd1f8f6e139c07a61953f2df6127bd
+        checksum/secret: dc22630d26497260e1c25395281586a8aff554fb283624c6fdb668c2453e32b7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -619,7 +619,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -660,7 +660,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -793,7 +793,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -820,14 +820,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -859,7 +859,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.3"
+    helm.sh/chart: "sonarqube-dce-2026.1.4"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -879,7 +879,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.1.3-datacenter-app
+        image: sonarqube:2026.1.4-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-app"
+    app.kubernetes.io/version: "2026.1.4-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 21fa551cda2193b9550b83cbf03b6dd55d3c4c3b45ca95ef71b68838d3de5524
-        checksum/config: d344d57eb7753b24726610b7b0f4ed421709606f6ad0fd4a1458df12f7c73412
-        checksum/secret: 99132701fe7ffe19da74db105fa04f1a80d7e9ddb36f341ec8eb331b15d43440
+        checksum/plugins: 9ec9a898c96cf180e36c9b6861ba1d3a771739c06165f5c46a3d7cc9f646a7d0
+        checksum/config: 97bb3e24f6dff5ff428ac02d3c2ae482b8518e9c62fbfbe73c633fa8b9ce303b
+        checksum/secret: 1de28650320a9e4f03b176d90d681aa482e75e80a2f9dd319217fb44399875f9
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.3-datacenter-search"
+    app.kubernetes.io/version: "2026.1.4-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b4b62057f414e57bb86c023f82513128737b1d4be93b3043451ec836290fbee3
-        checksum/init-fs: deeb0ce9f77032275c61a25bcbd98be2ffe7e19af3173b4ad3256155882c26e8
-        checksum/config: d344d57eb7753b24726610b7b0f4ed421709606f6ad0fd4a1458df12f7c73412
-        checksum/secret: 99132701fe7ffe19da74db105fa04f1a80d7e9ddb36f341ec8eb331b15d43440
+        checksum/init-sysctl: aaebe005dac1f9842f29b0243776a7c568c8561939ca97636af95d84cc202513
+        checksum/init-fs: bf580aa45991d7001f89fe990ef81e50fb9c095bedf50ef8a22254356b841011
+        checksum/config: 97bb3e24f6dff5ff428ac02d3c2ae482b8518e9c62fbfbe73c633fa8b9ce303b
+        checksum/secret: 1de28650320a9e4f03b176d90d681aa482e75e80a2f9dd319217fb44399875f9
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.3-datacenter-app
+          image: sonarqube:2026.1.4-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.3-datacenter-search"
+          image: "sonarqube:2026.1.4-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -744,7 +744,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -771,14 +771,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.3
+    chart: sonarqube-dce-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-datacenter-app"
+      image: "sonarqube:2026.1.4-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -810,7 +810,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.3"
+    helm.sh/chart: "sonarqube-dce-2026.1.4"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -830,7 +830,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.1.3-datacenter-app
+        image: sonarqube:2026.1.4-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -151,7 +151,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -159,7 +159,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -171,10 +171,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b277c1d01bae042b1200857d01a34a059dfca9ea76e9389be370c7e7d479ee27
-        checksum/init-sysctl: 27409e284ca8926c813b00eff8a7954635c79fad91aafe014e26cf6cda6311fa
-        checksum/plugins: d4c4074bdaa5576c294de091a70a6cb2ee0801b9a9e0e40791355a6921c598a4
-        checksum/secret: 181d71db109aee5bdf65c2dfff2a612aee5dcd6a75df580d5c4cbad3ed9072bb
+        checksum/config: e484e6d83f8b5aac4220b085b0fecc5f28dec488e92b00fd051e1e10ec44094d
+        checksum/init-sysctl: 1ea9efceb03dc124f208903102eff2e009c4107f2898694f01d7c3884e0a5bc7
+        checksum/plugins: 2add927c8e9d31dee88962e2f4582dd839f42d8c55e2df9898a4eae122706d5a
+        checksum/secret: c5ad8cf24da0eea9e8f4e48c0de4411ea755803d0479ab6e4efe838317f5d42c
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -184,7 +184,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -213,7 +213,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -231,7 +231,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -264,7 +264,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -403,14 +403,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6bdf92346fc4055a5b358fb215a6788ec3cc021f1eae59562afc41f4ad97c27e
-        checksum/init-sysctl: 208fdd8b81f0d93bb6279386b4c1ef0e9d6a30d647b1c7f27907f9a1734c07f3
-        checksum/plugins: 078293a42fae448310ea7169177ee98f886bf06a88bb4812b9955dc727774c95
-        checksum/secret: 150db6c9c6fed564d0561a8b221038aeb3c7ec37405fb990aae3a508aac00d53
+        checksum/config: cdb882e56e86e30d78b892577d8ae6eae5de8ef8040b4d7680afd813ad5d64af
+        checksum/init-sysctl: c4e5ab441ab91dfe97e9e4a161f13c55950c294c1810b73c42991b287943b54d
+        checksum/plugins: 4c2659b753fbace8953412180399a90a624ea5aa52d0973b98676cc1a51ed732
+        checksum/secret: 3acf66cf454ea240d5b3b47133e74a3ca6ce681ef755d919988a1b12fdca7525
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -197,7 +197,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -216,7 +216,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -233,7 +233,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -338,14 +338,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5f360ec62b17f5f76b15a6d2be91bf981cde41f6e2a3a0a8a75cfb0d58be1e19
-        checksum/init-sysctl: 0c1d21743cd71292abae142300c11da31d6820efe4f772bc4d0e933b3d19ec1f
-        checksum/plugins: b7d8cd67e64d18eb06912f1736789650ad0aba3a6327808207124ab263b5281b
-        checksum/secret: 200f0df81c74dda274eee99cc6ab9c52176563eae84c1ed9aa6ea83cdc1f4e26
+        checksum/config: 16c661a22acee0152c1e2bdf3c7ed9d96129a3e47e04959d12dad4a33a34e3ee
+        checksum/init-sysctl: 0f9c520f3342019d6b243ba5d36e609a61bdb36af5e01f9ffdfa6b70b0a0c5ff
+        checksum/plugins: 2f06c0c7f1e0a5097a03689cf209079f2d5395610a3265d956b1876e7a348746
+        checksum/secret: 9f9ae03b265ef3e55e4bb11005476fe50f3279ce07db787e1859dd9d461c8d93
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -357,7 +357,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -370,7 +370,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.3
+        chart: sonarqube-2026.1.4
         release: change-admin-password-hook-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 61bf16f549ecc9fd7c750d022eb989b2d8ae99bc98ad5c5118ee1003e3d9dd11
-        checksum/init-sysctl: 14161ae5b1709fbf13714e56849d981c248b578b7c04253d2abab270d00d776d
-        checksum/plugins: f4ea0b07a72f1bf63029930cc998aa6457ff181d51173cbaa1267ce5f62106a4
-        checksum/secret: 2abe321531d95163d6fe5aa08abbb60f06212ddd31965de29887cc7ea10581db
+        checksum/config: 5f7828142b68b5912f9a4fd6b47935da812536ac57a363f5731b47a0af90057e
+        checksum/init-sysctl: e59f1ad423d5adc40944ab64149583cb930830efb31e5c00534704feb4c2b705
+        checksum/plugins: ff7f2a906ffd797d837be98676b033e9495129d8e3a7bf1e2b2dc0dcdfcb09ab
+        checksum/secret: e9c99b2febc2e819cdcbc5622aa5039d6ae2536da5d46aae499a9dab0976852c
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -58,7 +58,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -139,7 +139,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -159,10 +159,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 885de9e0d30d939502d59d7f2ae1d6d185eca283cab7d9bc2534224916c391f4
-        checksum/init-sysctl: 79119ddc90a3d18fca46669cda5c635e1b84ae638eb7650ac3b3f1b04a9672c6
-        checksum/plugins: 05b96be33c9384c398ef3a86b24f1daf81a7662d678479509a5ed62f76c5dc46
-        checksum/secret: 98630c79ec9f169170e6e1ce38f2f02734c0f4fa7a486e058b80c1e0cebefbd2
+        checksum/config: 1bbcb84dd061cf9617ae7ca5a22f1eecae50a6ea56e7c3f7c834b5542aa3b87b
+        checksum/init-sysctl: 0f04b1a1ef388b73c925db8ad7f907ca66f181ce246de3f21888309e09a474db
+        checksum/plugins: 095583772fa206df8e3b7b200c0b2a5c26f6a72653e95cde7dcdf071c9abaded
+        checksum/secret: 8a3ec750b2ebe2cb1249e4ea0d3d7eb34a7f4552b1f66caf7463251cf4145e00
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -172,7 +172,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -190,7 +190,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -235,7 +235,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -252,7 +252,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -384,14 +384,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 80c7b83d78c010e39b130d27b4ba8e8b84a9dee790dd58551e0234e6734ee71a
-        checksum/init-sysctl: b5a32528b812488370906bebf858d9f74223244911cd9b2e20944ef74e0ab4b7
-        checksum/plugins: 1f3478bab3b3563c9f97d20dfaa58f13f9dd50bdacfc2e8fe4da15c11a2383b3
-        checksum/secret: 72f9cc42aff9a09dba234cccb4ba3e25c4e4198440d6fb41af506eee7440ee6a
+        checksum/config: 36134281175487352df708c3bf236afe1a4e296c850142b4c2726893e6b12aad
+        checksum/init-sysctl: 827530b13c3f2167c2c2b880d6b9102836d12c933c0ee707afbf5fa616453118
+        checksum/plugins: 5b51e2afec055a9be7b93cfcab854249b71067e8676771763ef4403616d4f053
+        checksum/secret: bb4d7bcb50a7b9f1de387cedaf8dec5a85aac1fdf3ca98e830905419894a079e
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3ed22fc843cabe9bc6c1f601f8c7c2b785b6acdbadbf92e8fe56ee8cda2f6426
-        checksum/init-sysctl: c52931382a7fa39ac2db1065acf3645bf2ca9afe79a8d79d00b00c23a27c603b
-        checksum/plugins: cdc42c873a7b417e94ff7e8ec1192e5f964365b47862e7af61389c030b13214c
-        checksum/secret: aeac5afc2d76154967c7174ccfd5f67249a049aeaecab6f698dcab108e2df4b1
+        checksum/config: 7af4c3011d3cf0568ab88f08cbc3672f3a018c254d0c82c7cad412df0e280efe
+        checksum/init-sysctl: cd44574fb6d0200c3212ce574a566a5974cd39bd7e40a190cdd2bb9770ac76df
+        checksum/plugins: 3690f40697b2ff3c96dd12f222c8fb67f9c42b86b1c3b89628b30f51d0195515
+        checksum/secret: 8eee94d8449065bc67e0ee6d2c78e465d76824d64b2bb2baa8d1d977f542f3d3
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,14 +306,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -156,10 +156,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a1c501f8215677c97122ce55cf70d185a389782987f1098c9d524d5d9f5396f0
-        checksum/init-sysctl: ea75c63f6eabd1133d9f3f3106ff43d83927ebc7a3a01913f31b34d6ad972afe
-        checksum/plugins: 5ee8d180e2a4007bb4b57f5a7f8c3ac7121977de1dd8eabecdda35304152506a
-        checksum/secret: cfc2f64f887f8dbab5f379fff8e1f2052f813caecd0656486ac07b106ae808c7
+        checksum/config: 133d16e193ccf16bc2ff04f6304e05a22c806ed5a1848226114ff4f2d9f6f03d
+        checksum/init-sysctl: 77eb85e860fc60c9b581efc6cd48e134de49249bdcd2f7ec18937521a5170387
+        checksum/plugins: a611af9ddc46323d06847709c9d64a682b20f07041c408d714732e8028c980c6
+        checksum/secret: 183ce4c0081393f55c0cadb01c00f9f322b1ed5caad0994216d6d7b79a1283bf
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -169,7 +169,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -188,7 +188,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -205,7 +205,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -307,14 +307,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: deployment-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -165,7 +165,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -173,7 +173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -185,12 +185,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d64a50c828ddc36e1035994a2456059d790bfc70c25e8318ba6c78a3ef2c8dbb
-        checksum/init-sysctl: 5ad274d461f804a44100cdd97625ea040178bfb9bfe4716222e3fad1452f9baa
-        checksum/plugins: b85227fbbb17fddfbbf715993cf896edfd7c5b689e1c8f101f690021f0326318
-        checksum/secret: b0c4721a140f3a097e1e6df1b7d3705001966961a697764fe346cdf48fd2100a
-        checksum/prometheus-config: bcc5e08c92d07cd269159d05c167a4fcc75988686f2933445f4205a9865d0106
-        checksum/prometheus-ce-config: 8ef8b6f7e0e84402538780d65ee21d3cd469655dc518bb18909e63067c4d63aa
+        checksum/config: ec5a71d3ac99ab227991644bac78917fbccfe829d2a89dd3b7e5b842f4215447
+        checksum/init-sysctl: b6c12b84c394545e0de7cf70233c16b1eda3e8a0b854a06fb7c148025c61623b
+        checksum/plugins: bad480f01975e43238e182aff69eea145b810fa485a52e5b56a27950482eec7f
+        checksum/secret: dd21657435348856573667735f3a07aafd303639f061c78b5d9245eabe75a339
+        checksum/prometheus-config: 89b5d6077e597d269411d76ac18f90aa39d3a2ab4fc6a24342169651c757b55e
+        checksum/prometheus-ce-config: 8b190a6284a628bdc939cd1641d72ba0ed10db363bd33fdc90713cd5277dceee
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -200,7 +200,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -275,7 +275,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -298,7 +298,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -425,14 +425,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
     app.kubernetes.io/name: host-path-values.yaml
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 21dfd99ec60b9e9724fd98d3876d20ae0763f9efd63f3b6959b3010b113b81c7
-        checksum/init-fs: c56fbc410eb74315d770ea131297f5d3055b9df35b1ef28e63c8b57f0e0ebe17
-        checksum/init-sysctl: f24e5e0a2f5c1fbe61e0dec190ee1b66c42441b4ad4a730bdaf03690fcce8ab8
-        checksum/plugins: c4f7e3515fbae6f4791b5a6fa88804d95bc74a6976f2f7aac216d57de988127a
-        checksum/secret: c50f78498524046b9fd7654e5cc2e02ba2f60c9288cda761ea5e09f168a42773
+        checksum/config: 28af61eed790c48a283edd08ed25eedbdc247dd9c6928239b588f8908989a771
+        checksum/init-fs: 96c0fdeeffbdc6f0379dfc843a3bbd9f7930425426a25c10887549b6cc679b41
+        checksum/init-sysctl: 3a9f49d68e4a61692c8774927afb6a9ea0772f61dbfd3612267eb43d0d1e6eea
+        checksum/plugins: 4ac94f627b5d2cf18eb902f21014c79793ca7e4558b4a43c5ad7ef3eb818b357
+        checksum/secret: cc29da434371423af18bb65cf95e4719bd503d808ad5596a849a6a4392773487
       labels:
         app: sonarqube
         release: host-path-values.yaml
@@ -272,7 +272,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -381,7 +381,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: host-path-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b31637379c8a2b51c7fe253b88fb5153945cc5bea373be25705eccfdcabb5234
-        checksum/init-sysctl: 97bba6c2c4c75811a275d529825eafe1ddb137b8745135e4b22817cfe5b7a1db
-        checksum/plugins: 998c9f52b2727c7d8ddaf99fbb425d81ea1775dbe3457ad9575a32a890d577bf
-        checksum/secret: d46bc21acca393a5a517880405f4caf0754dd118e1b0697cdf77c844d0a7b980
+        checksum/config: be5fc560fb9ba84e55ed83c994c938d21e0fd337f326026d9fc28cb39038536c
+        checksum/init-sysctl: 023b13968b331a34bd0e6d66cbd83ae86afb4d180fddbcc0fbc03fc208b2b91e
+        checksum/plugins: 9aac5bb1b0860763beeec75a9ffb4a0ff42d0aa5432d45ad091138fd23bd8cf7
+        checksum/secret: 31c00c68c8b83417eb7466414b52a4784c4a2fb904c5830de519899384300ba2
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -331,14 +331,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f7caf01a3986704a99d123d8ce0b21182fd3ebaa733c38ba19ba093039742f4b
-        checksum/init-sysctl: 7d23ad386aa5350193bc3f481f587a5e8df139a6ec71f056de6567b02a5e130d
-        checksum/plugins: a94aae05456651d9df7385fdc23b76bf4b4f0472c072123be68835a3f66565b2
-        checksum/secret: b5f7be4161d5f7aad2d3f528a804717806642bdab3e51df01119d2831c2e2dc8
+        checksum/config: f81697dc9f19790b440884d0f547201f207981610968e419337df068b70906cd
+        checksum/init-sysctl: a295d0e39f23c878951a6ae5ef9c5f38a8e623fdf2f620ddcc4a2d9d77635eef
+        checksum/plugins: f1f42743896b6247a0c5015bf3faf6d52ca4ebe0f5227280a5e2b6a39a17df0b
+        checksum/secret: 2a5e42e341e99aaaf4259dd832223207c1d5b7efeb60fb85c73970d3b220bfc2
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -332,14 +332,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a372746ade4a434a05451ab3d9ce669ddb98b3475256cabb725efde16645e052
-        checksum/init-sysctl: 6db305165b5d53b77a8ee2e304acf857fc3b77e5cc7374b20fe153bdfb061df8
-        checksum/plugins: 49178a5be508b34b151d6fd965f980dc7b8c08b0df7d5aa62638d1de03335377
-        checksum/secret: ece9e698dfc1a9172ddd66cbb32b6541dab1f9ee54696666cefe3bc75a060c62
+        checksum/config: a01581d83cd99c916b7f21e16569205d39f4f07a42effe269111e4a9790d2085
+        checksum/init-sysctl: a64df8283cb89031e0caad29542b293e15066493b6ae51cb5c9bdfd8455777e9
+        checksum/plugins: 55165afcd2989cb95f1342060693e1e48bff544e33c6554c888da5a0589098b3
+        checksum/secret: dfb103e9c30c55a82927f6b877f2dc321791415f8fe852088d91c532acfca0a7
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -339,14 +339,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -73,7 +73,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -430,7 +430,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -577,7 +577,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -597,10 +597,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 23382e5980f98fd75bf627811824a969841a3bdf154949b9cea78f050468ba2b
-        checksum/init-sysctl: a0809bcb6637329f8ba7569630a5459bddf48c6182a788015b69273f5090f1ad
-        checksum/plugins: d2a76c394d3573ade38feee79c24d5ba7f658cccaf06494119d798c200a137c9
-        checksum/secret: 1a7ea4276d3d409c6b40063e42748aa45253e5ddadaa8388e7701de8c46e2375
+        checksum/config: aea0424b29adeb587362915debaf72a5a8e38087af0405369449231025ae2f15
+        checksum/init-sysctl: 38ed0afca52a973f0e41caeb8fd8104c609f484b04dd8d25e22ec23f74f78939
+        checksum/plugins: 4a3b03e4798edb310f61389c2a5df245a1c828941048e5d3d796b91d71c24a89
+        checksum/secret: 29d826072ca6f0977ed5fdccddd1df86c8f8c5033ef56a17ed6e8d4202ffc17f
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -629,7 +629,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -646,7 +646,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -962,14 +962,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dc661a541df8a57a61ba09ddfe165e97348bf0ea809e12099b4bbc5a82ed1639
-        checksum/init-sysctl: 62c03b4e36d1d1bbc9f966998d9507d931c4bf2501356329b94792100a5fc56d
-        checksum/plugins: 5077256b84a950a27cc337a71ef75dab8cfcd3e5ba63b55d1edf52568e711557
-        checksum/secret: 36c18e2bdc1fa9326dadc286af617f3ab7600b50f887592f57eb02d6e22860b3
+        checksum/config: be6a65c0914f61eba898287c66fd696ef5144f6f8293177c27ede440d59ec094
+        checksum/init-sysctl: daa4850129e4918bdf2ea55353a9c6aeba4d7f9f162104f61d44388d2375c61c
+        checksum/plugins: 108a1cbe30a2edbd156a3941d3b08c89a546cdc34a53a7298ea3fbd5a01d7092
+        checksum/secret: 77fade6354fcdca5245707151ad65d74a7b03ef8722f9494c1ac8b204db3a7ba
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -35,7 +35,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -162,7 +162,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -170,7 +170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,10 +182,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: eeb9d8b18e0226515863c77f60f1b72a47f757a56cfab64ebaab78f7d1f5cbf4
-        checksum/init-sysctl: 7f8d4c2d58deb54d04188334bd2eb64b6a025a9b81a0b6f9e31f0be4cddb093d
-        checksum/plugins: 91b4ee72fb3f71d12f12974203da6d961cdbbfb3f43f3f7314465f9753a445bc
-        checksum/secret: 7eaaf559d408d10420c03aec5e8dc6566c7381fe219d14e0b7d6589349749ef1
+        checksum/config: bb29de0a692bebc9270905deaf6cf1b286da25b8f4edefbf2c0fe13fa1bcb74e
+        checksum/init-sysctl: 0f530cfce671b767be0ab26520b4a40367237b15ac63b3644d5085e5db8442ad
+        checksum/plugins: d16986a891c01233e5358e3e5dc78dea27ae3cd44baa3c2943d0c1ce5ba79088
+        checksum/secret: 9d2fa202d72366826d57228f2aef2aa2e5ee6cfc2a9bd3a22feb438337bdc3bd
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -195,7 +195,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -214,7 +214,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -231,7 +231,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -340,14 +340,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ebbc39e4dd1bbc5182a487b455eab04c341b48659f1a71d26375631157fc41bb
-        checksum/init-sysctl: 73ea7bd8dedfd54ded7ee65b1cc696fcb89d7747b1a7b6cd6c4f2e9fa168cf1c
-        checksum/plugins: 7c08d353b0966b15ff9284c906775fd98cb9d14fcd71fe2d435ccd631e4e7fa7
-        checksum/secret: 321d9fee45bd097e7824807bf4ced9ffd8e26d958a7988b3e10301686639f526
+        checksum/config: b6cab209ea0ffc373194d7ad08969829b28258b48a77f613708907bdb32ae81e
+        checksum/init-sysctl: c093a2d17dbade1bcd08e1087eeb8fd8622e087ceb400d8a79c889e9a8a7e2b8
+        checksum/plugins: 3a67fee3a044940d9ee238693d3419886012d9a1d11b1eaaf61fccb59fef75f0
+        checksum/secret: 4d7d888f9e1a50405e72dfee45ba46f09f90149ed8a6ec5ca6be505cd3c26991
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -249,7 +249,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -268,7 +268,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,14 +387,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 36aca0f9d727fa47112ef50de4e5b486968a389f2d6eab02814179707df37af1
-        checksum/init-sysctl: fe58fee21d1b7468b4a8d0a091adc72f3a1b83a8b971bc0c54ec091f9d7d102e
-        checksum/plugins: 88767e2a95811eedd345beec6adf1cee463d8dbfb45670a93ec6b1d169e54cd0
-        checksum/secret: ee0a9e32b69d07dea229b25cbf94bc1b294e0c5a04e4aa6e39b778fbd7033e01
+        checksum/config: f0b197f3d03b40d9dcc01ec8868713c592f8f05282137eacc7bfa439c02e8b77
+        checksum/init-sysctl: 5cb0adf53b883f2278fb460785d984651ebb66a9d0debf55906307152cd8ffc8
+        checksum/plugins: f0c4fc0da2021c09cdc2c48c20496e7affe80c6fa66bd4937eb9f19f8fbc7a41
+        checksum/secret: 39213f3d03e7ec43d7357b5f10fdcbe755bbb75e945e2b25a83dfdc5f2ce81d8
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -249,7 +249,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -268,7 +268,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,14 +387,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -182,7 +182,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -190,7 +190,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -202,12 +202,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff51bd07c0543abb50fba1e972677c57c52ae66da579372d195c49e3dd6de382
-        checksum/init-sysctl: bf2a9ab6ea537675ac0c68ae123aaec1894d4416962c2863c379d723fd455241
-        checksum/plugins: 43846f86c31f8bf16e8dffac282ff22e3e450ce9ca2dbea614071105e54e0b67
-        checksum/secret: 62d35962cb62edf0373efb090085d654694e42e881596371ae8a6b97d8bfc180
-        checksum/prometheus-config: fd796c3699673f7b384f8f73a145b3e1f39f7a779080567e4fbb1f915ee810d8
-        checksum/prometheus-ce-config: d32466ed52746b29c250a90a459ab37e98bbcea6851fc67f8b8455ef4ba394bb
+        checksum/config: a1cb9e04868de64e6ee0debf73a7a7dcd59e7d2501d36759b74b2b54b52111ea
+        checksum/init-sysctl: 351743a9d9472b482a1d2c304afea1a92add11e782268b1e32f4997e38df3994
+        checksum/plugins: 3d676d10ff5129bd6ad7b647a86b946e517e9967d3bfc05d19e9b8fa20593861
+        checksum/secret: 1717b9f221bad4363e44810bab8997ef8b2ec4c7177ff391a92a17b8001b583d
+        checksum/prometheus-config: e4364fa3d85ea37ecb6f1946cf5cb18075645bee6ca7f16b2824b7c25bccd834
+        checksum/prometheus-ce-config: e645780b9b145e0ec5d98d2e6a841930abf29ea2fbc1842682150169305d42ce
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -217,7 +217,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -235,7 +235,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -277,7 +277,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -321,7 +321,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -344,7 +344,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -470,14 +470,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -507,7 +507,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -520,7 +520,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.3
+        chart: sonarqube-2026.1.4
         release: non-default-security-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -108,9 +108,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 990d3e1161339df2a077c8b8d729a267a90fa36fd8dd90379e57247d3894b759
-        checksum/plugins: dafb83fa1c5c62da2a25b6bbddc8c6abae8a410d7c1bf6d9b075ed1dbbe75844
-        checksum/secret: c9e6a606987b071ead34b8675ba746a04d516e1983886e2cbf9b0bc8fd4162eb
+        checksum/config: 2b65f76f93c2bf1654e07be60085053793b32d2064340b33c548d215261d9d00
+        checksum/plugins: 51cfb6cbb6fed3c0ceba6bebe79e87f926405361cf9cef6cdd0121e5a76118a9
+        checksum/secret: 07c5e8542569e7493dd1b76973c86376a73babcd3f0e5bb9ea7f7373618a2f19
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -121,7 +121,7 @@ spec:
       initContainers:
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -138,7 +138,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_WEB_SYSTEMPASSCODE
@@ -230,7 +230,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -256,14 +256,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: openshift-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1bc456a142ddffac8b3aa475c498f592dd48d178115f83a771b78e99b991c0b2
-        checksum/init-sysctl: 59f083c7022129eb33772118f1160db690d01ad5db2fe19c4a11a04a25d61a41
-        checksum/plugins: 2b6eae188239acbb96c452ea35e239ba1160778462ff0168dfa690bbd2e97347
-        checksum/secret: a559b1503320f18cfd80906a4048e406d6bdfd42761468b8f4a11da451b1a123
+        checksum/config: 15f9d6f920f71c0867818336c2e23a0b46b613eaf13227b3c9eb075d52331d27
+        checksum/init-sysctl: 09a77ddb327d2f54433c76410aaf78232b97e20c70d11680d2f8e3e1703b89e4
+        checksum/plugins: 65afcdfa56228cc3a2e6231b5d028838f8d4638f869ac0185c42135ea3718dfc
+        checksum/secret: 5c905968ccb0047c0e695066bf5bc046c22ca3e4e58f76f8574f3aee9f203993
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -333,14 +333,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 600da396211ef45bdba6e678b5e960deddf733ef7c213501f1bba6d307bcec9d
-        checksum/init-sysctl: 274c7b498906262d52681739a8f667eaa01499a3cf9b8aa5ffd552596aa8fe2e
-        checksum/plugins: e4705f2efe74237869cec532cc4398b1036d736d6d8628670bcaa3ad2c0ddf80
-        checksum/secret: d4652be0570d72145be886fc77faf1b2a1bcd408c75f007219de7a06f5d1b515
+        checksum/config: 116e660f2e10ca1bc975210c3ef1513fadee8513380396f08dc53a2884016901
+        checksum/init-sysctl: 8a1775fe4d538e80e0ceaeedc4d8e90d1bfaf7e23abe40863bc4323c593d8629
+        checksum/plugins: 2454921bbc2523aa6e06df330b407205f8229cd2c6feac11e4122aadbe6b2ddb
+        checksum/secret: 50f16b1c4a95496540975f0f32e1efa32350148c866b49d950d12d84fbcd0435
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,12 +188,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4192a11d61929987198f1791e329171a5f8404a0434ca6209e0ea4995f1d2067
-        checksum/init-sysctl: 71b32cd45a23cba844b44ac6236ba8d949f4f47309c6cb1f56353c5a6661e449
-        checksum/plugins: 534640a91aa7b909a68cfe1fc92da2bd50a16667856de49d2049feba396d0aea
-        checksum/secret: 548d2f7820f224ac7323aad425beb87aee51ad295d56d489dfef1e2bf39f76c1
-        checksum/prometheus-config: ce654ee769c92e872b06536b5ea3150ea9b9a026fe9e28a9b7bd475f18efa1e9
-        checksum/prometheus-ce-config: 6436e164605f2a90e7347d82a6ef02e46e4718f8a876ce36ea47b24e3544ee21
+        checksum/config: b11a222bc863be547e19ed9d0283a717867a11866674fec00f8e78280993c4e0
+        checksum/init-sysctl: 23abdabfe41ca276aa087ed8272cf2780326b9ca8c656788c028bdbe67ff8f03
+        checksum/plugins: 0f7c96ab8c4278a9913cf07947a7d3b3333bf9f2b332c19545eb389cbcb328bd
+        checksum/secret: ad56972e8fd1e61c80bb8c42fb58368ea5473ffc58cf859c51d39a4baf227e90
+        checksum/prometheus-config: a8b2e75bea71e717013dff459c7fe94109821dc35582e7a48230074658278beb
+        checksum/prometheus-ce-config: 524c6c58911e207459f06b15f7f5da51123a7a14a099ac79ccfd8ceb6fad0768
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -221,7 +221,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -263,7 +263,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -307,7 +307,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -330,7 +330,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -456,14 +456,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -149,7 +149,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -170,7 +170,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -190,11 +190,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 694c505142997bc69ace9a092fb630ee7838f71c225fd068c7dcbae64e0de709
-        checksum/init-fs: 32789f38d9aa026713ed0e91a1c7c7f2e337dd8ee8e16a25b709eb9163671abf
-        checksum/init-sysctl: cf05952fee1a8a5afcf5d4b1ae0e9ba8ccf78952c62b0a87c738f858384514e7
-        checksum/plugins: 2445b08f26b8edd7f8e71b146eb862785de6009758ebaa5c0f29f71ec0e3a947
-        checksum/secret: c900168136d1e2d2a80068c7ea6f223a4d19407c4c2cdae332ec2efe020c2248
+        checksum/config: 88d28990d3ba50b00f64eca03947ef85986ba197191f421b36fd1e6abbe97b32
+        checksum/init-fs: 37844a232623b76d5ce4649c26b8c864edd1b10f00f869e5d8978b58185d6241
+        checksum/init-sysctl: d694f2f43192960829fd86163c314044839850560785f1569b92ec95267e9ecd
+        checksum/plugins: 55e5ca5a89638748ece4e19025362df20e0c4d8df11e3d5583b6e055f6ccae6c
+        checksum/secret: 725632cc5379b40a69c8a98dd3c3033bda4ab69f8c9593947310f8393c1822fa
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -204,7 +204,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -222,7 +222,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -257,7 +257,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -274,7 +274,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -382,14 +382,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0cd9694ba02cfe7f62096f484f960595116a9a38bbb2d36f33a316910174bbbb
-        checksum/init-sysctl: e00b1a3c60197af4438d41858a563054c3a4cd97631c584ce03c04f3ccab7f3c
-        checksum/plugins: 906166ccbdd9039c4aa72fc656f4bb63c0630029c5e52062a102f68e1b4e4067
-        checksum/secret: 8ce5f56c4c0cc708328e5c7ecff964a7b854dda2d837f438eeb00273d1bfbacc
+        checksum/config: ca0bcc626a5674c6c2892c7b01c2618098707ab031921901ea0933981b6e3570
+        checksum/init-sysctl: 59d7a6b6f98b31a35dc3e8926d92437c45ccf7603130ea8efc61a73ef2f5862d
+        checksum/plugins: 6e04e2a1cca1d39a521f4eb9e2134d9b27140892813d5bf07e865b927c63c09b
+        checksum/secret: 8e27aa118bbe3ef412c882d777cde7348e1d48016f95bf109fa89d09c980df1d
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -357,7 +357,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -370,7 +370,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.3
+        chart: sonarqube-2026.1.4
         release: secret-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -142,7 +142,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -162,10 +162,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a7a842da6ddba06bf057aaefb94d3f9326e4b65d8ca6aaa3c5c6e416ae3acb2f
-        checksum/init-sysctl: e461df7e48ce0d5441b59e26bba9c3bb5b29a24a32bb5a868d7f3bd06e3c739f
-        checksum/plugins: f6acb178bb0e70493b0bc1d4133c6baa77cfe9b4a7d4c88f207b97608a503c6f
-        checksum/secret: 520c085fd0a1dc33c4d11b25787603d44a49140c317887e56a3ad2ba7f83c748
+        checksum/config: 526b2f18f14c13adaf71098ebe0e1875341f0c0bb25ab46428a22b31db08b44d
+        checksum/init-sysctl: 7c854ba78fb70358a921ec7e4aee3b94ec396b61e03e33f4fe720f6fe1047561
+        checksum/plugins: 16913f841ddc68e6cf448c40daf7a5872af020cb781b71b4793ce84139a801b2
+        checksum/secret: 7307c08a6df581609e7601fe07f573ebbdb01f9c5e88ddd7623598ded77fbf53
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -175,7 +175,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -194,7 +194,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -211,7 +211,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -313,14 +313,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -21,7 +21,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e712ce9a4f6a1957dcb4bbabf46628945dc5cb0cc15205d822d40d5c40bb3cc6
-        checksum/init-sysctl: f293446c0691535cf5d9c33a006087f03eeb407f64033d20643da93780fee4b9
-        checksum/plugins: e0a7a8c75d771059da0211f19a94018c147604551cea32df003abaab51036d77
-        checksum/secret: 6a17dd02caba9ebf99feb2b404aba964d98288996c62f774270336e13c46c8ea
+        checksum/config: daca8654ae3dab0652a373a3882b2e7f7f4d19b1b61b3b5fc67bc50a62339148
+        checksum/init-sysctl: bae04d11e5c17cea756c5057c5005c363a4a6011656b00a5982cfe9d4c13e3a9
+        checksum/plugins: 758c02457271434c38e410673d33fcb9b1995440768a87b0fee36ca8d09376ea
+        checksum/secret: 3e62eab2c467d9b93a7ab3561cad482c3c947e31db6e6c9b5c6205031051848e
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -170,10 +170,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: eb67ad2b67cd0cc5d6f9b1f2a5ca6dd49e17a37009ea3607a0e0122f3fde3e73
-        checksum/init-sysctl: 6edae00dca1cb0b1d6aeb6a22f6e0e0043ae2faf6974865f55a34e1c00bd08ac
-        checksum/plugins: 528adbe50181c77a300cee7b62ee84a135ef8651936ca39463933ffceefd490a
-        checksum/secret: 3b285404803ca1d4830e370e68f7ff9efb8563d8f9cd49384241c4a2272fbf28
+        checksum/config: f68c0f50790743a137a2af44a612c7debb883b375d14d6d3c74e07797e28c418
+        checksum/init-sysctl: 3ac07a95d40c655a7d813d3f762a32683003a78c05eb76564f5b8ac5bd16df6f
+        checksum/plugins: e2a97bf576b2ef6713996531963b2f89bcbb928f6ecf1ad5b72515e018773a48
+        checksum/secret: a76a55e22466a52ba6159d0820d287839165db5798f6b4702bade4b7e4ad432e
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -183,7 +183,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -202,7 +202,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -219,7 +219,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -317,7 +317,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -344,14 +344,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -381,7 +381,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -393,7 +393,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.3
+        chart: sonarqube-2026.1.4
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -404,7 +404,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.1.3-enterprise
+        image: sonarqube:2026.1.4-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d574068dae41d74679db581b043e6f3558060549e3a34dcb2e5f5749ce02f15b
-        checksum/init-sysctl: c6d4235898c142a76c0de7d29e888f9fe699be416ab0679be971ff1ee509ad85
-        checksum/plugins: 7cd53d899c1cae5e81ecdfdeaa8cd913a20e029a7a3a26acb812b3659a7a34c4
-        checksum/secret: 568fe86f5830f9cf8d595779e3a81ad4fabe4544e6d0e362b5cec091410a8ab7
+        checksum/config: 1f9049257cc61847380349361e851d561ea779702f37839aefec6fa4d9326b19
+        checksum/init-sysctl: 89852e76c94f888a1814882019e7b411b74e20c77318c5bc3b42367fb6215112
+        checksum/plugins: adae6882d866aed7070b21aeb2767ec09e94fd5818274e9f1f43291aa78492ab
+        checksum/secret: f1ea2c6b21dadc2fedac00644f727d29f6dec5598d92bec78eb21ac43d8ddc66
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -380,7 +380,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -392,7 +392,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.3
+        chart: sonarqube-2026.1.4
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -403,7 +403,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.1.3-enterprise
+        image: sonarqube:2026.1.4-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 27bfe1ba08ec5a00e5e7aeb623d764628f502c239fb671886381c7f9f7d086f1
-        checksum/init-sysctl: 2551cb2b616333138dbdf18d782defbe5dd6fb346f504af473aa434b7b5b2c4e
-        checksum/plugins: e38812ac6760e728ea6b1939929ce587de980efb0b769c59245dfad60e1f3adf
-        checksum/secret: 64be5a42f9c39f9839da086f0adc1eba3afaa7f88afe3d15035105c24180acb4
+        checksum/config: fe7df986fb1bcee2cf3678637882389e07648c6fdd4f2b353d040d12f36c6115
+        checksum/init-sysctl: 7492b2058bea82dcdea535cf8e609d4ea7c69a744ea3d161fad574d6099dac08
+        checksum/plugins: 5f9dcef8e2335140ce83b4329fdaf5369c8e30faf3f782337327975f566118fe
+        checksum/secret: bac45447ac33a48926a8e426aa1234c91e62845b01f4be906d092aab47b4d68f
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -380,7 +380,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -392,7 +392,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.3
+        chart: sonarqube-2026.1.4
         release: sonar-web-context-values.yaml
         heritage: Helm
       annotations:
@@ -403,7 +403,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.1.3-enterprise
+        image: sonarqube:2026.1.4-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.3-enterprise"
+    app.kubernetes.io/version: "2026.1.4-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 401b1f7a44d236ea93dcea85b259eb2ba4ed40aa51050f257f6f5d1c987a7459
-        checksum/init-fs: 5c093fa06b5cb6b314dd509fadf4d006b439320a373bec639ab2c930c732b97e
-        checksum/init-sysctl: 09e45ec3d4b98ffaf197f0e2b4d89bb39fdebe48f72b17e267ac84ae58b3e6c6
-        checksum/plugins: 0c1c77ecd8775e2a05bced0e04e4cb1db23007a053b33e16d29829ca79484f26
-        checksum/secret: e9950f77ac2caf62819473a9683383271a2340dd9f8792ac41be37c3d4327270
+        checksum/config: c398d7163b711fecf38c2dcff014010fa5b3bfa8a76701f24c9b43e25b3c8504
+        checksum/init-fs: 5e582418933e11c7b18d246c0418a9c33c3f7335714ab0e58e08b774858369b6
+        checksum/init-sysctl: 0edc1ede51b88086d1381cab214f29bac75fe5480a9ac9a417fc0b0a2d535f93
+        checksum/plugins: 4a0669ba24e9c161b0275d43391ac2fdfb54e1c7b08a6687aa8dcd99f6128d81
+        checksum/secret: 254f12727a17d7832fde88e6f70c1b3aec5ee085314420d7bfc0cd1d6ccb8900
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -264,7 +264,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.3-enterprise
+          image: sonarqube:2026.1.4-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.3
+              value: 2026.1.4
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -389,14 +389,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.3
+    chart: sonarqube-2026.1.4
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2026.1.3-enterprise"
+      image: "sonarqube:2026.1.4-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -133,7 +133,7 @@ func TestShouldUseImageTag(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2026.1.3-enterprise"
+	expectedContainerImage := "sonarqube:2026.1.4-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -219,7 +219,7 @@ func TestDeveloperEdition(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2026.1.3-developer"
+	expectedContainerImage := "sonarqube:2026.1.4-developer"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2026.1.3-enterprise
+  tag: 2026.1.4-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Releases:**
    - Release SonarQube Server `2026.1.4` and upgrade Helm chart version
    - Regenerate unit test fixtures for SonarQube Server `2026.1.4`

<sub>This will update automatically on new commits.</sub>