### PR TITLE
REL-4832 Release sqs 2026.1.5

### DIFF
--- a/.github/workflows/azure-marketplace.yml
+++ b/.github/workflows/azure-marketplace.yml
@@ -17,8 +17,8 @@ concurrency:
 
 env:
   PSQL_VERSION: 11.14.0
-  SQ_VERSION: 2026.1.4
-  SQ_IMAGE_VERSION: 2026.1.4
+  SQ_VERSION: 2026.1.5
+  SQ_IMAGE_VERSION: 2026.1.5
 
 jobs:
   build-azure-staging-app:

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2026.1.4 # Update this value to the desired version
+  GCLOUD_TAG: 2026.1.5 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/azure-marketplace-k8s-app/manifest.yaml
+++ b/azure-marketplace-k8s-app/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: sonarqube
 publisher: "SonarSource"
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
-version: 2026.1.4
+version: 2026.1.5
 helmChart: "./sonarqube-azure"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"

--- a/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2 # Or v1 depending on your Helm version
 name: sonarqube-azure
-version: 2026.1.4
-appVersion: 2026.1.4
+version: 2026.1.5
+appVersion: 2026.1.5
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
 type: application
 dependencies:
   - name: sonarqube 
-    version: 2026.1.4
+    version: 2026.1.5
     repository: "file://../../charts/sonarqube" # Reference to the local SonarQube chart

--- a/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
@@ -22,7 +22,7 @@ global:
       sonarqube:
         registry: __ACR_REGISTRY_PLACEHOLDER__
         image: sonarqube
-        tag: 2026.1.4-enterprise
+        tag: 2026.1.5-enterprise
       postgresql:
         registry: __ACR_REGISTRY_PLACEHOLDER__
         image: bitnamilegacy/postgresql

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.1.5]
+* Upgrade Chart's version to 2026.1.5
+* Upgrade SonarQube Server to 2026.1.5
+
 ## [2026.1.4]
 * Upgrade Chart's version to 2026.1.4
 * Upgrade SonarQube Server to 2026.1.4

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.1.4
-appVersion: 2026.1.4
+version: 2026.1.5
+appVersion: 2026.1.5
 keywords:
   - coverage
   - security
@@ -36,9 +36,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.1.4"
+      description: "Upgrade Chart's version to 2026.1.5"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.1.4"
+      description: "Upgrade SonarQube Server to 2026.1.5"
     - kind: fixed
       description: "Fix http-route rendering when using multiple hostnames"
   artifacthub.io/links: |
@@ -49,9 +49,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2026.1.4-datacenter-app
+      image: sonarqube:2026.1.5-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2026.1.4-datacenter-search
+      image: sonarqube:2026.1.5-datacenter-search
   charts.openshift.io/name: sonarqube-dce
 dependencies:
   - name: ingress-nginx

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2026.1.4`
+Compatible SonarQube Version: `2026.1.5`
 
 Supported Kubernetes Versions: From `1.32` to `1.35`
 Supported Openshift Versions: From `4.17` to `4.20`
@@ -448,7 +448,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.1.4-datacenter-search`                                             |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.1.5-datacenter-search`                                             |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -504,7 +504,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.1.4-datacenter-app`                                                |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.1.5-datacenter-app`                                                |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/ci-values.yaml
+++ b/charts/sonarqube-dce/ci/ci-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 3
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.4-master-datacenter-search"
+    tag: "2026.1.5-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.4-master-datacenter-app"
+    tag: "2026.1.5-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
   webPort: 4023

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -7,7 +7,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.4-master-datacenter-search"
+    tag: "2026.1.5-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -16,7 +16,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.1.4-master-datacenter-app"
+    tag: "2026.1.5-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
 

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2026.1.4-datacenter-search
+    tag: 2026.1.5-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -153,7 +153,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2026.1.4-datacenter-app
+    tag: 2026.1.5-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.1.5]
+* Upgrade Chart's version to 2026.1.5
+* Upgrade SonarQube Server to 2026.1.5
+
 ## [2026.1.4]
 * Upgrade Chart's version to 2026.1.4
 * Upgrade SonarQube Server to 2026.1.4

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.1.4
-appVersion: 2026.1.4
+version: 2026.1.5
+appVersion: 2026.1.5
 keywords:
   - coverage
   - security
@@ -41,9 +41,9 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.1.4"
+      description: "Upgrade Chart's version to 2026.1.5"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.1.4"
+      description: "Upgrade SonarQube Server to 2026.1.5"
     - kind: fixed
       description: "Fix http-route rendering when using multiple hostnames"
   artifacthub.io/containsSecurityUpdates: "false"
@@ -51,9 +51,9 @@ annotations:
     - name: sonarqube-community
       image: sonarqube:26.1.0.118079-community
     - name: sonarqube-developer
-      image: sonarqube:2026.1.4-developer
+      image: sonarqube:2026.1.5-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2026.1.4-enterprise
+      image: sonarqube:2026.1.5-enterprise
   charts.openshift.io/name: sonarqube
 dependencies:
   - name: ingress-nginx

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Default Versions
 
-SonarQube Server Version: `2026.1.4`
+SonarQube Server Version: `2026.1.5`
 
 SonarQube Community Build: `26.1.0.118079`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2026.1.4
+export TAG=2026.1.5
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -304,7 +304,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-static-hazelcast-values.yaml
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -357,14 +357,14 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d1fc8f91cded96e13b80378193e1b2f7acbb682a3ab364c2602df7d078542442
-        checksum/config: 61f12cbc694e2101275a7f9c51f5fa11649efcf92d414b295c7361bc89307069
-        checksum/secret: 6cffa9913bf0113ac2f9d57ed4f4c2a0aabf956f34cf1a53a5e2caf5930312e8
+        checksum/plugins: 5c76b007d040011c7263f666c2e5a0d5c06c4c39c387cf8399ed6d66b57c2c6b
+        checksum/config: 01955fd42ddb910b9bb51dde94ee39656d80873c9e2cecc3631ef353c6f18bb1
+        checksum/secret: dc1e57225951cc79c4c6c72c40545c655749b3365797434215bfc9b76ac4edf1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -403,7 +403,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -437,7 +437,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-static-hazelcast-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-static-hazelcast-values.yaml"
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -600,15 +600,15 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 1871a49a870afe5c4a908885249417923d17a5647b6c2ad26ccd76b74f0985ca
-        checksum/init-fs: 922d3e51fc5b244e73d9521ceced55e0abcb562936e0c0b40e794564d4a77fee
-        checksum/config: 61f12cbc694e2101275a7f9c51f5fa11649efcf92d414b295c7361bc89307069
-        checksum/secret: 6cffa9913bf0113ac2f9d57ed4f4c2a0aabf956f34cf1a53a5e2caf5930312e8
+        checksum/init-sysctl: 74f3e6e7e2bda9dbbce6d6e29fa4aad5ac920a9cc87b525ab9a09b5534058386
+        checksum/init-fs: 4ac82870758294a3026be0a375ac241b6d4eda8b7f1fac60156ed2b782a40ddb
+        checksum/config: 01955fd42ddb910b9bb51dde94ee39656d80873c9e2cecc3631ef353c6f18bb1
+        checksum/secret: dc1e57225951cc79c4c6c72c40545c655749b3365797434215bfc9b76ac4edf1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -623,7 +623,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -664,7 +664,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -801,14 +801,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-static-hazelcast-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ae55c3cdea14effe517ddba55160e00b7295567199220ecab0d90564113026ec
-        checksum/config: d3bad94cfadc207780a1b92267664630fbe300ebd7d4fd0052a322fe9dc593db
-        checksum/secret: 401afe5e26d1605ca1d95199c879d2429bcf80e0bf65721953923d67eacf7b80
+        checksum/plugins: a3dc2b8b6645dd264bed35de4f2333d440550509fa51da94522a351a296ca268
+        checksum/config: 18f1dbadbad994090c0855200795a070000535079f7f1ef95101df1b96a9e2e3
+        checksum/secret: 7c1ea490a41847f8bcda5c8d8927c04462144d21eeb6cc2bf94917ff67555562
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 514a7a9d55716d8225375f63b517931a32b6960b5de8a3c528be86fed3619b45
-        checksum/init-fs: 38ad88e496ef53175e0eb981b5faf53a05589a36a7d5f68b34b1d8b46c8bbfcd
-        checksum/config: d3bad94cfadc207780a1b92267664630fbe300ebd7d4fd0052a322fe9dc593db
-        checksum/secret: 401afe5e26d1605ca1d95199c879d2429bcf80e0bf65721953923d67eacf7b80
+        checksum/init-sysctl: 831d122f809ed3fdf4ba771f9dd61d90b1332728c0fb696ae00d507c4b2bd1ac
+        checksum/init-fs: a6c1c6b983edcfcd5bd53bf5eaa1c7475bf8c06953dbc7fc4a7a3d23d9fa3bd4
+        checksum/config: 18f1dbadbad994090c0855200795a070000535079f7f1ef95101df1b96a9e2e3
+        checksum/secret: 7c1ea490a41847f8bcda5c8d8927c04462144d21eeb6cc2bf94917ff67555562
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -729,7 +729,7 @@ apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
   name: "application-values.yaml"
-  namespace: "default"
+  namespace: "sonarqube"
   labels:
     app.kubernetes.io/name: "application-values.yaml"
   annotations:
@@ -739,7 +739,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2026.1.4-datacenter-app"
+    version: "2026.1.5-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -793,14 +793,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: application-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -729,7 +729,7 @@ apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
   name: "application-values.yaml"
-  namespace: "sonarqube"
+  namespace: "default"
   labels:
     app.kubernetes.io/name: "application-values.yaml"
   annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -235,7 +235,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -282,7 +282,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -308,7 +308,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -335,7 +335,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -344,7 +344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -361,14 +361,14 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5670e870fedb956de335e2bf55ed769b0870eb0c0c64d943b60c93546fbc1c28
-        checksum/config: 474eeb80d29aaf56c7b27d2d6191cd8b04a396a4ce07f0bad55e56bf3f613977
-        checksum/secret: 81f2ac9c142074b193f45e52e478a90fb89975085fd0bac1fdbfab2cbdbde32f
+        checksum/plugins: a214064077e6431e6f46b8aa7e4bd8e3687e9f00f4cdb78238baf476568fb443
+        checksum/config: 71b0f19c2aaad55a43c0382927fa50aff1d231de143ca46fcc423007ddc171e3
+        checksum/secret: 355da06414aa4f5bc90d4c0fe142a552ab5311627ff3074e8e45814b36fd3dcf
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -392,7 +392,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -420,7 +420,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -448,7 +448,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -584,7 +584,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -593,7 +593,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -622,15 +622,15 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 98ede473b4dcd18c0325abd166a9e1b6c874f2d7b4eb83cdc36d40385bc9efe0
-        checksum/init-fs: 0a941b06f678df534fa8ac4c9aa4bc1b2dd1435e3c5a67c6ec9d83dfec66327f
-        checksum/config: 474eeb80d29aaf56c7b27d2d6191cd8b04a396a4ce07f0bad55e56bf3f613977
-        checksum/secret: 81f2ac9c142074b193f45e52e478a90fb89975085fd0bac1fdbfab2cbdbde32f
+        checksum/init-sysctl: e0379ed0b41e430ae91a952e79f3fcf2a36493778f56aa7fd9937e5809ecf931
+        checksum/init-fs: 1fa22ffdc45f0d92ed671891dd3f175fdc356634ced4f9f46fed23e5ab8c942d
+        checksum/config: 71b0f19c2aaad55a43c0382927fa50aff1d231de143ca46fcc423007ddc171e3
+        checksum/secret: 355da06414aa4f5bc90d4c0fe142a552ab5311627ff3074e8e45814b36fd3dcf
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -645,7 +645,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -669,7 +669,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -710,7 +710,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -852,14 +852,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -241,7 +241,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -266,7 +266,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -319,7 +319,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -345,14 +345,14 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2e870772dd81f64a7313f6988e5eb5f28e778c3113dc29c30f1b5c6d7619be4e
-        checksum/config: e4c6b63e6745651a3d4115f5ab8e6d44b8c919c4c6447d812191194212125221
-        checksum/secret: e23cb7c661d69a4ab7d68382dfeb763bc4fc88d6f8a870adee44697abdc9a42c
+        checksum/plugins: e45a52248532ff90021b5d53dd8236cf40976c649e99d6c8308c3e9740857b95
+        checksum/config: 5a4821f086482038118a5c75d58fff5b4f2b12e7dead19d9ed30efa9d52282b4
+        checksum/secret: f0509160898de784f0ad2ef474b0f15fc76b98dfd1ec56be9dfd4a7ad5653e1b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -379,7 +379,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -407,7 +407,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -523,7 +523,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -561,15 +561,15 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 58fb8abc5b17059d2c59a008d7c851a000db4cbf7fc5dc15f7163831efcf8fb0
-        checksum/init-fs: 9e2d4e6b25997492365dbe5fb724a77e0928bccf3e5ff35c81f533117c763365
-        checksum/config: e4c6b63e6745651a3d4115f5ab8e6d44b8c919c4c6447d812191194212125221
-        checksum/secret: e23cb7c661d69a4ab7d68382dfeb763bc4fc88d6f8a870adee44697abdc9a42c
+        checksum/init-sysctl: efa1aaa11b865010252dc0ab95116fcc436a1b9463e7a56532fac9eaf16aeac7
+        checksum/init-fs: 3c43417fc70b5aaf633405a5ec7d2f009f84e4b13fd7ea40ed0da08e6c4cb272
+        checksum/config: 5a4821f086482038118a5c75d58fff5b4f2b12e7dead19d9ed30efa9d52282b4
+        checksum/secret: f0509160898de784f0ad2ef474b0f15fc76b98dfd1ec56be9dfd4a7ad5653e1b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -584,7 +584,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -608,7 +608,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -649,7 +649,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -786,14 +786,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0d44e22e47a7d49600c31c54dde3bcfd7a95f1309f310b5ec1513f58eafab519
-        checksum/config: 8722a55a9b742dbcfb936ea2302d49f8f493e54d46fdeec4618ae891d16c199a
-        checksum/secret: f1cc9229e52b7c409668343f6f37b8a294ecbf9380353e819c85615f068467ff
+        checksum/plugins: 9b786094fa62538a4b80f3d7961ce796e381fcad3a18c52618154328e3d79ad8
+        checksum/config: e66a5154d2ae4ce2a4ec0f7e29fa4ec953252af21973e2e54e562ef62bd9261a
+        checksum/secret: 72f0bab54baa319cafd9f0361c7b27aef88b8e68f363a6ac8713a54b8b677d0b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e1f75b92bb7f01447b23b5b20f77502a75d191912fb0d496fecb4bc25fb4c984
-        checksum/init-fs: 30a649d9c6bdcb726b5fd1c06221c82a6b12c834b9607381c549a0bc414271ea
-        checksum/config: 8722a55a9b742dbcfb936ea2302d49f8f493e54d46fdeec4618ae891d16c199a
-        checksum/secret: f1cc9229e52b7c409668343f6f37b8a294ecbf9380353e819c85615f068467ff
+        checksum/init-sysctl: 167ffae07cff27be90c1f19d4787a608849b3cf46a39895237155650dc6f62b5
+        checksum/init-fs: e62f0d264eaf8c0505bd476a7a6ad297a488bb3c1743fa81c88088bfb9a86fb9
+        checksum/config: e66a5154d2ae4ce2a4ec0f7e29fa4ec953252af21973e2e54e562ef62bd9261a
+        checksum/secret: 72f0bab54baa319cafd9f0361c7b27aef88b8e68f363a6ac8713a54b8b677d0b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -787,7 +787,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.4"
+    helm.sh/chart: "sonarqube-dce-2026.1.5"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 
@@ -246,7 +246,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 
@@ -271,7 +271,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -350,14 +350,14 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ba0f0e5021639f82a39996ffa7906ca42d35dcbd94b5540b5befa594fd2d1550
-        checksum/config: 80384d2c6636d64ec270ea295218e2f353c23da42b0562a41b839dea36c32093
-        checksum/secret: 1929efab6342ef2e89ecd64ca94fa41311ac4540452a3b7b7aa5e03f4ce4b159
+        checksum/plugins: c8c38735b2c5cc73ae56f554f03bbbcf9a59fff54fd15ef3802877ae34b85b61
+        checksum/config: 6c99224738396563d53b2908313bf1be812f317c14e0db90fc8b33f3b1fc4d59
+        checksum/secret: 8dc53a3c959359bf20d65fa17949ca4658c72759fe65751a4bc977cf9bc4f791
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -396,7 +396,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -424,7 +424,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -562,7 +562,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -600,15 +600,15 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d55f12bead0245567bd401585d1a9f9299eb57088368165b3eedfa32d0a44dbc
-        checksum/init-fs: 9f14bf6ab655c9e348ea972de4dc7c4933477ee49cc8b1af4dff97950fa8b84f
-        checksum/config: 80384d2c6636d64ec270ea295218e2f353c23da42b0562a41b839dea36c32093
-        checksum/secret: 1929efab6342ef2e89ecd64ca94fa41311ac4540452a3b7b7aa5e03f4ce4b159
+        checksum/init-sysctl: 1d66c95f344cca50dab6f234086106e3bcd3524647bf36008aab98ef6d9af241
+        checksum/init-fs: a7eb46186a4498ea917dc55c81d7e9282fbc926615ccf41a5abc2986f505e475
+        checksum/config: 6c99224738396563d53b2908313bf1be812f317c14e0db90fc8b33f3b1fc4d59
+        checksum/secret: 8dc53a3c959359bf20d65fa17949ca4658c72759fe65751a4bc977cf9bc4f791
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -623,7 +623,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -659,7 +659,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -700,7 +700,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -858,14 +858,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 20cfcb9767bf274f16597d45621c44f7af5a4a21f1c71c9958aa7cb4d744d1af
-        checksum/config: 813bc64fb839c3a891acd4ed5bf4584f360aa5a516adb03e22933fd04aa0084a
-        checksum/secret: 2f43d18cbf7ada195c8f58144a4a6284ff00026b27919c449c34d30c485aa32a
+        checksum/plugins: e7699e230ae05ced795bce6f6bdde1e8787ead32901f598e29165362b30aec50
+        checksum/config: 5f9a9f9b87d1d16756bc19f7821f0a10200ed375e6762871b56afa455db8ab3f
+        checksum/secret: 868fa999c49d9f375e48651b2ae55a8e907ec578f96e755eff6ed89822a684ba
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -533,10 +533,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a4017b1815b5fdad75a155f9f251876cdad77d0d17e6a276016c3f8736879717
-        checksum/init-fs: b7c6d9dd6d57e64bc2afe8cbce52e33a5e1c042f2d3fcb5a358dc411f3506ea1
-        checksum/config: 813bc64fb839c3a891acd4ed5bf4584f360aa5a516adb03e22933fd04aa0084a
-        checksum/secret: 2f43d18cbf7ada195c8f58144a4a6284ff00026b27919c449c34d30c485aa32a
+        checksum/init-sysctl: 8cbe483068e00a4ab56824110da51f39223189c6cf0bf634d44d7100b46f8191
+        checksum/init-fs: 891edc966a93fbdd771e67b0e555b5b3bbe2caa46e7c9e8427c6cf0db637d537
+        checksum/config: 5f9a9f9b87d1d16756bc19f7821f0a10200ed375e6762871b56afa455db8ab3f
+        checksum/secret: 868fa999c49d9f375e48651b2ae55a8e907ec578f96e755eff6ed89822a684ba
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -734,7 +734,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 04576cb5645e4cf4df043ad99e4c8d8b06f949f143408fb1ecd0bb7d115f55ee
-        checksum/config: 2deb48f82fd7072af0747631a732a89276b92bc7bf481917ef3ab11c78008d90
-        checksum/secret: 62e35a5f49c57cbb068de8c4ed67e59b77ca8b19bbc844406e6d3154cc484506
+        checksum/plugins: 25b62e47e70d76de0c74b722744d9a16d3332b0c80167b704a0f91db9c3706f8
+        checksum/config: 87e06ed124e4ab432039057700108e4cfa8a9f696e5cc6bb209576a9ad0cf15a
+        checksum/secret: 50b6478edc31161899b82cdc3e3fdf948f5e1a59907e3f269374d7d9c955d04e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 927b3128f388147226afbdfe102b31876578df132947aed13380a3ce236e7a07
-        checksum/init-fs: 0a5d3cac0c6af160e3f4651eaea0406e24696a911360973519bc3dddffc54d28
-        checksum/config: 2deb48f82fd7072af0747631a732a89276b92bc7bf481917ef3ab11c78008d90
-        checksum/secret: 62e35a5f49c57cbb068de8c4ed67e59b77ca8b19bbc844406e6d3154cc484506
+        checksum/init-sysctl: 2ffaecb5aee9e3314230426804af0da5843bf3e2b5f67775d2263a5911839526
+        checksum/init-fs: c1140019252d00c247f4f45f67ab716f9047e9e10cbb08bc2a5aa9361eb35bc6
+        checksum/config: 87e06ed124e4ab432039057700108e4cfa8a9f696e5cc6bb209576a9ad0cf15a
+        checksum/secret: 50b6478edc31161899b82cdc3e3fdf948f5e1a59907e3f269374d7d9c955d04e
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -734,14 +734,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a432260f02e5eb36cf68c69ac23963908096a9a1293c0086004205e150531604
-        checksum/config: c327ef91c4dfa1d3b2c194861c614d1dd25d753cf712abfddb85b04c142ea924
-        checksum/secret: 4cdca6ed8a05be3bd005bdf8679e393debde4ce74838b8db050d825fd1cc95a7
+        checksum/plugins: 284b5eb934806db392f7140bca52a57e37fb959cd4acbcc9273acedc6f1dc54a
+        checksum/config: e1ccdf39571a9fb1600fafc8c2805a7c176e230fbd2d29e8366de8711eeb4c9a
+        checksum/secret: 2f1ce1e90f840fd5f6c11f96430654d91cfd38050fc88a618732bd6a9ea06dcf
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: db9b4e32436e22c212f8d475f659ce66b5e29af13a82960ff6f818ca52452a5d
-        checksum/init-fs: fa8990179f6a60c302582a6113ecfdef5973911f828dd470932ca43effce6e62
-        checksum/config: c327ef91c4dfa1d3b2c194861c614d1dd25d753cf712abfddb85b04c142ea924
-        checksum/secret: 4cdca6ed8a05be3bd005bdf8679e393debde4ce74838b8db050d825fd1cc95a7
+        checksum/init-sysctl: 592786776ae1e2200725f940ce86155e8f40cc3f7e0b5c532d07aca2699855ce
+        checksum/init-fs: 5e538744bd7c73833869e93562d08bc883b09d9e355cbcae97b35db69e349014
+        checksum/config: e1ccdf39571a9fb1600fafc8c2805a7c176e230fbd2d29e8366de8711eeb4c9a
+        checksum/secret: 2f1ce1e90f840fd5f6c11f96430654d91cfd38050fc88a618732bd6a9ea06dcf
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -734,14 +734,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: deprecation-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ee00a4bd9a11461fa496875ea35f33976f06e1dcde63aefbbb8b52120b7779a5
-        checksum/config: 5c695ac4789d47dedf0f22204e39565e6c8cbf419a11c064696a1258d216ff21
-        checksum/secret: e37a53ef11c53fbbb1b99f722ec771f98273df71f981244ccd98a019d1f7153a
+        checksum/plugins: 6e1b0970780fd982f9cd2cb2c374eaefa9334b73fbbed41bb702cd02b9cc2340
+        checksum/config: 79c4ee7581aa13c3fdde7040f9197549c921448fddfb15cf4784f76f155525e2
+        checksum/secret: 0aae004fd0fdb900810390521e954c6a4b44cc521b34fd05d3e4cdaa8f93e81c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -387,7 +387,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -500,7 +500,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -538,15 +538,15 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e1f0e8eee496627493bfef859853fd25c8a53d23b9154d1f01e44265d44724e1
-        checksum/init-fs: a3e15ee8f25711be933b01ab6a913dbe725726ddfcd69cb868022adf8e362e43
-        checksum/config: 5c695ac4789d47dedf0f22204e39565e6c8cbf419a11c064696a1258d216ff21
-        checksum/secret: e37a53ef11c53fbbb1b99f722ec771f98273df71f981244ccd98a019d1f7153a
+        checksum/init-sysctl: 5561f2c2cfa381aecd0cc934f3ded9b9c68f04c1d8d3375335a8fe178a8dce58
+        checksum/init-fs: b0965e2a0362ebebc300ef0fba5412500f4f969d8a3731dbaf285ecdfd90017a
+        checksum/config: 79c4ee7581aa13c3fdde7040f9197549c921448fddfb15cf4784f76f155525e2
+        checksum/secret: 0aae004fd0fdb900810390521e954c6a4b44cc521b34fd05d3e4cdaa8f93e81c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -561,7 +561,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -602,7 +602,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -739,14 +739,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraConfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 11d7c5f88b7321ddbcfdbe4ce55a73b3232534eab6d3800bdfd91b28e2df4066
-        checksum/config: 22d6488ac6d3e4472eb569b0fff1334ac19c3549844a7dc403171fd2052de1cd
-        checksum/secret: 86caee6eeebe2ab52728b4d7d8410d31f9ee4c45a3002fa9d1f804b590f22215
+        checksum/plugins: d2f54aed4760188d12686e981dfe00c69f548c07ef84ea6de590e208c16a356f
+        checksum/config: 9d78a933d2634ed946a36b9f480508b3c7ec82607ea9d15c20b8368eb0d8ec4a
+        checksum/secret: 112a0b484a7be05aaa37a3d4585e460713a4a4385351c05b573b022e697bdb1e
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -499,7 +499,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -537,15 +537,15 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 9311935cec8d291b3c873cfee360e5030fd31742de12230e4d5c7f611e99ad44
-        checksum/init-fs: 47ea4b19b97942ce10ce8ea7e1560ce41c9a8ab2a2b13e4a5dace0ec8656af20
-        checksum/config: 22d6488ac6d3e4472eb569b0fff1334ac19c3549844a7dc403171fd2052de1cd
-        checksum/secret: 86caee6eeebe2ab52728b4d7d8410d31f9ee4c45a3002fa9d1f804b590f22215
+        checksum/init-sysctl: 8c4b57eb4d1aab33ef0e02296c52fb76366199643b20d37e7ef4f18606b3534b
+        checksum/init-fs: 74b966d0fee806bf054f6d31d24c0ed224484e59037413efe1f6ffee5276eb50
+        checksum/config: 9d78a933d2634ed946a36b9f480508b3c7ec82607ea9d15c20b8368eb0d8ec4a
+        checksum/secret: 112a0b484a7be05aaa37a3d4585e460713a4a4385351c05b573b022e697bdb1e
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -560,7 +560,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -601,7 +601,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -743,14 +743,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -343,9 +343,9 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c61139e94d81ca9420774748b034ee05897163176d5aad1becd37d41600a0d79
-        checksum/config: 2301786a62d348d53cf28b86656f1944b1e72a49925dbd7eaa06bd3dbf31f363
-        checksum/secret: 247cccbc5b70eea913b0164d3e5366e47c558f0a01c8d1566164fe44cb838343
+        checksum/plugins: ccc541a45d9ac66b01de6f9328cf1d3c0e49e59faac59a86ecfb1f752fe086a4
+        checksum/config: 8ca1dc73800accd575ad155211a9ddb602c0ea34ecc6900587e708d87d6be044
+        checksum/secret: dab4469b895d1958dbd097f48c5290789e7cf618bd4a65dd90e688b6295bc38a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -353,7 +353,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -381,7 +381,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -529,7 +529,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -567,15 +567,15 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a1b088d6e4dee9ef205f0edec98ba264759094b8c5c6a1b498537cbcf9091310
-        checksum/init-fs: 2315dc4fccefafd333bcc1a2f5524d8f0159c5ec986260bd237e8cfd9fa68f64
-        checksum/config: 2301786a62d348d53cf28b86656f1944b1e72a49925dbd7eaa06bd3dbf31f363
-        checksum/secret: 247cccbc5b70eea913b0164d3e5366e47c558f0a01c8d1566164fe44cb838343
+        checksum/init-sysctl: 158d63360488c18e49f158d003c0471c2518ee340150b2849783e8747d92ef9f
+        checksum/init-fs: 8f7492527fe5f6d0990078067780d87661aabcd438fee008284f6a3b88df4c91
+        checksum/config: 8ca1dc73800accd575ad155211a9ddb602c0ea34ecc6900587e708d87d6be044
+        checksum/secret: dab4469b895d1958dbd097f48c5290789e7cf618bd4a65dd90e688b6295bc38a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -590,7 +590,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -631,7 +631,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -768,14 +768,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: hpa-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 02eeeaea6c7a0741c1b3abb101d32022c7d499c6afdac061220dc653f32413de
-        checksum/config: 5a5a358e11f0cd46832adcda03f21055ae4eaa3cfeec25534af97ba7be687e3e
-        checksum/secret: f68f5f85ff11b422bc35bc660d2261ec282185dc890dee7ebc48dff9fd2adf2a
+        checksum/plugins: c55b4563bce86c003d5167565591c8545f4c87b722efc00eac79e538fa611b69
+        checksum/config: 23f4e52eb86a3c2a15909ad0e19a3ad2b455ec2c9a67100e549b9ab0b0c07111
+        checksum/secret: dc40c6f1f6284e5c6841ef13160c1f9b2fac0351c165e91fe6e47edcf86788e5
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 49ec40bf755677ea2d964a589c2b2d7b91a161b9e32a322ef37720bfdb2b3d87
-        checksum/init-fs: caeac0fe88ca27c46faaad809b0d505f9aa7f007b1b1ecd706488efbde9ed199
-        checksum/config: 5a5a358e11f0cd46832adcda03f21055ae4eaa3cfeec25534af97ba7be687e3e
-        checksum/secret: f68f5f85ff11b422bc35bc660d2261ec282185dc890dee7ebc48dff9fd2adf2a
+        checksum/init-sysctl: 27d4ae6e3b587a4403139cbbd17f2624e427069780f8d4ff17c2ea980cb33e4d
+        checksum/init-fs: cfbc158162c68a9e051a42267b7cdc4bab7291fc552f690dd7a9a1cb1f212557
+        checksum/config: 23f4e52eb86a3c2a15909ad0e19a3ad2b455ec2c9a67100e549b9ab0b0c07111
+        checksum/secret: dc40c6f1f6284e5c6841ef13160c1f9b2fac0351c165e91fe6e47edcf86788e5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -759,14 +759,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 49a12f7f405e9930e9e484ba482f9a269e9f83a69f50af9cf13cd711a00ac84d
-        checksum/config: abe8f8916610f55c3e3df5a8529117154ae8e7b578ba2b81d7e5e6a3b39929a4
-        checksum/secret: 9e07ea0b872cef13e85602462c0ff14b6ba3b1c0a71bf9e1eb96d7e70e6191aa
+        checksum/plugins: 8bab883bcdc7f31838bcb7088902a6691acccf487e39250ff311e08a09eda6af
+        checksum/config: db60b58f6258319f5ad0e5e9028f10876f7fbf298a4b835dccc64985e276d00b
+        checksum/secret: 696173657d29445ee8f793752f0644354eeacaf787102f8906b6159dcc4a317b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 32a8a682936fbf46ec8dbf3570bcb4730111c45f0b19ac574223327028afaf32
-        checksum/init-fs: 5c8799a154e369e78c8b93c385204bd80eecd782214426a4bf55b42566462c4f
-        checksum/config: abe8f8916610f55c3e3df5a8529117154ae8e7b578ba2b81d7e5e6a3b39929a4
-        checksum/secret: 9e07ea0b872cef13e85602462c0ff14b6ba3b1c0a71bf9e1eb96d7e70e6191aa
+        checksum/init-sysctl: 0027d1711a2b4dc4c9161ad4382310c3e9919a1fd051f26e0655693c5ca3ed66
+        checksum/init-fs: 4ee5541ff72d50bef9ccac8a88b24ce5c1f310053827bfdead4e341cfb8a8bf5
+        checksum/config: db60b58f6258319f5ad0e5e9028f10876f7fbf298a4b835dccc64985e276d00b
+        checksum/secret: 696173657d29445ee8f793752f0644354eeacaf787102f8906b6159dcc4a317b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -760,14 +760,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a6c19d582a12bf81a07036166f351b9ee426946c7a706217b06b63077553f8b0
-        checksum/config: a246858f9eadaa3b99f7c4561eaddb3470a63cb42a3bd4cb62601e950f8cb717
-        checksum/secret: f97174c11a88b1070dba37f7cc22ba18a8e2b9f43ec9585cf1e3bfd1cb4a2859
+        checksum/plugins: e7b8dd3fdbb8d945a82ee52d5fc428f59c70b3ef24b33d056cc5d8dd4405d5f2
+        checksum/config: e359053aad46215def336f25dbfd4b240e05176a47bf5d96356195a9bf94beb4
+        checksum/secret: 599f1afc11a36775313bf70e5dd69b26926e69350f842cdbe500ea42b2373f75
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -533,15 +533,15 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 97de2a7d780b0920aae7654dd01287a22a65fe2deac86351e7fb3a82d3bc9fb2
-        checksum/init-fs: 8ec1a1b4878ae94a052b60a8d8d02eb2bd4c155423faa418547d356945b0751e
-        checksum/config: a246858f9eadaa3b99f7c4561eaddb3470a63cb42a3bd4cb62601e950f8cb717
-        checksum/secret: f97174c11a88b1070dba37f7cc22ba18a8e2b9f43ec9585cf1e3bfd1cb4a2859
+        checksum/init-sysctl: 0ad379ebe2648b54ce97abe95396a17a132eb5bc730492fb89086a279d31b7d1
+        checksum/init-fs: e2eef2062e9e762c466ea01e3ec89668db31366038657202c04c7df6ececfd04
+        checksum/config: e359053aad46215def336f25dbfd4b240e05176a47bf5d96356195a9bf94beb4
+        checksum/secret: 599f1afc11a36775313bf70e5dd69b26926e69350f842cdbe500ea42b2373f75
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -556,7 +556,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -597,7 +597,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -730,7 +730,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -767,14 +767,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: sonarqube
+  namespace: default
 automountServiceAccountToken: true
 ---
 # Source: sonarqube-dce/templates/secret.yaml
@@ -124,7 +124,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: sonarqube
+  namespace: default
 data:
 ---
 # Source: sonarqube-dce/templates/config.yaml
@@ -346,7 +346,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube-dce/charts/ingress-nginx/templates/controller-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -361,7 +361,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: sonarqube
+  namespace: default
 rules:
   - apiGroups:
       - ""
@@ -455,7 +455,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: sonarqube
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -463,7 +463,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube-dce/charts/ingress-nginx/templates/controller-service-webhook.yaml
 apiVersion: v1
@@ -478,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-  namespace: sonarqube
+  namespace: default
 spec:
   type: ClusterIP
   ports:
@@ -505,7 +505,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: sonarqube
+  namespace: default
 spec:
   type: LoadBalancer
   ipFamilyPolicy: SingleStack
@@ -640,7 +640,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: sonarqube
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -1250,7 +1250,7 @@ webhooks:
     clientConfig:
       service:
         name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-        namespace: sonarqube
+        namespace: default
         port: 443
         path: /networking/v1/ingresses
 ---
@@ -1263,7 +1263,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1325,14 +1325,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube-dce/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1358,7 +1358,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1377,7 +1377,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube-dce/templates/tests/sonarqube-test.yaml
 apiVersion: v1
@@ -1425,7 +1425,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-create
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1487,7 +1487,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-patch
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: default
+  namespace: sonarqube
 automountServiceAccountToken: true
 ---
 # Source: sonarqube-dce/templates/secret.yaml
@@ -56,7 +56,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -84,7 +84,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -99,7 +99,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -124,7 +124,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: default
+  namespace: sonarqube
 data:
 ---
 # Source: sonarqube-dce/templates/config.yaml
@@ -134,7 +134,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -223,7 +223,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -346,7 +346,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube-dce/charts/ingress-nginx/templates/controller-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -361,7 +361,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: default
+  namespace: sonarqube
 rules:
   - apiGroups:
       - ""
@@ -455,7 +455,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: default
+  namespace: sonarqube
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -463,7 +463,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube-dce/charts/ingress-nginx/templates/controller-service-webhook.yaml
 apiVersion: v1
@@ -478,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-  namespace: default
+  namespace: sonarqube
 spec:
   type: ClusterIP
   ports:
@@ -505,7 +505,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: default
+  namespace: sonarqube
 spec:
   type: LoadBalancer
   ipFamilyPolicy: SingleStack
@@ -534,7 +534,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -556,7 +556,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -581,7 +581,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -607,7 +607,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -640,7 +640,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: default
+  namespace: sonarqube
 spec:
   selector:
     matchLabels:
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -769,7 +769,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -786,9 +786,9 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9a7af5019a4f2b7bc758e211bd309d85d8ecc28accd5e008e01e1c34b866cc5b
-        checksum/config: e9963911bbca810098d1864dcb925f8413f1d3b60e774412fc55a53577a78918
-        checksum/secret: 51eb9cd0bfa7f9fb650784a63686d110c77302c249023c973e5e416655dffab5
+        checksum/plugins: f2bd10d16f0243564df4e777d9e5ec31f090481980b3907b7d858c4a0f8c2ea8
+        checksum/config: 3609aa49eb0f4bb628319b4120b00af1451098bdb69027afbaae28fc8638e027
+        checksum/secret: bcf4583aca725b28eac043004c5faa9ec0250156a8038df46ca0d77fd05f90c9
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -796,7 +796,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -824,7 +824,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -937,7 +937,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -946,7 +946,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -975,15 +975,15 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3b2117d2a7b31541557fe8ef6a46e517e9f5b5f7bf5991fcc825e9727316a757
-        checksum/init-fs: f32b431731e2f777c180a2049b0ab73577fa76e0279bcd300895e2390ed442d1
-        checksum/config: e9963911bbca810098d1864dcb925f8413f1d3b60e774412fc55a53577a78918
-        checksum/secret: 51eb9cd0bfa7f9fb650784a63686d110c77302c249023c973e5e416655dffab5
+        checksum/init-sysctl: 8f45b1d6c48ea082fb72a6d17074a8c1b63918efe92fb17624d6f48ce78c7c65
+        checksum/init-fs: f87f131baa08eb6002ac20980ec04856c39f8fc455e2d4fba2ac5ed254f0044e
+        checksum/config: 3609aa49eb0f4bb628319b4120b00af1451098bdb69027afbaae28fc8638e027
+        checksum/secret: bcf4583aca725b28eac043004c5faa9ec0250156a8038df46ca0d77fd05f90c9
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -998,7 +998,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1039,7 +1039,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1188,7 +1188,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1250,7 +1250,7 @@ webhooks:
     clientConfig:
       service:
         name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-        namespace: default
+        namespace: sonarqube
         port: 443
         path: /networking/v1/ingresses
 ---
@@ -1263,7 +1263,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1325,14 +1325,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube-dce/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1358,7 +1358,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1377,7 +1377,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube-dce/templates/tests/sonarqube-test.yaml
 apiVersion: v1
@@ -1390,14 +1390,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -1425,7 +1425,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-create
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1487,7 +1487,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-patch
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 4ae403212d8c805d77822a2c1430d4cd0c19e462ef06c055fa74875a9497bda1
-        checksum/config: 6e29b940ef3a6b681fff94c4ea7f689ce7e8c418717c641adefbd75e4c3d6623
-        checksum/secret: 48c8accae67077a6b3a889fa4e2346912f91b5386d9e485222309b24051633be
+        checksum/plugins: 4eb098338c244ebf19e0cc47d738f99d961967d4947ab5d2af85562042f4a8e3
+        checksum/config: 2f40932b9f333778556fa20391aade63c45b06b714b468f68aa22f5b318d2737
+        checksum/secret: 08af02bf42e53beb5e6530acf9e746d2026872c03bfc437f0237dbb85ae3a077
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -580,15 +580,15 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: c2c24dc68df02cf20b26b0ea1f2ce55f8c4fad4854502849cb9b9eb47a639738
-        checksum/init-fs: 6c1072f93c8c1c13d6e6675cc90ffae3de8a339e8805fbc3e1a8bf17ea363edd
-        checksum/config: 6e29b940ef3a6b681fff94c4ea7f689ce7e8c418717c641adefbd75e4c3d6623
-        checksum/secret: 48c8accae67077a6b3a889fa4e2346912f91b5386d9e485222309b24051633be
+        checksum/init-sysctl: 53e8cf283ffe6bd1498bcc4a63c1276800b54273aaeecfbc8aa623c5b74f66f0
+        checksum/init-fs: 0724b0eef0af80ad22ba20371490ed9b93cb4f00cce1baa5fc8213c85bb1ee65
+        checksum/config: 2f40932b9f333778556fa20391aade63c45b06b714b468f68aa22f5b318d2737
+        checksum/secret: 08af02bf42e53beb5e6530acf9e746d2026872c03bfc437f0237dbb85ae3a077
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -603,7 +603,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -644,7 +644,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -781,14 +781,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -178,7 +178,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -227,7 +227,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -252,7 +252,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -314,7 +314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -331,9 +331,9 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 73f786e03633c5df240f231bd13d26dd32b6c4b2eaeab7d944d04e276be6047e
-        checksum/config: 59998f2072d91c458bcda53c79c8b6c42320279418fcd2a0c5fac266fddb99c9
-        checksum/secret: e95fc1dbb0369064c45d62f703f54fff83fdaf5fd7d9b60099e7345063a36c68
+        checksum/plugins: 97760b84519e4b3117060e6b8934cf7d6fe7473996a2a3fd06fbad397e3c9b48
+        checksum/config: 3d3dc7aee19526be3d0b5199d7ba5216dd4ea5ae5aba27efbde296667605c465
+        checksum/secret: 05e9d3e792d13dafe2bcd7b5aed42bf96bcf4bbe040a815e5f3557171f178cb1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -341,7 +341,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -369,7 +369,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -482,7 +482,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -491,7 +491,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -520,15 +520,15 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b479a1bcc3bafa33aba6a107be5b21d188e4c857346307332111256806706d71
-        checksum/init-fs: 152a912b4a12d6cfa3de43f446ef3069a814a949b437e1444c701e990d791105
-        checksum/config: 59998f2072d91c458bcda53c79c8b6c42320279418fcd2a0c5fac266fddb99c9
-        checksum/secret: e95fc1dbb0369064c45d62f703f54fff83fdaf5fd7d9b60099e7345063a36c68
+        checksum/init-sysctl: ecf49585bf46d5b4533850a10a4c2e776f242443b8ca901a9a72bc2978e0307a
+        checksum/init-fs: ac15c6a05f36040b2419661004c4ed65ab21af99fbb7925e1c52f8b70726e5aa
+        checksum/config: 3d3dc7aee19526be3d0b5199d7ba5216dd4ea5ae5aba27efbde296667605c465
+        checksum/secret: 05e9d3e792d13dafe2bcd7b5aed42bf96bcf4bbe040a815e5f3557171f178cb1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -543,7 +543,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -584,7 +584,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -721,14 +721,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d549023aa3dfcadad1ae7fcc696271c0d07cde1ed413f8ffd5cdb38c1d2ee21d
-        checksum/config: bcc51079117fb6d2131c1ede8cb9111575c99a6e694b9f256875d4a286526b4d
-        checksum/secret: 2840697af6410e76dbb957cea16edf481427348c8a84b9782c997fe96c266613
+        checksum/plugins: 8d03946e290ca56dde249a4340100d60997a406af6a8ce97bd67dfa659c1a634
+        checksum/config: cf38d3ae5cd38b52590b4a08093a2b58241d46a1956e5ce8a1d0092b748ee83c
+        checksum/secret: 6e9d848976ea5ead7ab843c4d3b2c84c1ef1dda7e86ca3fa5964d3d4e43db661
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -502,7 +502,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -681,15 +681,15 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a3863766084ea72ced96aa96bb55ad9ea58d86a1026e622f5bf555cfe5dc7acd
-        checksum/init-fs: 73cd1273f15f610932708960add9fc384243b4e407ca8bf285c0522cfc2d3501
-        checksum/config: bcc51079117fb6d2131c1ede8cb9111575c99a6e694b9f256875d4a286526b4d
-        checksum/secret: 2840697af6410e76dbb957cea16edf481427348c8a84b9782c997fe96c266613
+        checksum/init-sysctl: a38e01df16b2bec03940ac61f18d9c4f9375b13baef4bdd2f101b68139b097cc
+        checksum/init-fs: 5aef673a3d1174b12f95eeabf5bf51ccd781966abe13271b42c81c0790121aaf
+        checksum/config: cf38d3ae5cd38b52590b4a08093a2b58241d46a1956e5ce8a1d0092b748ee83c
+        checksum/secret: 6e9d848976ea5ead7ab843c4d3b2c84c1ef1dda7e86ca3fa5964d3d4e43db661
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -704,7 +704,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -745,7 +745,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -882,14 +882,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -60,7 +60,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -114,7 +114,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -171,7 +171,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -188,7 +188,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -202,7 +202,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -231,7 +231,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -250,7 +250,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -263,7 +263,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -276,7 +276,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -292,7 +292,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -339,7 +339,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -352,7 +352,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -366,7 +366,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -388,7 +388,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -413,7 +413,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -439,7 +439,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -466,7 +466,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -492,9 +492,9 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0d36ed7f6dfe4776563e0289eb3ed95e1ec0de3ffc94e5cff4e988bcbbd2e18d
-        checksum/config: b08482db94ed5019176c248458c5659359b5f372671fbcf37eba85dd1d8fe1bb
-        checksum/secret: 2aa88bc6b5287ae26fdfdd60293c8f67e90bd5ecdd5064dfd60e7a5e14cbdfba
+        checksum/plugins: aa9e723357f00332d1b62374e58d86deeaffe6f9f66d8d01ebc3999810146002
+        checksum/config: 8cebd341345ff5a1a8e6c0df5f22d9ee9ce19d58d0f5032880d1e08aa52ffcf0
+        checksum/secret: d94075a792a3a846701df47562ac45d231b964ab417f63e54677dd96f8e48a3b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -502,7 +502,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -530,7 +530,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -643,7 +643,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -681,15 +681,15 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d4655df024b2ad2d5f80c8396612cf60cc27b86d57901c986893bed3d0988c72
-        checksum/init-fs: 73e97797a4d879c914c425f275743d061d5e7c6ccf23d8bec2c17690a189a4ed
-        checksum/config: b08482db94ed5019176c248458c5659359b5f372671fbcf37eba85dd1d8fe1bb
-        checksum/secret: 2aa88bc6b5287ae26fdfdd60293c8f67e90bd5ecdd5064dfd60e7a5e14cbdfba
+        checksum/init-sysctl: e6f772c024cfc90b7cc6ed2e231a2e940d6a815326a9cc9cd9f8c4dd8672d3fa
+        checksum/init-fs: 93415f63b9f05e8c8d677ffa4588b49e3861efb88ad75c2aceb51035aa7f77c6
+        checksum/config: 8cebd341345ff5a1a8e6c0df5f22d9ee9ce19d58d0f5032880d1e08aa52ffcf0
+        checksum/secret: d94075a792a3a846701df47562ac45d231b964ab417f63e54677dd96f8e48a3b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -704,7 +704,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -745,7 +745,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -882,14 +882,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 08cb8d519a3395a9d246744b3f5a3b570541aaa7b287f72d3ad56b709c88e622
-        checksum/config: 17519bf9d6e00a3ddc20c3799989345f657f908b5588695c080ea81a2f3351c6
-        checksum/secret: 71c83330be73ae966b982ba316e64e44a6fbe03255e465249247b33e80198931
+        checksum/plugins: a676ac5851dce158c70ffcab4debbe82dfa8b2cfda36e556dfb9c1d268b13d18
+        checksum/config: 5d7941d45d2f5e82bb055de8dc5978a94b2f98e3d3884abb6aba12c92e2963ab
+        checksum/secret: ca4b659f242aa951b98e3b8b2fce9edd53ff3e5abe60c017821a1936f13b507b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -519,7 +519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -548,15 +548,15 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 030e68a7226798097fdbc080eddcb4f2284ab8a841d477be3f6ac78da950420f
-        checksum/init-fs: 2ba6dd2ae8efb8e4a92cb8046d0bd0a67e49e2acb8931d6af739a3af0461ab51
-        checksum/config: 17519bf9d6e00a3ddc20c3799989345f657f908b5588695c080ea81a2f3351c6
-        checksum/secret: 71c83330be73ae966b982ba316e64e44a6fbe03255e465249247b33e80198931
+        checksum/init-sysctl: 7b400f3545d6aac3809b261ac6927d7ab26dbe42849f3f04d7e575a2c3575caf
+        checksum/init-fs: 3bb259be22af742b1d0231a74ca643d6b47a1bf92afd98d55ba8fc9e691ec2c7
+        checksum/config: 5d7941d45d2f5e82bb055de8dc5978a94b2f98e3d3884abb6aba12c92e2963ab
+        checksum/secret: ca4b659f242aa951b98e3b8b2fce9edd53ff3e5abe60c017821a1936f13b507b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -571,7 +571,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -612,7 +612,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -764,14 +764,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 38b7a97c9a9654a1e7b8a570914b9e65ae02d77653e7b49492410c45da8306de
-        checksum/config: e8db6a2bf24ea9f1c86044535b621c55f403eafca92cb53d1ff25e69e32b8c65
-        checksum/secret: 653929dfec01b475b81de87c11936985731259dc6dbf1724177dea2be12c49d9
+        checksum/plugins: ea9b34be011c1e2ea0693b1dcf457c69db312352624f77ec20b47af65b35093e
+        checksum/config: 2f8b0e6be64643bdb5d481048c4e3071dbeec62af52b3e324769717e8cd5512a
+        checksum/secret: 567e03b7790d0e9cd104092710f447375fdee20d636a674eaf982d5a5e9dc1b8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -510,7 +510,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -519,7 +519,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -548,15 +548,15 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e5df27c1e733770af7595e02dd79247971b240312183d64dc10985424fe82ae6
-        checksum/init-fs: 2513f1ffce6d698aaf62ea8bba315cc19ac15c2e7fea6cb8c6352039af344fa2
-        checksum/config: e8db6a2bf24ea9f1c86044535b621c55f403eafca92cb53d1ff25e69e32b8c65
-        checksum/secret: 653929dfec01b475b81de87c11936985731259dc6dbf1724177dea2be12c49d9
+        checksum/init-sysctl: 81b7c372f8272ef4b8155ac1aa75b78b70d2e0f12e80a07a32c7a3fa8eba10c3
+        checksum/init-fs: a35d93e585971911244ddc23e320805598c49ef121997f9aa296b6917151daa8
+        checksum/config: 2f8b0e6be64643bdb5d481048c4e3071dbeec62af52b3e324769717e8cd5512a
+        checksum/secret: 567e03b7790d0e9cd104092710f447375fdee20d636a674eaf982d5a5e9dc1b8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -571,7 +571,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -612,7 +612,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -764,14 +764,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: node-topology-values.yml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -248,7 +248,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -270,7 +270,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -295,7 +295,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -357,7 +357,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -374,16 +374,16 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 39fb94762d8d1c86a74845654e64902b8a6d3de6818de8021a007799fc833b4d
-        checksum/config: e029e4ad0aad1861e6b1e23aafd54d1ecde0a99661a962a68e2e70fc118d344e
-        checksum/secret: 8fa9025911909efea48badc690a68ce043456e7a1412beea673b1d07af9761cd
-        checksum/prometheus-config: 0129ac46620bb29d056f73ffa26d25cef7de190ea036d11f5dd707aff3a9ef59
-        checksum/prometheus-ce-config: 1866f739268881db50ee9095bbc1e982347702b8a427cde58679b1ce52cc57d1
+        checksum/plugins: d889acdac6d7c20741ebeb67aa0e79a0e7a92c5dc96973b0e6dbc09fd5c5f631
+        checksum/config: ab0111ace28f69c6c40d756919c8583b725794b9ee13e20cbeee7180324a12d4
+        checksum/secret: 3412e27b29de4a11ec2836bab18458273358c5de2574d99b21916981225e8b4a
+        checksum/prometheus-config: 5ddf0816f93fa70359b54921fada78ba4e89f084342ef02ae96a6f94f2d6a5a8
+        checksum/prometheus-ce-config: 731e4bee281f7e772cc12afa51f99f2dad020f95de587163e43065068c46e960
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -589,7 +589,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -598,7 +598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -627,15 +627,15 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b3650fe0a51d6e8c5340412848c333eceaf82f7a66cd981796ce2320f02cdd64
-        checksum/init-fs: 8b9543bc05b41f513a39428af1c1c26e079945ba60d714d0a925ac9cc9d426ff
-        checksum/config: e029e4ad0aad1861e6b1e23aafd54d1ecde0a99661a962a68e2e70fc118d344e
-        checksum/secret: 8fa9025911909efea48badc690a68ce043456e7a1412beea673b1d07af9761cd
+        checksum/init-sysctl: 43fe76d5a5622617d080329f84270f66024c71b1749eaed65ac70a85f9ea9103
+        checksum/init-fs: 2d61336e0c9a7dc82f8e347dfe9ec8737b496c5c375e47e34483e7cc4558186a
+        checksum/config: ab0111ace28f69c6c40d756919c8583b725794b9ee13e20cbeee7180324a12d4
+        checksum/secret: 3412e27b29de4a11ec2836bab18458273358c5de2574d99b21916981225e8b4a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -650,7 +650,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -691,7 +691,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -822,7 +822,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: sonarqube-dce
-  namespace: default
+  namespace: sonarqube
   labels:
     app: sonarqube-dce
     toto: tutu
@@ -830,7 +830,7 @@ spec:
   jobLabel: "something"
   namespaceSelector:
     matchNames:
-    - default
+    - sonarqube
   selector:
     matchLabels:
       app: sonarqube-dce
@@ -865,14 +865,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -822,7 +822,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: sonarqube-dce
-  namespace: sonarqube
+  namespace: default
   labels:
     app: sonarqube-dce
     toto: tutu
@@ -830,7 +830,7 @@ spec:
   jobLabel: "something"
   namespaceSelector:
     matchNames:
-    - sonarqube
+    - default
   selector:
     matchLabels:
       app: sonarqube-dce

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: cbb34030209a8931234f2c0f41674a9d238774d54411ce2eb649587da0a9bd68
-        checksum/config: fb84ed4d21df1fad1009d886fdad64257fa4a9cdc249ce6d30483d2970e415af
-        checksum/secret: ea259faa3a48de50b7511ae670cafad85a1aeadf78f1c7149e57ca000f264334
+        checksum/plugins: dbf21321d5db71a7c7f8d99cb0bf098e2fe04831da8ce7348fc23db8538bd215
+        checksum/config: 4e53264ecbd5d5540c58c413576d1f19f160927355fbd2b9a99a17c9200151dc
+        checksum/secret: 3124c194acd7bb84f51b92775b5f6f58743f81271cfa5c01476c09f67e7e518a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -542,7 +542,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -580,15 +580,15 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3476d073a3aa5480f098f4778d620361268c1748a47fd165e4ea30f84651d0e6
-        checksum/init-fs: 151d5e35256f9bb9949bd48129162d85116be170013e527a485c1b4ab2af4131
-        checksum/config: fb84ed4d21df1fad1009d886fdad64257fa4a9cdc249ce6d30483d2970e415af
-        checksum/secret: ea259faa3a48de50b7511ae670cafad85a1aeadf78f1c7149e57ca000f264334
+        checksum/init-sysctl: 3f29dc19880bc0ef764b9d12d52991782df1ad28d0534e4cb55f40fcf2fafe7f
+        checksum/init-fs: f1b90c9772c379b1fd297351921b59e9d8f7b12783f8288c3b978d6bc0849372
+        checksum/config: 4e53264ecbd5d5540c58c413576d1f19f160927355fbd2b9a99a17c9200151dc
+        checksum/secret: 3124c194acd7bb84f51b92775b5f6f58743f81271cfa5c01476c09f67e7e518a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -603,7 +603,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -644,7 +644,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -781,14 +781,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -251,7 +251,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 
@@ -273,7 +273,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -360,7 +360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -377,16 +377,16 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 74dc9870b152a4c4b864df96dbedc291dbaa9d61c3496207674be8758ad9b76e
-        checksum/config: 5fa2f5ff3e7af46a9cd554be170b3f1b21b7c977092b3950b81d40a05038ea39
-        checksum/secret: 36ca85a5a332e79d6d3a6c524c5155fbbafd998001d8d8e8db2d720825dfd9b8
-        checksum/prometheus-config: e57f2438f1bfedf4e95c1c187621450aee7c1c3997f567bc6cfc970238648ad6
-        checksum/prometheus-ce-config: 57b24b022a2847e509f17f717b39de27e0fa473f77a006e7945298d247ed9183
+        checksum/plugins: 2f35127f2aaabb335cab2563e4b3941614d84720a3db5c23e621b91786e70704
+        checksum/config: 397546881faf73c1fabba3164746a9e6787b1dbad1be16239d48e74e4e951562
+        checksum/secret: 5e9b5731d600d1c92271f13053b00e71822e90dd1647f38afa9fc8859905d558
+        checksum/prometheus-config: c09afcc0be8828b7289b9d05ac5839a3078cfe56b8f042f4e512850887c08872
+        checksum/prometheus-ce-config: b71181ea2e7e84013f4ba901cdbfeef39167f3722b64395296188137c2561c38
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -468,7 +468,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -502,7 +502,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -636,7 +636,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -645,7 +645,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -674,15 +674,15 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 96d5d3a5150f86f8eaaf6e057cb48fc5c8b9e9f4e374aa51e848b229238103cf
-        checksum/init-fs: da3c2e41ef4f892763426067a67a2536be08ae00e49b269964bce4bec62f5abe
-        checksum/config: 5fa2f5ff3e7af46a9cd554be170b3f1b21b7c977092b3950b81d40a05038ea39
-        checksum/secret: 36ca85a5a332e79d6d3a6c524c5155fbbafd998001d8d8e8db2d720825dfd9b8
+        checksum/init-sysctl: 349ce931e2b810868ecfd375b5e5bf604ae72ce39e462327ca4fc393d98ee42a
+        checksum/init-fs: 99855779dec80f03bf1d1b16debf98d5575b5adf99a28d0d59c3e501ce60fb64
+        checksum/config: 397546881faf73c1fabba3164746a9e6787b1dbad1be16239d48e74e4e951562
+        checksum/secret: 5e9b5731d600d1c92271f13053b00e71822e90dd1647f38afa9fc8859905d558
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -697,7 +697,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -738,7 +738,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -875,14 +875,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: de1f275b1626ba2a4520e8d18014296225ac2f9a3c5b47c84270c1a8a5656ad3
-        checksum/config: 67932e647d637a675b38baa5248a3175a088f26861ee32f4ec848ac18d27773b
-        checksum/secret: 490ce24bc4fbdd4aefca52b7e500c6f1cfdf9834a2a7cb0cec45aebc0a7f4d73
+        checksum/plugins: 7a270edfb756d0b997faca9a7b8b8c844f1d94a73ae1f35b9da3b01b5e55f415
+        checksum/config: b5a146386ead51b3acd875584c8e33d145be4755b382bfdfa43e1bc037d07ca4
+        checksum/secret: 0ee9879f7e36ce97723550e94b0fe8d56821799c1c4604a1961e5c47a9856c5f
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -495,7 +495,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -535,15 +535,15 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b6ab7b11453f39c8e1f42250225b7cef85ee8f0aee6254ba1422cd8df9add444
-        checksum/init-fs: 2c3bd400da0059f11b8b8006147539132ed8ef4c2f4118855efdf80cfaef411d
-        checksum/config: 67932e647d637a675b38baa5248a3175a088f26861ee32f4ec848ac18d27773b
-        checksum/secret: 490ce24bc4fbdd4aefca52b7e500c6f1cfdf9834a2a7cb0cec45aebc0a7f4d73
+        checksum/init-sysctl: 118bcaba68a3ad330e342d53e3cd5f99abf5716045ebfab6828b089108d93d88
+        checksum/init-fs: 933afff3247ffe4542ee50db7bcf0e256e0293f6c0111197434d3adb1208db64
+        checksum/config: b5a146386ead51b3acd875584c8e33d145be4755b382bfdfa43e1bc037d07ca4
+        checksum/secret: 0ee9879f7e36ce97723550e94b0fe8d56821799c1c4604a1961e5c47a9856c5f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -558,7 +558,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -599,7 +599,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -736,14 +736,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -204,7 +204,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -230,7 +230,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -283,9 +283,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: adfb811156e20c8de3f04bf0259050e2233a7d636e0ebd0a2195b9378e81d7d6
-        checksum/config: ee5cc29b456032f9eec7eea44a6003e85c8538c1ea329a4030d6e8c85e334b62
-        checksum/secret: f2aa2020e15270576ae0b3a7028abc04a6e590390eb8aaf251d4d11d0d982b02
+        checksum/plugins: 31705eb01474b9046811431dc66bcefb534e8031c83ea59934f1fdb2b9d876e9
+        checksum/config: d31dd3d00e81c9f37b400b0f5bf9651e9fd2c16996c0b671b1874897e9676128
+        checksum/secret: a7cdbe6185a13c2f27791fe2d9427e6405623010f34b754c0a47db021fa2e861
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -355,7 +355,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -480,7 +480,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -518,8 +518,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: ee5cc29b456032f9eec7eea44a6003e85c8538c1ea329a4030d6e8c85e334b62
-        checksum/secret: f2aa2020e15270576ae0b3a7028abc04a6e590390eb8aaf251d4d11d0d982b02
+        checksum/config: d31dd3d00e81c9f37b400b0f5bf9651e9fd2c16996c0b671b1874897e9676128
+        checksum/secret: a7cdbe6185a13c2f27791fe2d9427e6405623010f34b754c0a47db021fa2e861
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -692,7 +692,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 31feb3725a3b968f86b0c52abeee12601df0dae19b9dba861fdc04ebb1a969e2
-        checksum/config: e9cb0092ef8e479c06149a758a3589dcd1f2d55a9961b0c2c10033ad17ec8e67
-        checksum/secret: f331e28fd7b447331693e0eca0a4116e4e33e59d6c3a2d8a5139308b4affb926
+        checksum/plugins: d212eb5371982773c3b43d323308d2cb03cdd919938b80d63eaae2333879a95b
+        checksum/config: 56258e588fb1208698a34c234b71680654ba75c3909a382ccaaf5cc01bb41a68
+        checksum/secret: 24eab81299e6d9b91494c0bb8d6ea7f9437a713ffae70a0337734109ab6dffc8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e39a8d143b7d37fe57b253d54d15f685a4aceeac796160fdb00be85fc06e33c0
-        checksum/init-fs: 8d65166b06caba6c553e2411cafd77f94545b52224bcc6663bdb8afd25850c56
-        checksum/config: e9cb0092ef8e479c06149a758a3589dcd1f2d55a9961b0c2c10033ad17ec8e67
-        checksum/secret: f331e28fd7b447331693e0eca0a4116e4e33e59d6c3a2d8a5139308b4affb926
+        checksum/init-sysctl: 0e83c07c031c1660e48f95ae99645192c2f1d75be6f6e17c92329f7a3f533a17
+        checksum/init-fs: 663b08eb5b659abc1fb3e881ca2897889187dd100e1deb8e6282b8a4a0913318
+        checksum/config: 56258e588fb1208698a34c234b71680654ba75c3909a382ccaaf5cc01bb41a68
+        checksum/secret: 24eab81299e6d9b91494c0bb8d6ea7f9437a713ffae70a0337734109ab6dffc8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,14 +748,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -787,7 +787,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.4"
+    helm.sh/chart: "sonarqube-dce-2026.1.5"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -247,7 +247,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -276,7 +276,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -305,7 +305,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -336,7 +336,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -345,7 +345,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -362,9 +362,9 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c6fa606aab21919f2dc589ec59a526f05ba32ecb6b460cba7d95374a0bbb4282
-        checksum/config: de77a85c3f823afe097c3cbde1b1cd6f9f6f285ffe0d5ebf476ba41009842951
-        checksum/secret: 4d43e2c364bcbe9ea57b9c03391d3a51fd3ecb6193112f76d55af27572edb971
+        checksum/plugins: 9535dc2cbfacdde978ef37ea83c7a4a1f9c6c93cd33a495ce072cf936e462a89
+        checksum/config: e8d1aa15a1263044a4b85965d5da4a6ec400cf41733718d40c839c3a13349a53
+        checksum/secret: 3f9913867bf776e850a69e4c252b339f31cffff28356eac824514a7a7ed6360c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -372,7 +372,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -400,7 +400,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -513,7 +513,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -522,7 +522,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -551,15 +551,15 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3409389608c34c5b97cddc06d6516588ed6061ea8e9745a0ec8f580dc88665ad
-        checksum/init-fs: cbdab5d49e4416ec07da9ef1a984b26acde2aad9f9ce3809544bfd29a2cd1756
-        checksum/config: de77a85c3f823afe097c3cbde1b1cd6f9f6f285ffe0d5ebf476ba41009842951
-        checksum/secret: 4d43e2c364bcbe9ea57b9c03391d3a51fd3ecb6193112f76d55af27572edb971
+        checksum/init-sysctl: 5409c5fc03836c4a6ae129879366dc6cc9b4e7f05e36a6fa7c823bf84b9c5960
+        checksum/init-fs: c6a43424abc77bcd1efe35f70612bcf4d3bf29a752f9a175c6351c0200d57c69
+        checksum/config: e8d1aa15a1263044a4b85965d5da4a6ec400cf41733718d40c839c3a13349a53
+        checksum/secret: 3f9913867bf776e850a69e4c252b339f31cffff28356eac824514a7a7ed6360c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -574,7 +574,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -615,7 +615,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -752,14 +752,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -49,7 +49,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -63,7 +63,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -77,7 +77,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -92,7 +92,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -111,7 +111,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -124,7 +124,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -227,7 +227,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -249,7 +249,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -274,7 +274,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -336,7 +336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -353,9 +353,9 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: fd30ac28d24ef06e394b51a19b1fee36968be5fea1ab83b8a62e49df70e504ee
-        checksum/config: 06f66c15cac8e5b72edbc3741f5cb881c091f98c76591ebb983116c9327c61d7
-        checksum/secret: 496d6eee18908d8226f7b3ea1d5e8f096b05f7f329e94062bb94f57e28b4a4ab
+        checksum/plugins: 5c45c19aa72b62e973b93fd5eab26205942279f0e250cd60e3a07c5239abb26e
+        checksum/config: c04ae31fc0c954d2f396ad32743cfb63de4606003bbc86ca08dc0c074cc858ff
+        checksum/secret: a6bd480948eca54f8d5770fe6f8c053528fc7f80dba3773c3ba6a831a81a41c5
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -363,7 +363,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -391,7 +391,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -504,7 +504,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -513,7 +513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -542,15 +542,15 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 523501847ed67ccb1ecfced937a8ff3f911c633c8da77ba09efa86758292ffd1
-        checksum/init-fs: 5d833cc0be667c290ec1ab391910b503080c1a4233be766838d4c434855defb9
-        checksum/config: 06f66c15cac8e5b72edbc3741f5cb881c091f98c76591ebb983116c9327c61d7
-        checksum/secret: 496d6eee18908d8226f7b3ea1d5e8f096b05f7f329e94062bb94f57e28b4a4ab
+        checksum/init-sysctl: 70abb7f2ce5ba717442f0ce6752e782bf4c8a86847ee2da85180f60f6d640ad0
+        checksum/init-fs: 4e4a19b4de9780beec6f3d03fbd3471cf358830b6187012c164ca56977746cb4
+        checksum/config: c04ae31fc0c954d2f396ad32743cfb63de4606003bbc86ca08dc0c074cc858ff
+        checksum/secret: a6bd480948eca54f8d5770fe6f8c053528fc7f80dba3773c3ba6a831a81a41c5
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -565,7 +565,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -606,7 +606,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -743,14 +743,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -206,7 +206,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -255,7 +255,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -333,7 +333,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -359,14 +359,14 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e710bafe26dbe7c72ed0b910d0a9f01533f423a29310dae38516cc01aac35772
-        checksum/config: 65b1217518016c9ed283a0a2e6fcbef943bd1f8f6e139c07a61953f2df6127bd
-        checksum/secret: dc22630d26497260e1c25395281586a8aff554fb283624c6fdb668c2453e32b7
+        checksum/plugins: d6c8a1fca28b5fc6b5785d4cac47d5745e31d6bf795127355274d448ea54901f
+        checksum/config: 118ca6a6adb9aa00b8cb4f123043751f9a3fa436d043a70fb35012a8528b2138
+        checksum/secret: e747e43f4d8baabf13d6e01304946574896a2e12c0967329b2a99f9d471d6d46
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -405,7 +405,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -433,7 +433,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -558,7 +558,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -567,7 +567,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -596,15 +596,15 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 94db325c9557a24c0c13a6d6fe4ac7f5775b0aa3bed35b77a8064e4b6f754e4f
-        checksum/init-fs: c41b6243fadc153dda8d8a0bba03ab43bc1f4e2b4f1537305b84c191ea80498f
-        checksum/config: 65b1217518016c9ed283a0a2e6fcbef943bd1f8f6e139c07a61953f2df6127bd
-        checksum/secret: dc22630d26497260e1c25395281586a8aff554fb283624c6fdb668c2453e32b7
+        checksum/init-sysctl: 45b232bd65d7b05734e3d183e16b20c8dfc52046561d57d3857120de405de429
+        checksum/init-fs: 50be5f2905bc0617ef4ce868b34d8c35f3bec1244b8a68d6738d261752de1afe
+        checksum/config: 118ca6a6adb9aa00b8cb4f123043751f9a3fa436d043a70fb35012a8528b2138
+        checksum/secret: e747e43f4d8baabf13d6e01304946574896a2e12c0967329b2a99f9d471d6d46
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -619,7 +619,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -660,7 +660,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -793,7 +793,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -820,14 +820,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -859,7 +859,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.4"
+    helm.sh/chart: "sonarqube-dce-2026.1.5"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -879,7 +879,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.1.4-datacenter-app
+        image: sonarqube:2026.1.5-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-app"
+    app.kubernetes.io/version: "2026.1.5-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 9ec9a898c96cf180e36c9b6861ba1d3a771739c06165f5c46a3d7cc9f646a7d0
-        checksum/config: 97bb3e24f6dff5ff428ac02d3c2ae482b8518e9c62fbfbe73c633fa8b9ce303b
-        checksum/secret: 1de28650320a9e4f03b176d90d681aa482e75e80a2f9dd319217fb44399875f9
+        checksum/plugins: e57e080a7762fb974de6ffe276b2ffbb591e109f514c3300caae29662009d0df
+        checksum/config: fd28fd5625e83bbeaf54d730189dbf9fca693b7dce24f64ef80e62c0ff0d5e70
+        checksum/secret: 19cb8ca657776bd7ffdd13be3652238edb075eb6bd75bd57e9fc151f89a501e9
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -509,7 +509,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.1.4-datacenter-search"
+    app.kubernetes.io/version: "2026.1.5-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -547,15 +547,15 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: aaebe005dac1f9842f29b0243776a7c568c8561939ca97636af95d84cc202513
-        checksum/init-fs: bf580aa45991d7001f89fe990ef81e50fb9c095bedf50ef8a22254356b841011
-        checksum/config: 97bb3e24f6dff5ff428ac02d3c2ae482b8518e9c62fbfbe73c633fa8b9ce303b
-        checksum/secret: 1de28650320a9e4f03b176d90d681aa482e75e80a2f9dd319217fb44399875f9
+        checksum/init-sysctl: ae114656a8e9ab6e443248fd673f9d107e98bf9ae0aaa9c041c33015b394cd13
+        checksum/init-fs: 4c62f79b27de83dd1e50bd47d6e64fe2f09ac962fa49d2f01d6d90dc5fb37bf1
+        checksum/config: fd28fd5625e83bbeaf54d730189dbf9fca693b7dce24f64ef80e62c0ff0d5e70
+        checksum/secret: 19cb8ca657776bd7ffdd13be3652238edb075eb6bd75bd57e9fc151f89a501e9
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -570,7 +570,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.1.4-datacenter-app
+          image: sonarqube:2026.1.5-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -611,7 +611,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.1.4-datacenter-search"
+          image: "sonarqube:2026.1.5-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -744,7 +744,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -771,14 +771,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.1.4
+    chart: sonarqube-dce-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-datacenter-app"
+      image: "sonarqube:2026.1.5-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -810,7 +810,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.1.4"
+    helm.sh/chart: "sonarqube-dce-2026.1.5"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -830,7 +830,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.1.4-datacenter-app
+        image: sonarqube:2026.1.5-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -151,7 +151,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -159,7 +159,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -171,10 +171,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e484e6d83f8b5aac4220b085b0fecc5f28dec488e92b00fd051e1e10ec44094d
-        checksum/init-sysctl: 1ea9efceb03dc124f208903102eff2e009c4107f2898694f01d7c3884e0a5bc7
-        checksum/plugins: 2add927c8e9d31dee88962e2f4582dd839f42d8c55e2df9898a4eae122706d5a
-        checksum/secret: c5ad8cf24da0eea9e8f4e48c0de4411ea755803d0479ab6e4efe838317f5d42c
+        checksum/config: 15b9dc1ff484023d8a88b6131d29dfc72832ff2dd89422204ad2739e564c01b1
+        checksum/init-sysctl: 145f1f010ac8e0ab30186b3eb331c7e296914f5875c47b55c0b060f8ecd35fdc
+        checksum/plugins: b0e67f6b885a5fa700e4100f2ece3bde100414c378841d7432d53af15ed4456f
+        checksum/secret: 13636aa0dae795e3447745ad7e7e488e7459b28893591255763c18f9bf969b10
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -184,7 +184,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -213,7 +213,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -231,7 +231,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -264,7 +264,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -403,14 +403,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cdb882e56e86e30d78b892577d8ae6eae5de8ef8040b4d7680afd813ad5d64af
-        checksum/init-sysctl: c4e5ab441ab91dfe97e9e4a161f13c55950c294c1810b73c42991b287943b54d
-        checksum/plugins: 4c2659b753fbace8953412180399a90a624ea5aa52d0973b98676cc1a51ed732
-        checksum/secret: 3acf66cf454ea240d5b3b47133e74a3ca6ce681ef755d919988a1b12fdca7525
+        checksum/config: 0c487786ed1da3031bec89cb8f32a3454b58f79a23c6b5821163687ae6c42e46
+        checksum/init-sysctl: df76e0b2d1a04f788578e0dad9f2d40f0b4642e77593e3d98bcf620cc0bfe1e1
+        checksum/plugins: 29b1c8a08aff080252fdc79c70028f7c3db0e416f9afcbe424494e585d454eba
+        checksum/secret: 25444b6a98e11e5ab1147fa8a2f4ad54c69bdb91b5ce02330a00b5073c7945f9
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh"]
           args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
@@ -197,7 +197,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -216,7 +216,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -233,7 +233,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -338,14 +338,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 16c661a22acee0152c1e2bdf3c7ed9d96129a3e47e04959d12dad4a33a34e3ee
-        checksum/init-sysctl: 0f9c520f3342019d6b243ba5d36e609a61bdb36af5e01f9ffdfa6b70b0a0c5ff
-        checksum/plugins: 2f06c0c7f1e0a5097a03689cf209079f2d5395610a3265d956b1876e7a348746
-        checksum/secret: 9f9ae03b265ef3e55e4bb11005476fe50f3279ce07db787e1859dd9d461c8d93
+        checksum/config: e071a577bd5db4d8a842e252b9c67d180213f5c04be98ff3c8d4a4f011909bee
+        checksum/init-sysctl: 7242f3a398f7c07ebd83f6f42e284e761cc76f5e71e2fd4d6aed4e8b3306c2d2
+        checksum/plugins: 9d986523f9b9288bfa351434c5ec24a29e2c1807bbce00b989d9ee4106c4dcc4
+        checksum/secret: 630f2ee6b378f1b23906609f0403fc0cd58af5ce49a5020dab3054462cd2a04d
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -357,7 +357,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -370,7 +370,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.4
+        chart: sonarqube-2026.1.5
         release: change-admin-password-hook-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5f7828142b68b5912f9a4fd6b47935da812536ac57a363f5731b47a0af90057e
-        checksum/init-sysctl: e59f1ad423d5adc40944ab64149583cb930830efb31e5c00534704feb4c2b705
-        checksum/plugins: ff7f2a906ffd797d837be98676b033e9495129d8e3a7bf1e2b2dc0dcdfcb09ab
-        checksum/secret: e9c99b2febc2e819cdcbc5622aa5039d6ae2536da5d46aae499a9dab0976852c
+        checksum/config: 83c6fff7695d6f3101087ccede7511765ad34cd0fc655518e2c408610b4b0afb
+        checksum/init-sysctl: 726fceb8c4193b52f2948b8264786ca4e72a5239c077859428027cb0c0a211c7
+        checksum/plugins: 1582c23287af5e6e7b43b72e3289d886a83e8f957c79b6a3e637425f6fdf7819
+        checksum/secret: 8250a37fb6df2ae734327183d0b524d07892482c1fbc999d6e11ca5551e03f3c
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -58,7 +58,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -139,7 +139,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -159,10 +159,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1bbcb84dd061cf9617ae7ca5a22f1eecae50a6ea56e7c3f7c834b5542aa3b87b
-        checksum/init-sysctl: 0f04b1a1ef388b73c925db8ad7f907ca66f181ce246de3f21888309e09a474db
-        checksum/plugins: 095583772fa206df8e3b7b200c0b2a5c26f6a72653e95cde7dcdf071c9abaded
-        checksum/secret: 8a3ec750b2ebe2cb1249e4ea0d3d7eb34a7f4552b1f66caf7463251cf4145e00
+        checksum/config: fdf4c4d54060131cceac4659497dd4237c7632cbe22c7b4821fabde10501638d
+        checksum/init-sysctl: c9c5662f7457191265fd9c92b1c94848c4b4ea2e407fadef53d9a61a8c2750e4
+        checksum/plugins: d149a7fb290fc8ea61ccbbae7f8809d29c6f8d8c20a8113f6b1cfc8a3d2a48c2
+        checksum/secret: f62e6068cdaf1a1722d9ddcc6637ad51fb4cd49b478205b2fd6330bbccf6a1e3
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -172,7 +172,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -190,7 +190,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -235,7 +235,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -252,7 +252,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -384,14 +384,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 36134281175487352df708c3bf236afe1a4e296c850142b4c2726893e6b12aad
-        checksum/init-sysctl: 827530b13c3f2167c2c2b880d6b9102836d12c933c0ee707afbf5fa616453118
-        checksum/plugins: 5b51e2afec055a9be7b93cfcab854249b71067e8676771763ef4403616d4f053
-        checksum/secret: bb4d7bcb50a7b9f1de387cedaf8dec5a85aac1fdf3ca98e830905419894a079e
+        checksum/config: 6b5d1378e0a66ef36add73768ffe8449acdd960f24aadf257cf3d5d1a60152f7
+        checksum/init-sysctl: a9282ac3c36749dedc3b4ee4b4cc2a76bcf77cfbff25750f0865aaeeb64c7709
+        checksum/plugins: e0e1ff0602b5d9f4f89b1e6f647c60a38babf23abdc612b36628342e44fff934
+        checksum/secret: 57780689fc59a028c01f18258bb0ca268719a1838ab40260e934c78c0ce4bb9b
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7af4c3011d3cf0568ab88f08cbc3672f3a018c254d0c82c7cad412df0e280efe
-        checksum/init-sysctl: cd44574fb6d0200c3212ce574a566a5974cd39bd7e40a190cdd2bb9770ac76df
-        checksum/plugins: 3690f40697b2ff3c96dd12f222c8fb67f9c42b86b1c3b89628b30f51d0195515
-        checksum/secret: 8eee94d8449065bc67e0ee6d2c78e465d76824d64b2bb2baa8d1d977f542f3d3
+        checksum/config: aca6e927e738ef2a4180c907bd9a915ed825588e62da5bcaff9c05ee34d30dc9
+        checksum/init-sysctl: a5cd586d7179c07b5590ec7764a270ef0d367076b73a926706a69c842dc7a8f3
+        checksum/plugins: 70af3943c3e461b2b82b81d84cccefe3f14dac2b37cd4a53d91fb5fc208dd59f
+        checksum/secret: c9d9ff797017af01ac9e73981a3561775ee195b47d811e8f1f96fb3e05e58e17
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,14 +306,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -156,10 +156,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 133d16e193ccf16bc2ff04f6304e05a22c806ed5a1848226114ff4f2d9f6f03d
-        checksum/init-sysctl: 77eb85e860fc60c9b581efc6cd48e134de49249bdcd2f7ec18937521a5170387
-        checksum/plugins: a611af9ddc46323d06847709c9d64a682b20f07041c408d714732e8028c980c6
-        checksum/secret: 183ce4c0081393f55c0cadb01c00f9f322b1ed5caad0994216d6d7b79a1283bf
+        checksum/config: 0595b09a715942ed6f9b5b9eb19063dceae02dc26db8ea824c0e9b1f45951de2
+        checksum/init-sysctl: 71b26689cef9eeacc500fc4a37e7ada8958167e500671c767618ca45da0214d6
+        checksum/plugins: 86ab2d2bdfdbd26cdd59e13dd86eb835a94ef3e2774cf13568fe1a45c7a461bb
+        checksum/secret: 98831f6053fa8a651132509cdfd67027e8528d051c410586d4020b3f400cefed
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -169,7 +169,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -188,7 +188,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -205,7 +205,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -307,14 +307,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: deployment-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -165,7 +165,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -173,7 +173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -185,12 +185,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ec5a71d3ac99ab227991644bac78917fbccfe829d2a89dd3b7e5b842f4215447
-        checksum/init-sysctl: b6c12b84c394545e0de7cf70233c16b1eda3e8a0b854a06fb7c148025c61623b
-        checksum/plugins: bad480f01975e43238e182aff69eea145b810fa485a52e5b56a27950482eec7f
-        checksum/secret: dd21657435348856573667735f3a07aafd303639f061c78b5d9245eabe75a339
-        checksum/prometheus-config: 89b5d6077e597d269411d76ac18f90aa39d3a2ab4fc6a24342169651c757b55e
-        checksum/prometheus-ce-config: 8b190a6284a628bdc939cd1641d72ba0ed10db363bd33fdc90713cd5277dceee
+        checksum/config: eb6adb810c8fee3988d7feb142ecc2810a3912999f22320a4bc97d44259e6129
+        checksum/init-sysctl: d367f8fbedf20be30c8e22014c54291f0f9df9fbf8f6362631ea450eecfac414
+        checksum/plugins: ff90acf90c6f53ef58708492645c020e7e5b7b1b224d8a94fe9f8a80ea1311a4
+        checksum/secret: 5a1626bd1ac43b756c422936465d8c54274263e48d9c3ab67bc3c34cc507bf90
+        checksum/prometheus-config: 405f5635c09f227e4863254ea6b36cd9707d7fc8818fd5eb4f387e3a611b243c
+        checksum/prometheus-ce-config: 4ee1ae2bfc218e130cb8f287237165dd860dd8b039d1940d3b02847f34148ed9
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -200,7 +200,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -275,7 +275,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -298,7 +298,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -425,14 +425,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
     app.kubernetes.io/name: host-path-values.yaml
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 28af61eed790c48a283edd08ed25eedbdc247dd9c6928239b588f8908989a771
-        checksum/init-fs: 96c0fdeeffbdc6f0379dfc843a3bbd9f7930425426a25c10887549b6cc679b41
-        checksum/init-sysctl: 3a9f49d68e4a61692c8774927afb6a9ea0772f61dbfd3612267eb43d0d1e6eea
-        checksum/plugins: 4ac94f627b5d2cf18eb902f21014c79793ca7e4558b4a43c5ad7ef3eb818b357
-        checksum/secret: cc29da434371423af18bb65cf95e4719bd503d808ad5596a849a6a4392773487
+        checksum/config: 237a5c17b4142034fc2fcecec2b188661cd498c98e9680bccdbce2f9859550a3
+        checksum/init-fs: f32bfc7657c01913c37c9e16dc4fb25bb8b152d14b3ca97600a567d684932d48
+        checksum/init-sysctl: fe25846626c1d443dca9f7141d72323cf3e7b0bf594818268d67908f6ad22049
+        checksum/plugins: 64fa730bc39d32dbe835d31ac766a2d16393e7b4d101f3a4fbce153d967e22dc
+        checksum/secret: 753fdb0db6af99a11db41336be3e66a6601b74bf718ccb76185916019d684058
       labels:
         app: sonarqube
         release: host-path-values.yaml
@@ -272,7 +272,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -381,7 +381,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: host-path-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be5fc560fb9ba84e55ed83c994c938d21e0fd337f326026d9fc28cb39038536c
-        checksum/init-sysctl: 023b13968b331a34bd0e6d66cbd83ae86afb4d180fddbcc0fbc03fc208b2b91e
-        checksum/plugins: 9aac5bb1b0860763beeec75a9ffb4a0ff42d0aa5432d45ad091138fd23bd8cf7
-        checksum/secret: 31c00c68c8b83417eb7466414b52a4784c4a2fb904c5830de519899384300ba2
+        checksum/config: 638b4de5ee6ea332badfd6848df32c2a767a0ce280930e2bc8c65327f992e706
+        checksum/init-sysctl: 9d8c53720420250d632bd87ce005f5589788474825c92b84acec69c0ea04533e
+        checksum/plugins: c30b777566bbb59cfe25741941a4faf110d54fa202b35cfd1647e3805589fa75
+        checksum/secret: cf45628e8ee89d97af43f58b0d6d895affc100f7a38ba40341a4bd84cbd6aa63
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -331,14 +331,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f81697dc9f19790b440884d0f547201f207981610968e419337df068b70906cd
-        checksum/init-sysctl: a295d0e39f23c878951a6ae5ef9c5f38a8e623fdf2f620ddcc4a2d9d77635eef
-        checksum/plugins: f1f42743896b6247a0c5015bf3faf6d52ca4ebe0f5227280a5e2b6a39a17df0b
-        checksum/secret: 2a5e42e341e99aaaf4259dd832223207c1d5b7efeb60fb85c73970d3b220bfc2
+        checksum/config: 16e932a79be0b7f6627e1dd3d3420646ab7bdad09a66f361ebb8486c7189784c
+        checksum/init-sysctl: 744ff15e79cc0b251baa7c6e42d76f1bf6c9ee0f8ad4b8cb75796015f05077bd
+        checksum/plugins: 122e5f0f4f89b9e63d1542483bbca8ecdfc345fdc6022a8927ed7ceb75044fca
+        checksum/secret: b030c7604b78cda814c8f701a1dc31f078bc1f5e3bf799c96d54f3596c309187
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -332,14 +332,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a01581d83cd99c916b7f21e16569205d39f4f07a42effe269111e4a9790d2085
-        checksum/init-sysctl: a64df8283cb89031e0caad29542b293e15066493b6ae51cb5c9bdfd8455777e9
-        checksum/plugins: 55165afcd2989cb95f1342060693e1e48bff544e33c6554c888da5a0589098b3
-        checksum/secret: dfb103e9c30c55a82927f6b877f2dc321791415f8fe852088d91c532acfca0a7
+        checksum/config: d6d18e162b958121c3af76f33ef364014bb61641a0fc4845f472b8a88ae360fa
+        checksum/init-sysctl: 33754157eadc87de6c9fd4e4097edafc08a68cd85d9f1995b58e12dec8f30fee
+        checksum/plugins: 47b187c231d0c91d0eced63515f9d0a6ed682bfd532a509533bc6ac6e09919a3
+        checksum/secret: 5c894e72198fd68f3c280f41f07f20b4ac9687da06c0d22a4b7c95d4ba9ce263
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -339,14 +339,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: default
+  namespace: sonarqube
 automountServiceAccountToken: true
 ---
 # Source: sonarqube/templates/secret.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: default
+  namespace: sonarqube
 data:
 ---
 # Source: sonarqube/templates/config.yaml
@@ -73,7 +73,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -242,7 +242,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube/charts/ingress-nginx/templates/controller-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -257,7 +257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: default
+  namespace: sonarqube
 rules:
   - apiGroups:
       - ""
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: default
+  namespace: sonarqube
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -359,7 +359,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube/charts/ingress-nginx/templates/controller-service-webhook.yaml
 apiVersion: v1
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-  namespace: default
+  namespace: sonarqube
 spec:
   type: ClusterIP
   ports:
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: default
+  namespace: sonarqube
 spec:
   type: LoadBalancer
   ipFamilyPolicy: SingleStack
@@ -430,7 +430,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: default
+  namespace: sonarqube
 spec:
   selector:
     matchLabels:
@@ -577,7 +577,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -597,10 +597,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: aea0424b29adeb587362915debaf72a5a8e38087af0405369449231025ae2f15
-        checksum/init-sysctl: 38ed0afca52a973f0e41caeb8fd8104c609f484b04dd8d25e22ec23f74f78939
-        checksum/plugins: 4a3b03e4798edb310f61389c2a5df245a1c828941048e5d3d796b91d71c24a89
-        checksum/secret: 29d826072ca6f0977ed5fdccddd1df86c8f8c5033ef56a17ed6e8d4202ffc17f
+        checksum/config: 935f927b85198dfe8335815abe08d3456584cbfba00d57862d28d98323ca2458
+        checksum/init-sysctl: 9d899b172e7e2494530e739576942ba2efc57b7d42b37ba31ad04fe3b44b8903
+        checksum/plugins: fd3bc3c15a5aedb04312944a422a6407fb9be9ecdfb53b919a956ea7a56442a5
+        checksum/secret: 657250efcf6d0cc385892ef6eac1edfdbd73ccaf68529f19bd5d51ff5a0b1ade
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -629,7 +629,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -646,7 +646,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -822,7 +822,7 @@ webhooks:
     clientConfig:
       service:
         name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-        namespace: default
+        namespace: sonarqube
         port: 443
         path: /networking/v1/ingresses
 ---
@@ -835,7 +835,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -897,14 +897,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -930,7 +930,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -949,7 +949,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: default
+    namespace: sonarqube
 ---
 # Source: sonarqube/templates/tests/sonarqube-test.yaml
 apiVersion: v1
@@ -962,14 +962,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -997,7 +997,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-create
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1059,7 +1059,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-patch
-  namespace: default
+  namespace: sonarqube
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: sonarqube
+  namespace: default
 automountServiceAccountToken: true
 ---
 # Source: sonarqube/templates/secret.yaml
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: sonarqube
+  namespace: default
 data:
 ---
 # Source: sonarqube/templates/config.yaml
@@ -242,7 +242,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube/charts/ingress-nginx/templates/controller-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -257,7 +257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: sonarqube
+  namespace: default
 rules:
   - apiGroups:
       - ""
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx
-  namespace: sonarqube
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -359,7 +359,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube/charts/ingress-nginx/templates/controller-service-webhook.yaml
 apiVersion: v1
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-  namespace: sonarqube
+  namespace: default
 spec:
   type: ClusterIP
   ports:
@@ -401,7 +401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: sonarqube
+  namespace: default
 spec:
   type: LoadBalancer
   ipFamilyPolicy: SingleStack
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-with-controller.yaml-ingress-nginx-controller
-  namespace: sonarqube
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -822,7 +822,7 @@ webhooks:
     clientConfig:
       service:
         name: ingress-with-controller.yaml-ingress-nginx-controller-admission
-        namespace: sonarqube
+        namespace: default
         port: 443
         path: /networking/v1/ingresses
 ---
@@ -835,7 +835,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -897,14 +897,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube/charts/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -930,7 +930,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -949,7 +949,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ingress-with-controller.yaml-ingress-nginx-admission
-    namespace: sonarqube
+    namespace: default
 ---
 # Source: sonarqube/templates/tests/sonarqube-test.yaml
 apiVersion: v1
@@ -997,7 +997,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-create
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1059,7 +1059,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ingress-with-controller.yaml-ingress-nginx-admission-patch
-  namespace: sonarqube
+  namespace: default
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be6a65c0914f61eba898287c66fd696ef5144f6f8293177c27ede440d59ec094
-        checksum/init-sysctl: daa4850129e4918bdf2ea55353a9c6aeba4d7f9f162104f61d44388d2375c61c
-        checksum/plugins: 108a1cbe30a2edbd156a3941d3b08c89a546cdc34a53a7298ea3fbd5a01d7092
-        checksum/secret: 77fade6354fcdca5245707151ad65d74a7b03ef8722f9494c1ac8b204db3a7ba
+        checksum/config: bc727339d3cd7c472bef4f7e06f15ac3dd17003f25a2d8d1c2df207cb239db23
+        checksum/init-sysctl: 9a58b37a2539035df33b57f7abb219106fafe994a10c042f48256d2c0d884e6c
+        checksum/plugins: 7cdbd94230287b8ddf4daa472c071ed835853d75036e4003df3f8bd32bda819c
+        checksum/secret: 80db80cd330a43604a34437a980cb0d5084dfe8750da98ab638f1515b93fef0c
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -35,7 +35,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -162,7 +162,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -170,7 +170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,10 +182,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb29de0a692bebc9270905deaf6cf1b286da25b8f4edefbf2c0fe13fa1bcb74e
-        checksum/init-sysctl: 0f530cfce671b767be0ab26520b4a40367237b15ac63b3644d5085e5db8442ad
-        checksum/plugins: d16986a891c01233e5358e3e5dc78dea27ae3cd44baa3c2943d0c1ce5ba79088
-        checksum/secret: 9d2fa202d72366826d57228f2aef2aa2e5ee6cfc2a9bd3a22feb438337bdc3bd
+        checksum/config: 468a932dc7c86752c907d4e8fa42249dad0524e87b0525e9eebefddc438320e1
+        checksum/init-sysctl: 4cb3569d2c777ae355c19e8738e7f79995ca08284ec20a8a450ee0acf87bc688
+        checksum/plugins: f70a16c9d7b7b8f99e595e18146876e191acc643c0800063435b9e83c2c38308
+        checksum/secret: 48b0b4b840399372170a93dfb34fbcf1e7fbfdceacd558e5697ebc1d36d067ac
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -195,7 +195,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -214,7 +214,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -231,7 +231,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -340,14 +340,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b6cab209ea0ffc373194d7ad08969829b28258b48a77f613708907bdb32ae81e
-        checksum/init-sysctl: c093a2d17dbade1bcd08e1087eeb8fd8622e087ceb400d8a79c889e9a8a7e2b8
-        checksum/plugins: 3a67fee3a044940d9ee238693d3419886012d9a1d11b1eaaf61fccb59fef75f0
-        checksum/secret: 4d7d888f9e1a50405e72dfee45ba46f09f90149ed8a6ec5ca6be505cd3c26991
+        checksum/config: 750f155b2369a2e65dc12ce0ac79dc176d7c02df4058a26234581c43af1d77e4
+        checksum/init-sysctl: 2053c59419b79c0a94064da4957d522e7285e762b04beed41ba350c77eb81b18
+        checksum/plugins: 36630776e81b7d56c9b1cdd9f32ce1a7e35758a1c4bdbd08b9ee18955f18aed6
+        checksum/secret: d01b3b13844184c91a7fe0a761738732b3cca0eee4a0b61816b034d12430cf3d
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -249,7 +249,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -268,7 +268,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,14 +387,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -47,7 +47,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -103,7 +103,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -122,7 +122,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -135,7 +135,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -182,7 +182,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -195,7 +195,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -216,7 +216,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -224,7 +224,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -236,10 +236,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f0b197f3d03b40d9dcc01ec8868713c592f8f05282137eacc7bfa439c02e8b77
-        checksum/init-sysctl: 5cb0adf53b883f2278fb460785d984651ebb66a9d0debf55906307152cd8ffc8
-        checksum/plugins: f0c4fc0da2021c09cdc2c48c20496e7affe80c6fa66bd4937eb9f19f8fbc7a41
-        checksum/secret: 39213f3d03e7ec43d7357b5f10fdcbe755bbb75e945e2b25a83dfdc5f2ce81d8
+        checksum/config: 61749c829d71108b58efec8fe84a39ed5506b7bf40876d03b1a51674ccce5630
+        checksum/init-sysctl: 251db5abef0629d2cce22a23466711f1aae8afc102f74605899763af47fb6faa
+        checksum/plugins: 675cdbe685cb952a3029453ebd0058dfb63daa17154fc09ec9c20def9029736a
+        checksum/secret: 470cd85d9f08ee740dcb6ae69795f50c100bfc1668807d99514d16c4dc02c026
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -249,7 +249,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -268,7 +268,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -285,7 +285,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -387,14 +387,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -182,7 +182,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -190,7 +190,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -202,12 +202,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a1cb9e04868de64e6ee0debf73a7a7dcd59e7d2501d36759b74b2b54b52111ea
-        checksum/init-sysctl: 351743a9d9472b482a1d2c304afea1a92add11e782268b1e32f4997e38df3994
-        checksum/plugins: 3d676d10ff5129bd6ad7b647a86b946e517e9967d3bfc05d19e9b8fa20593861
-        checksum/secret: 1717b9f221bad4363e44810bab8997ef8b2ec4c7177ff391a92a17b8001b583d
-        checksum/prometheus-config: e4364fa3d85ea37ecb6f1946cf5cb18075645bee6ca7f16b2824b7c25bccd834
-        checksum/prometheus-ce-config: e645780b9b145e0ec5d98d2e6a841930abf29ea2fbc1842682150169305d42ce
+        checksum/config: 9ce19962dc1d6353380cf9504ed5e0560faa1f955f66fc154f785243f3be55df
+        checksum/init-sysctl: b334f44cfb95429c4d642992b6096a87a7bdd8852e8ded03a703c65e8e5a26fe
+        checksum/plugins: 283c1560859276dbcf4e6c28cc6c38b03d6d0a8a36d930d167ec3c33bbd87d4d
+        checksum/secret: 38421a2836c530009365bc1d73b14c65d4e87ad7b6b810f0fa929d4b3eeb206c
+        checksum/prometheus-config: c1ef96c7c9bab4ad2626ccf99729de1c18af5f70ee09137c0fc62654fa8a0f6b
+        checksum/prometheus-ce-config: f84175ba0f081c387f809447e70cacaddba60349b8108d94b58f5a8fef350025
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -217,7 +217,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -235,7 +235,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -277,7 +277,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -321,7 +321,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -344,7 +344,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -470,14 +470,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -507,7 +507,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -520,7 +520,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.4
+        chart: sonarqube-2026.1.5
         release: non-default-security-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -108,9 +108,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b65f76f93c2bf1654e07be60085053793b32d2064340b33c548d215261d9d00
-        checksum/plugins: 51cfb6cbb6fed3c0ceba6bebe79e87f926405361cf9cef6cdd0121e5a76118a9
-        checksum/secret: 07c5e8542569e7493dd1b76973c86376a73babcd3f0e5bb9ea7f7373618a2f19
+        checksum/config: 0526fcd54e1b4f7a683d3805395d60a4ad935beb0cd47408bcc67425c96f0a95
+        checksum/plugins: 5811b40a86ff9332ee2e4b43e824d987c2e4e51934c515fa9ad6829f473ec375
+        checksum/secret: 459b0033df508d0bac2efa1c705f25dbc3dd41720879c78c8ea41957329a17e2
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -121,7 +121,7 @@ spec:
       initContainers:
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -138,7 +138,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_WEB_SYSTEMPASSCODE
@@ -230,7 +230,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -256,14 +256,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: openshift-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -300,7 +300,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: sonarqube
-  namespace: sonarqube
+  namespace: default
   labels:
     app: sonarqube
     toto: tutu
@@ -308,7 +308,7 @@ spec:
   jobLabel: "something"
   namespaceSelector:
     matchNames:
-    - sonarqube
+    - default
   selector:
     matchLabels:
       app: sonarqube

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 15f9d6f920f71c0867818336c2e23a0b46b613eaf13227b3c9eb075d52331d27
-        checksum/init-sysctl: 09a77ddb327d2f54433c76410aaf78232b97e20c70d11680d2f8e3e1703b89e4
-        checksum/plugins: 65afcdfa56228cc3a2e6231b5d028838f8d4638f869ac0185c42135ea3718dfc
-        checksum/secret: 5c905968ccb0047c0e695066bf5bc046c22ca3e4e58f76f8574f3aee9f203993
+        checksum/config: 55bc1582e49d6aad289e181784a80ed76230ee7aeb4dc7202f8b63d2d1b5de20
+        checksum/init-sysctl: 5e8ebc00cce533903bf9d1f5e15fdf572dbfbf8d90e6752157dd2a50920a0d38
+        checksum/plugins: 6d99841d036bcb97175b1e703c388d95f3e9b882b642d57c16e5f5aef531a34a
+        checksum/secret: f240743deb4d2e73616cebf2717735a71dc63cda9e998cb355dc314e66ddb69f
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -300,7 +300,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: sonarqube
-  namespace: default
+  namespace: sonarqube
   labels:
     app: sonarqube
     toto: tutu
@@ -308,7 +308,7 @@ spec:
   jobLabel: "something"
   namespaceSelector:
     matchNames:
-    - default
+    - sonarqube
   selector:
     matchLabels:
       app: sonarqube
@@ -333,14 +333,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 116e660f2e10ca1bc975210c3ef1513fadee8513380396f08dc53a2884016901
-        checksum/init-sysctl: 8a1775fe4d538e80e0ceaeedc4d8e90d1bfaf7e23abe40863bc4323c593d8629
-        checksum/plugins: 2454921bbc2523aa6e06df330b407205f8229cd2c6feac11e4122aadbe6b2ddb
-        checksum/secret: 50f16b1c4a95496540975f0f32e1efa32350148c866b49d950d12d84fbcd0435
+        checksum/config: 5bb5eef023da51f9a6d3d0a95ba623c3209d84756e6da47a22a497ca076ea2ba
+        checksum/init-sysctl: 97203753c4a44ed420e012770c33ead1a685bc27d312d376cecb29b7ce174cbd
+        checksum/plugins: 5c9d57ef3c582bf412c8fb27e9e62ac4d87dd03cac11e158268282b3071524cc
+        checksum/secret: 35bee8ad9fa68eb575d89694cb13a9c58b60116394efcb515633a3c652cbb409
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,12 +188,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b11a222bc863be547e19ed9d0283a717867a11866674fec00f8e78280993c4e0
-        checksum/init-sysctl: 23abdabfe41ca276aa087ed8272cf2780326b9ca8c656788c028bdbe67ff8f03
-        checksum/plugins: 0f7c96ab8c4278a9913cf07947a7d3b3333bf9f2b332c19545eb389cbcb328bd
-        checksum/secret: ad56972e8fd1e61c80bb8c42fb58368ea5473ffc58cf859c51d39a4baf227e90
-        checksum/prometheus-config: a8b2e75bea71e717013dff459c7fe94109821dc35582e7a48230074658278beb
-        checksum/prometheus-ce-config: 524c6c58911e207459f06b15f7f5da51123a7a14a099ac79ccfd8ceb6fad0768
+        checksum/config: 6832e014135e4012e6e703c2d2e02bd4473122e78c5d28939eb91ab5ee0680d4
+        checksum/init-sysctl: 284d70b017d815cce92068a778a3434a8c1f5a1ada1db70714e078660d64a7e1
+        checksum/plugins: e83de0ece06e9d48edda28f73866c61974f561c607f5ae87d397cfa467cf776f
+        checksum/secret: ab59bcb2f159ae52e209855ad755483a7faebecee0897693d2d40e4e453b9554
+        checksum/prometheus-config: 03af3ec92339e5630c799eeeadd5ab7ffaf5fb5ab414a368b83f309be329ae83
+        checksum/prometheus-ce-config: 563ed6d80668fde03e867aedad1cd105a5be928f37e9ff1e5e1ecb9af5172027
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -221,7 +221,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -263,7 +263,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -307,7 +307,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -330,7 +330,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -456,14 +456,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -149,7 +149,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -170,7 +170,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -190,11 +190,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 88d28990d3ba50b00f64eca03947ef85986ba197191f421b36fd1e6abbe97b32
-        checksum/init-fs: 37844a232623b76d5ce4649c26b8c864edd1b10f00f869e5d8978b58185d6241
-        checksum/init-sysctl: d694f2f43192960829fd86163c314044839850560785f1569b92ec95267e9ecd
-        checksum/plugins: 55e5ca5a89638748ece4e19025362df20e0c4d8df11e3d5583b6e055f6ccae6c
-        checksum/secret: 725632cc5379b40a69c8a98dd3c3033bda4ab69f8c9593947310f8393c1822fa
+        checksum/config: 042237980d44a5b952d8da5384482c64fafbcd36670c8e1c50b168d434f3ff5a
+        checksum/init-fs: d2b316292a8fdeba3ccf0e84c84fe656f596f39db8d8fe07edf9d81aa771e054
+        checksum/init-sysctl: 3f9844954ff8f973eb6dedeec876a40946d2873ae57601355df264e3b7393a56
+        checksum/plugins: 1b50908a66ad43d2c963fa147136e8f7ebd5464f95095f99c29263355e38d42d
+        checksum/secret: c14780b79b422527b69a322b6298827a79b88646eb5d68e84fdeab440ec52a83
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -204,7 +204,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -222,7 +222,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -257,7 +257,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -274,7 +274,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -382,14 +382,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca0bcc626a5674c6c2892c7b01c2618098707ab031921901ea0933981b6e3570
-        checksum/init-sysctl: 59d7a6b6f98b31a35dc3e8926d92437c45ccf7603130ea8efc61a73ef2f5862d
-        checksum/plugins: 6e04e2a1cca1d39a521f4eb9e2134d9b27140892813d5bf07e865b927c63c09b
-        checksum/secret: 8e27aa118bbe3ef412c882d777cde7348e1d48016f95bf109fa89d09c980df1d
+        checksum/config: 0d8e4b4d415ed9b59fda1979df90e4bc539602d6968fc3de0ed8e66ed81134f9
+        checksum/init-sysctl: 2d8e589a7ee2fbc7a4e7513b6f5403912409f410e8f4a8011f9bb5645fa73ce8
+        checksum/plugins: 5525f95eac67958bede43a710a71ce31b2b32ff2aa28ee258ab82f19d9991eb9
+        checksum/secret: bc1bea626e3e988fc8fb5fb552c400d981704ebd2c53c2485858b163ce2bcb55
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -357,7 +357,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -370,7 +370,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.4
+        chart: sonarqube-2026.1.5
         release: secret-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -142,7 +142,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -162,10 +162,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 526b2f18f14c13adaf71098ebe0e1875341f0c0bb25ab46428a22b31db08b44d
-        checksum/init-sysctl: 7c854ba78fb70358a921ec7e4aee3b94ec396b61e03e33f4fe720f6fe1047561
-        checksum/plugins: 16913f841ddc68e6cf448c40daf7a5872af020cb781b71b4793ce84139a801b2
-        checksum/secret: 7307c08a6df581609e7601fe07f573ebbdb01f9c5e88ddd7623598ded77fbf53
+        checksum/config: 3feb4535a868853061dd19ddafa054ac20c0df4ba219c342a6c2ab879358ee7f
+        checksum/init-sysctl: 544a8fe1d853f527acf109f07204dbca3a2147e8bc6f80573bf48e9f0fc034e0
+        checksum/plugins: 92cf0cc167cdf507eada79d16dc1e341022aecb74eff2eb31eaf7e3082448cd5
+        checksum/secret: f3f13013a2fdb27a887c5699d164c6090eea1c014c47eb305eacccb9c4016b36
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -175,7 +175,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -194,7 +194,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -211,7 +211,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -313,14 +313,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -21,7 +21,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: daca8654ae3dab0652a373a3882b2e7f7f4d19b1b61b3b5fc67bc50a62339148
-        checksum/init-sysctl: bae04d11e5c17cea756c5057c5005c363a4a6011656b00a5982cfe9d4c13e3a9
-        checksum/plugins: 758c02457271434c38e410673d33fcb9b1995440768a87b0fee36ca8d09376ea
-        checksum/secret: 3e62eab2c467d9b93a7ab3561cad482c3c947e31db6e6c9b5c6205031051848e
+        checksum/config: a13000510552f140c2cde95713add49496e086cd8196824aac0303958a5d8190
+        checksum/init-sysctl: dc02141ef34ab7014ac5c7e1676a3e69122ad4f54d3268adf52db966ee0fc219
+        checksum/plugins: 0d4d43a8992cfaa68d1cd7b49ba4b69ef4f20800c04b23cb537c295ce39d3061
+        checksum/secret: 3072c6a62acc98cff566f092985c038348ff476ec6c615c5f606240300855348
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -170,10 +170,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f68c0f50790743a137a2af44a612c7debb883b375d14d6d3c74e07797e28c418
-        checksum/init-sysctl: 3ac07a95d40c655a7d813d3f762a32683003a78c05eb76564f5b8ac5bd16df6f
-        checksum/plugins: e2a97bf576b2ef6713996531963b2f89bcbb928f6ecf1ad5b72515e018773a48
-        checksum/secret: a76a55e22466a52ba6159d0820d287839165db5798f6b4702bade4b7e4ad432e
+        checksum/config: 4aa8d88f471c5589b689c75263c2955bcb976b44377dbfd890694857394b995e
+        checksum/init-sysctl: c496c0a8828179f01d28f124628cf3f10a769999921d5f55d76c020c7c87ae19
+        checksum/plugins: f7c00fad92eafa7aa4f1000b4c8e7a6015614a8bb9fd060e0545e42b623c96d2
+        checksum/secret: e24e576c17d2124c9d0fe9dce7fac904b6e94641b949d2e187fb4d4ab6102415
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -183,7 +183,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -202,7 +202,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -219,7 +219,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -317,7 +317,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -344,14 +344,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -381,7 +381,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -393,7 +393,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.4
+        chart: sonarqube-2026.1.5
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -404,7 +404,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.1.4-enterprise
+        image: sonarqube:2026.1.5-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1f9049257cc61847380349361e851d561ea779702f37839aefec6fa4d9326b19
-        checksum/init-sysctl: 89852e76c94f888a1814882019e7b411b74e20c77318c5bc3b42367fb6215112
-        checksum/plugins: adae6882d866aed7070b21aeb2767ec09e94fd5818274e9f1f43291aa78492ab
-        checksum/secret: f1ea2c6b21dadc2fedac00644f727d29f6dec5598d92bec78eb21ac43d8ddc66
+        checksum/config: c6476025ee3e92d5760c50cb32c035d68a82e5dbb48da3d80b9cd3ff22ada494
+        checksum/init-sysctl: 3de9e6a96a146bf6162b773f63eabb26d25c72f8911bc21e53a4844eeaa4e7c5
+        checksum/plugins: a25c7459251a44253c36f86aa8d85046f078ba563bb9119831a40443a5ff2c42
+        checksum/secret: 6bcbb2e0398c6ea548c42aa269383d3c43bac3400f980ed60a7fac392d625223
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -380,7 +380,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -392,7 +392,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.4
+        chart: sonarqube-2026.1.5
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -403,7 +403,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.1.4-enterprise
+        image: sonarqube:2026.1.5-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fe7df986fb1bcee2cf3678637882389e07648c6fdd4f2b353d040d12f36c6115
-        checksum/init-sysctl: 7492b2058bea82dcdea535cf8e609d4ea7c69a744ea3d161fad574d6099dac08
-        checksum/plugins: 5f9dcef8e2335140ce83b4329fdaf5369c8e30faf3f782337327975f566118fe
-        checksum/secret: bac45447ac33a48926a8e426aa1234c91e62845b01f4be906d092aab47b4d68f
+        checksum/config: ebb9c02a76887a586911eaa4ed1b8b90e25dbb68c1986711c675ef69cdb6fd67
+        checksum/init-sysctl: 24087c864c542c18515f9a4e4c4b3e6bd26efc81c5f248e762d6f8ee231e9edf
+        checksum/plugins: 88c868ab04979bdd72da0e8be3ec6f064d267c6c107a63dfb4641af15e6fa9ae
+        checksum/secret: a676158d71851836b8d20ced6157c421f7024ae69f7f281508c241ef72409344
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [
@@ -380,7 +380,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -392,7 +392,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.1.4
+        chart: sonarqube-2026.1.5
         release: sonar-web-context-values.yaml
         heritage: Helm
       annotations:
@@ -403,7 +403,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.1.4-enterprise
+        image: sonarqube:2026.1.5-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.1.4-enterprise"
+    app.kubernetes.io/version: "2026.1.5-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c398d7163b711fecf38c2dcff014010fa5b3bfa8a76701f24c9b43e25b3c8504
-        checksum/init-fs: 5e582418933e11c7b18d246c0418a9c33c3f7335714ab0e58e08b774858369b6
-        checksum/init-sysctl: 0edc1ede51b88086d1381cab214f29bac75fe5480a9ac9a417fc0b0a2d535f93
-        checksum/plugins: 4a0669ba24e9c161b0275d43391ac2fdfb54e1c7b08a6687aa8dcd99f6128d81
-        checksum/secret: 254f12727a17d7832fde88e6f70c1b3aec5ee085314420d7bfc0cd1d6ccb8900
+        checksum/config: 817db320008edd26dd383cf9e6ab580907dcf6bfa36d1169ac5701cafc91ccbe
+        checksum/init-fs: 53a3ceb393ee0002700b1251e57a2d3ca7e95d9e7a1643cbcac3140bbebf1510
+        checksum/init-sysctl: e5648341b89e9892199ea47cd32353e3f2efffbf8ac0fd39d4dac4a74ca57527
+        checksum/plugins: a577e13d50cf0b978398ed1f2a2c6ad5188afbdf32327edcd6ddde45d14e2f17
+        checksum/secret: ebe50ec5f48b00935b4bab2871999e9eec4473e73188b446c2b803db8fb49b61
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -264,7 +264,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.1.4-enterprise
+          image: sonarqube:2026.1.5-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.1.4
+              value: 2026.1.5
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -389,14 +389,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.1.4
+    chart: sonarqube-2026.1.5
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2026.1.4-enterprise"
+      image: "sonarqube:2026.1.5-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['wget']
       args: [

--- a/tests/unit-test/schema_test.go
+++ b/tests/unit-test/schema_test.go
@@ -133,7 +133,7 @@ func TestShouldUseImageTag(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2026.1.4-enterprise"
+	expectedContainerImage := "sonarqube:2026.1.5-enterprise"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)
@@ -219,7 +219,7 @@ func TestDeveloperEdition(t *testing.T) {
 	var renderedTemplate appsv1.StatefulSet
 	helm.UnmarshalK8SYaml(t, output, &renderedTemplate)
 
-	expectedContainerImage := "sonarqube:2026.1.4-developer"
+	expectedContainerImage := "sonarqube:2026.1.5-developer"
 	actualContainers := renderedTemplate.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
 	assert.Equal(t, expectedContainerImage, actualContainers[0].Image)

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2026.1.4-enterprise
+  tag: 2026.1.5-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Release Updates:**
    - Upgrade chart and app versions to `2026.1.5` across `Chart.yaml` and related manifests
    - Update SonarQube container image tags to `2026.1.5` in helm charts and test fixtures

<sub>This will update automatically on new commits.</sub>