### PR TITLE
SONAR-31124 Fix GCP Marketplace test

### DIFF
--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -128,8 +128,10 @@ jobs:
   # Mirrors Google's functionality test: no external database and no parameter override, so the
   # deployer relies on the data-test schema defaults and the /data-test/chart PostgreSQL overlay.
   # mpdev verify provisions and tears down its own ephemeral apptest-* namespace.
+  # Runs after (not alongside) verify-gcp-staging-app so only one DCE stack occupies the
+  # autoscaling staging cluster at a time, avoiding node-cap contention.
   verify-gcp-staging-app-selfcontained:
-    needs: [build-gcp-staging-app]
+    needs: [verify-gcp-staging-app]
     runs-on: github-ubuntu-latest-s
     name: Verify GCP Staging App (self-contained)
     permissions:

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -125,8 +125,54 @@ jobs:
         run: |
           kubectl delete namespace test-github --ignore-not-found=true
 
+  # Mirrors Google's functionality test: no external database and no parameter override, so the
+  # deployer relies on the data-test schema defaults and the /data-test/chart PostgreSQL overlay.
+  # mpdev verify provisions and tears down its own ephemeral apptest-* namespace.
+  verify-gcp-staging-app-selfcontained:
+    needs: [build-gcp-staging-app]
+    runs-on: github-ubuntu-latest-s
+    name: Verify GCP Staging App (self-contained)
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      BASE_FOLDER: "/home/runner/.gcp/cache"
+      HOME: "/tmp"
+      GCLOUD_CLI_VERSION: 495.0.0
+      MPDEV_VERSION: 0.12.4
+      GCLOUD_REGISTRY: gcr.io/sonarqube-marketplace-provider
+      GCLOUD_PRODUCT_NAME: sonarqube-dce-staging
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.3.13
+      - name: Setup GCP tools
+        run: ./.github/scripts/setup.sh
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/team/sonarqube/kv/data/gcp-marketplace-registry-staging key | DOCKER_GCLOUD_SA_KEY;
+      - name: Login and setup GCP
+        env:
+          DOCKER_GCLOUD_SA_KEY: ${{ fromJSON(steps.secrets.outputs.vault).DOCKER_GCLOUD_SA_KEY }}
+        run: |
+          export PATH="${BASE_FOLDER}:${PATH}"
+          echo ${DOCKER_GCLOUD_SA_KEY} | base64 -d > /tmp/key.json
+          gcloud auth activate-service-account cirrusciservice@sonarqube-marketplace-provider.iam.gserviceaccount.com --key-file /tmp/key.json --project=sonarqube-marketplace-provider
+          gcloud auth configure-docker gcr.io --quiet
+          gcloud container clusters get-credentials sonarqube-marketplace-staging-standard --zone=europe-west1-b --project=sonarqube-marketplace-provider
+          kubectl get pods -A
+      - name: Verify with mpdev (self-contained)
+        run: |
+          export PATH="${BASE_FOLDER}:${PATH}"
+          mpdev verify --deployer=$GCLOUD_REGISTRY/$GCLOUD_PRODUCT_NAME/deployer:$GCLOUD_TAG --wait_timeout=1200
+
   release-gcp-prod-app:
-    needs: [verify-gcp-staging-app]
+    needs: [verify-gcp-staging-app, verify-gcp-staging-app-selfcontained]
     runs-on: github-ubuntu-latest-s
     name: Release GCP Prod App
     permissions:
@@ -175,10 +221,10 @@ jobs:
 
   notify-slack-on-failure:
     name: Notify on Failure
-    needs: [ build-gcp-staging-app, verify-gcp-staging-app, release-gcp-prod-app ]
+    needs: [ build-gcp-staging-app, verify-gcp-staging-app, verify-gcp-staging-app-selfcontained, release-gcp-prod-app ]
     if: >-
       always() &&
-      (needs.build-gcp-staging-app.result == 'failure' || needs.verify-gcp-staging-app.result == 'failure' || needs.release-gcp-prod-app.result == 'failure') &&
+      (needs.build-gcp-staging-app.result == 'failure' || needs.verify-gcp-staging-app.result == 'failure' || needs.verify-gcp-staging-app-selfcontained.result == 'failure' || needs.release-gcp-prod-app.result == 'failure') &&
       (github.ref_name == github.event.repository.default_branch ||
       startsWith(github.ref_name, 'release/'))
     permissions:

--- a/google-cloud-marketplace-k8s-app/Dockerfile
+++ b/google-cloud-marketplace-k8s-app/Dockerfile
@@ -22,6 +22,14 @@ RUN cat /data/schema.yaml \
         > /data/schema.yaml.new \
         && mv /data/schema.yaml.new /data/schema.yaml
 
+# Test-only chart overlay (ephemeral PostgreSQL), merged into the chart only
+# during the functionality test (create_manifests.sh --mode=test).
+COPY google-cloud-marketplace-k8s-app/data-test/chart /tmp/test-chart.tmp/chart
+RUN tar -czvf /tmp/test-chart.tar.gz -C /tmp/test-chart.tmp chart \
+        && mkdir -p /data-test/chart \
+        && mv /tmp/test-chart.tar.gz /data-test/chart/chart.tar.gz \
+        && rm -Rf /tmp/test-chart.tmp
+
 COPY google-cloud-marketplace-k8s-app/data-test/schema.yaml /data-test/schema.yaml
 # Provide registry prefix and tag for default values for images.
 # Might not be needed on V2 schema

--- a/google-cloud-marketplace-k8s-app/data-test/chart/templates/test-postgres.yaml
+++ b/google-cloud-marketplace-k8s-app/data-test/chart/templates/test-postgres.yaml
@@ -1,0 +1,77 @@
+{{/* Ephemeral PostgreSQL, overlaid only during the Marketplace functionality
+     test (--mode=test). Never shipped in the chart or deployed for real installs.
+     Credentials/service name match data-test/schema.yaml. */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-postgres-postgresql
+  labels:
+    app.kubernetes.io/component: test-postgresql
+spec:
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+  selector:
+    app.kubernetes.io/component: test-postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-postgres-postgresql
+  labels:
+    app.kubernetes.io/component: test-postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test-postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test-postgresql
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgresql
+          image: postgres:16-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: POSTGRES_USER
+              value: username
+            - name: POSTGRES_PASSWORD
+              value: password
+            - name: POSTGRES_DB
+              value: sonarqube
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "username", "-d", "sonarqube"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/google-cloud-marketplace-k8s-app/data-test/schema.yaml
+++ b/google-cloud-marketplace-k8s-app/data-test/schema.yaml
@@ -50,7 +50,7 @@ properties:
     title: JDBC URL
     description: The JDBC URL to connect to the database
     type: string
-    default: 'jdbc:postgresql://myPostgres/myDatabase'
+    default: 'jdbc:postgresql://external-postgres-postgresql:5432/sonarqube'
   jdbcOverwrite.jdbcUsername:
     title: JDBC Username
     description: The username to connect to the database

--- a/tests/unit-test/go.mod
+++ b/tests/unit-test/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/gruntwork-io/terratest v0.46.16
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.5
 	k8s.io/api v0.34.2
 )
@@ -84,7 +85,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.2 // indirect
 	k8s.io/apimachinery v0.34.2 // indirect
 	k8s.io/client-go v0.34.2 // indirect

--- a/tests/unit-test/sonarqube_dce_marketplace_test.go
+++ b/tests/unit-test/sonarqube_dce_marketplace_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+var marketplaceTestSchemaPath string = "../../google-cloud-marketplace-k8s-app/data-test/schema.yaml"
+
+// Placeholder rejected by charts/sonarqube-dce/templates/validation.yaml.
+var rejectedJdbcPlaceholder string = "jdbc:postgresql://myPostgres/myDatabase"
+
+// marketplaceTestSchemaDefaults returns the property defaults declared in the GCP
+// Marketplace data-test schema. These are the values fed to the deployer during the
+// automated functionality test, so the chart must render with them.
+func marketplaceTestSchemaDefaults(t *testing.T) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(marketplaceTestSchemaPath)
+	require.NoError(t, err)
+
+	var schema struct {
+		Properties map[string]struct {
+			Default interface{} `yaml:"default"`
+		} `yaml:"properties"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &schema))
+
+	defaults := map[string]string{}
+	for name, prop := range schema.Properties {
+		if prop.Default != nil {
+			defaults[name] = fmt.Sprintf("%v", prop.Default)
+		}
+	}
+	return defaults
+}
+
+// TestMarketplaceDataTestSchemaRenders guards the regression where the data-test schema
+// defaulted jdbcOverwrite.jdbcUrl to the placeholder rejected by validation.yaml, making
+// the Marketplace deployer fail at `helm template`. The chart must render cleanly with the
+// data-test defaults, and jdbcOverwrite.jdbcUrl must never be the rejected placeholder.
+func TestMarketplaceDataTestSchemaRenders(t *testing.T) {
+	defaults := marketplaceTestSchemaDefaults(t)
+
+	require.Contains(t, defaults, "jdbcOverwrite.jdbcUrl")
+	assert.NotEqual(t, rejectedJdbcPlaceholder, defaults["jdbcOverwrite.jdbcUrl"],
+		"data-test jdbcOverwrite.jdbcUrl must not be the placeholder rejected by validation.yaml")
+
+	setValues := map[string]string{"gcp_marketplace": "true"}
+	for k, v := range defaults {
+		setValues[k] = v
+	}
+
+	helmOptions := &helm.Options{
+		Logger:    logger.Discard,
+		SetValues: setValues,
+	}
+	_, err := helm.RenderTemplateE(t, helmOptions, dceChartPath, dceReleaseName, []string{"templates/sonarqube-application.yaml"})
+	assert.NoError(t, err, "DCE chart must render with the GCP Marketplace data-test schema defaults")
+}


### PR DESCRIPTION
## Problem
GCP Marketplace's `TEST_K8S_APP_FUNCTIONALITY` fails: the deployer Job exits with `BackoffLimitExceeded` on all GKE versions. `helm template` fails because `data-test/schema.yaml` defaults `jdbcOverwrite.jdbcUrl` to `jdbc:postgresql://myPostgres/myDatabase`, the placeholder that the chart's `validation.yaml` rejects.

## Changes
- `data-test/schema.yaml`: point the jdbcUrl default at a real value instead of the placeholder.
- `data-test/chart/templates/test-postgres.yaml` (new): ephemeral Postgres. The deployer applies it only through the `--mode=test` overlay. This is needed as GCP perform's a self-contained test and cannot connect to an external DB (a DB is required to run DCE).
- `Dockerfile`: package the overlay into `/data-test/chart/chart.tar.gz`.
- `TestMarketplaceDataTestSchemaRenders`: renders the chart with the real `data-test` defaults; fails if the placeholder returns.
- New CI job `verify-gcp-staging-app-selfcontained`: runs `mpdev verify` with no external DB and no param override, matching GCP path.

## Testing
- Unit test and local `helm template` pass.
- kind e2e with the overlay Postgres.
- Full GCP Marketplace CI on GKE, both verify GCP jobs green: https://github.com/SonarSource/helm-chart-sonarqube/actions/runs/30108210930


----
## Summary by Gitar

- **Tests:**
    - Added unit test asserting the GCP Marketplace data-test schema successfully renders the Helm chart
- **GCP Marketplace:**
    - Fixed functionality test by updating default JDBC URL to a valid endpoint and adding an ephemeral test-only PostgreSQL overlay

<sub>This will update automatically on new commits.</sub>