### PR TITLE
REL-4835 Release SQS 2026.4.1

### DIFF
--- a/.github/workflows/azure-marketplace.yml
+++ b/.github/workflows/azure-marketplace.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  SQ_VERSION: 2026.4.0
-  SQ_IMAGE_VERSION: 2026.4.0
+  SQ_VERSION: 2026.4.1
+  SQ_IMAGE_VERSION: 2026.4.1
 
 jobs:
   build-azure-staging-app:

--- a/.github/workflows/gcp-marketplace.yml
+++ b/.github/workflows/gcp-marketplace.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ !(github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
 
 env:
-  GCLOUD_TAG: 2026.4.0 # Update this value to the desired version
+  GCLOUD_TAG: 2026.4.1 # Update this value to the desired version
 
 jobs:
   build-gcp-staging-app:

--- a/azure-marketplace-k8s-app/manifest.yaml
+++ b/azure-marketplace-k8s-app/manifest.yaml
@@ -1,7 +1,7 @@
 applicationName: sonarqube
 publisher: "SonarSource"
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
-version: 2026.4.0
+version: 2026.4.1
 helmChart: "./sonarqube-azure"
 clusterArmTemplate: "./mainTemplate.json"
 uiDefinition: "./createUIDefinition.json"

--- a/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2 # Or v1 depending on your Helm version
 name: sonarqube-azure
-version: 2026.4.0
-appVersion: 2026.4.0
+version: 2026.4.1
+appVersion: 2026.4.1
 description: "SonarQube Server is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards."
 type: application
 dependencies:
   - name: sonarqube 
-    version: 2026.4.0
+    version: 2026.4.1
     repository: "file://../../charts/sonarqube" # Reference to the local SonarQube chart

--- a/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
+++ b/azure-marketplace-k8s-app/sonarqube-azure/values.yaml
@@ -22,4 +22,4 @@ global:
       sonarqube:
         registry: __ACR_REGISTRY_PLACEHOLDER__
         image: sonarqube
-        tag: 2026.4.0-enterprise
+        tag: 2026.4.1-enterprise

--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.4.1]
+* Upgrade Chart's version to 2026.4.1
+* Upgrade SonarQube Server to 2026.4.1
+
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
 * Upgrade SonarQube Server to 2026.4.0

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.4.0
-appVersion: 2026.4.0
+version: 2026.4.1
+appVersion: 2026.4.1
 keywords:
   - coverage
   - security
@@ -36,9 +36,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.4.0"
+      description: "Upgrade Chart's version to 2026.4.1"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.4.0"
+      description: "Upgrade SonarQube Server to 2026.4.1"
     - kind: changed
       description: "Upgrade SonarQube Community build to 26.6.0.123539"
     - kind: added
@@ -63,9 +63,9 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-app
-      image: sonarqube:2026.4.0-datacenter-app
+      image: sonarqube:2026.4.1-datacenter-app
     - name: sonarqube-search
-      image: sonarqube:2026.4.0-datacenter-search
+      image: sonarqube:2026.4.1-datacenter-search
     - name: sonarqube-mcp
       image: sonarsource/sonarqube-mcp:1.22.0.3040
   charts.openshift.io/name: sonarqube-dce

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -14,7 +14,7 @@ Please note that this chart does NOT support SonarQube Community, Developer, and
 
 ## Compatibility
 
-Compatible SonarQube Version: `2026.4.0`
+Compatible SonarQube Version: `2026.4.1`
 
 Supported Kubernetes Versions: From `1.32` to `1.35`
 Supported Openshift Versions: From `4.17` to `4.20`
@@ -565,7 +565,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                 | Description                                                                                | Default                                                                |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `searchNodes.image.repository`                            | search image repository                                                                    | `sonarqube`                                                            |
-| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.4.0-datacenter-search`                                             |
+| `searchNodes.image.tag`                                   | search image tag                                                                           | `2026.4.1-datacenter-search`                                             |
 | `searchNodes.image.pullPolicy`                            | search image pull policy                                                                   | `IfNotPresent`                                                         |
 | `searchNodes.image.pullSecret`                            | (DEPRECATED) search imagePullSecret to use for private repository                          | `nil`                                                                  |
 | `searchNodes.image.pullSecrets`                           | search imagePullSecrets to use for private repository                                      | `nil`                                                                  |
@@ -623,7 +623,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | Parameter                                                        | Description                                                                                                                                                                                                    | Default                                                                |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `applicationNodes.image.repository`                              | app image repository                                                                                                                                                                                           | `sonarqube`                                                            |
-| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.4.0-datacenter-app`                                                |
+| `applicationNodes.image.tag`                                     | app image tag                                                                                                                                                                                                  | `2026.4.1-datacenter-app`                                                |
 | `applicationNodes.image.pullPolicy`                              | app image pull policy                                                                                                                                                                                          | `IfNotPresent`                                                         |
 | `applicationNodes.image.pullSecret`                              | (DEPRECATED) app imagePullSecret to use for private repository                                                                                                                                                 | `nil`                                                                  |
 | `applicationNodes.image.pullSecrets`                             | app imagePullSecrets to use for private repository                                                                                                                                                             | `nil`                                                                  |

--- a/charts/sonarqube-dce/ci/ci-values.yaml
+++ b/charts/sonarqube-dce/ci/ci-values.yaml
@@ -5,7 +5,7 @@ searchNodes:
   replicaCount: 3
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.4.0-master-datacenter-search"
+    tag: "2026.4.1-master-datacenter-search"
     pullSecrets:
       - name: pullsecret
 
@@ -14,7 +14,7 @@ ApplicationNodes:
   jwtSecret: "mnGBJtmwRbIREqy3vSw6Cinoi2WEom9JH+iw/tXOJX4="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.4.0-master-datacenter-app"
+    tag: "2026.4.1-master-datacenter-app"
     pullSecrets:
       - name: pullsecret
   webPort: 4023

--- a/charts/sonarqube-dce/openshift-verifier/values.yaml
+++ b/charts/sonarqube-dce/openshift-verifier/values.yaml
@@ -7,7 +7,7 @@ searchNodes:
   replicaCount: 1
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.4.0-master-datacenter-search"
+    tag: "2026.4.1-master-datacenter-search"
     pullPolicy: Always
     pullSecrets:
       - name: pullsecret
@@ -17,7 +17,7 @@ ApplicationNodes:
   jwtSecret: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
   image:
     repository: "sonarsource/sonarqube"
-    tag: "2026.4.0-master-datacenter-app"
+    tag: "2026.4.1-master-datacenter-app"
     pullPolicy: Always
     pullSecrets:
       - name: pullsecret

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -5,7 +5,7 @@
 searchNodes:
   image:
     repository: sonarqube
-    tag: 2026.4.0-datacenter-search
+    tag: 2026.4.1-datacenter-search
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:
@@ -164,7 +164,7 @@ searchNodes:
 applicationNodes:
   image:
     repository: sonarqube
-    tag: 2026.4.0-datacenter-app
+    tag: 2026.4.1-datacenter-app
     pullPolicy: IfNotPresent
     # If using a private repository, the imagePullSecrets to use
     # pullSecrets:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.4.1]
+* Upgrade Chart's version to 2026.4.1
+* Upgrade SonarQube Server to 2026.4.1
+
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0
 * Upgrade SonarQube Server to 2026.4.0

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.4.0
-appVersion: 2026.4.0
+version: 2026.4.1
+appVersion: 2026.4.1
 keywords:
   - coverage
   - security
@@ -41,9 +41,9 @@ annotations:
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
     - kind: changed
-      description: "Upgrade Chart's version to 2026.4.0"
+      description: "Upgrade Chart's version to 2026.4.1"
     - kind: changed
-      description: "Upgrade SonarQube Server to 2026.4.0"
+      description: "Upgrade SonarQube Server to 2026.4.1"
     - kind: changed
       description: "Upgrade SonarQube Community build to 26.7.0.124771"
     - kind: added
@@ -57,9 +57,9 @@ annotations:
     - name: sonarqube-community
       image: sonarqube:26.7.0.124771-community
     - name: sonarqube-developer
-      image: sonarqube:2026.4.0-developer
+      image: sonarqube:2026.4.1-developer
     - name: sonarqube-enterprise
-      image: sonarqube:2026.4.0-enterprise
+      image: sonarqube:2026.4.1-enterprise
     - name: sonarqube-mcp
       image: sonarsource/sonarqube-mcp:1.22.0.3040
   charts.openshift.io/name: sonarqube

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -14,7 +14,7 @@ Please note that this chart only supports SonarQube Server Developer and Enterpr
 
 ## Default Versions
 
-SonarQube Server Version: `2026.4.0`
+SonarQube Server Version: `2026.4.1`
 
 SonarQube Community Build: `26.7.0.124771`. If you want the use a more recent SonarQube Community Build, please set the `community.buildNumber` with the desired version.
 

--- a/google-cloud-marketplace-k8s-app/README.md
+++ b/google-cloud-marketplace-k8s-app/README.md
@@ -20,7 +20,7 @@ and run this command.
 # make sure you are on a staging account
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=sonarqube-dce
-export TAG=2026.4.0
+export TAG=2026.4.1
 export MINOR_VERSION=$(echo $TAG | cut -d. -f1,2)
 # Deployer does not care about patch version. see [here](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#images-in-staging-gcr)
 docker build -f google-cloud-marketplace-k8s-app/Dockerfile --build-arg REGISTRY="${REGISTRY}" --build-arg TAG="${TAG}" --tag $REGISTRY/$APP_NAME/deployer:$MINOR_VERSION .

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -194,7 +194,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -304,7 +304,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-static-hazelcast-values.yaml
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -357,14 +357,14 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: e8e6708a15871eb048f5a9cab199fda3c610218d8301a03b441d60dff599fb77
-        checksum/config: c18e54a5b2b346d466c0c8431ce059c36885bcdfe4d563116f0194911c93bfa9
-        checksum/secret: 04c724e94a1c1a8f24664a2b78bc432c370d2435cc71840d57a546f35481a990
+        checksum/plugins: 10736a0bc520f32a5324f583e280ef4d770e50ebc042d4fb1f7855428f75416a
+        checksum/config: adb1e97cbfbb8b5705e05aaa2172351af159c9193a840a35e113f3d900fe6417
+        checksum/secret: 16e7d2c6f3429543a21dc573228de6593540bdcbb29899e95bcbb6eba0154103
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -403,7 +403,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -437,7 +437,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-static-hazelcast-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -570,7 +570,7 @@ metadata:
   name: application-static-hazelcast-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-static-hazelcast-values.yaml"
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-static-hazelcast-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -608,15 +608,15 @@ spec:
         release: application-static-hazelcast-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f67227d721c476b2710645fa6f9d6f988ba27b9b33ac9c977612c5d208c74f7b
-        checksum/init-fs: fcef9cdecb109c563a3a5dd0e3c55dd584c57190651f5704d39434d8cebb74d0
-        checksum/config: c18e54a5b2b346d466c0c8431ce059c36885bcdfe4d563116f0194911c93bfa9
-        checksum/secret: 04c724e94a1c1a8f24664a2b78bc432c370d2435cc71840d57a546f35481a990
+        checksum/init-sysctl: ef336f5270f6306a4d9b8fe942917b76c45270cc7c80919f86d8ecd576ffa874
+        checksum/init-fs: 774e166247e1b7f9202f7b59fdcf56e5d5f112b739b386a38b75cbaec0e90e13
+        checksum/config: adb1e97cbfbb8b5705e05aaa2172351af159c9193a840a35e113f3d900fe6417
+        checksum/secret: 16e7d2c6f3429543a21dc573228de6593540bdcbb29899e95bcbb6eba0154103
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -631,7 +631,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -672,7 +672,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -819,14 +819,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-static-hazelcast-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-static-hazelcast-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: application-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2252cd3d1c2849eea9ba0b3d808d2633486f12260145743514e9b3713143e4c4
-        checksum/config: e15f3bab31d177e426ae9625a079f804a126ddb4b12eda4ee94db620d1b86a39
-        checksum/secret: 5f740c225b67dc05ff8f6add161ab8fceb3c8c2259201cdac9dab7ec38aad83d
+        checksum/plugins: 35947b3bbfd54ed1e24296650e5d285d2d12f8de4134758698b09bcff8c85813
+        checksum/config: 449413ede63a46dc4c70b82b2b50634e17dcb8003a1fb68d58f7b05d307235eb
+        checksum/secret: fd6a28398b707679f5917aa8371455a6e148f5e04c5488d035ecaa53154ae190
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "application-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: application-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "application-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: application-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -541,15 +541,15 @@ spec:
         release: application-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 883b4e117fc01d424a4c3cfc1429e774d9f6878c81a3410c9b4dd63ec19684fc
-        checksum/init-fs: 531b8362dbae6fa4f6521c6b9ebac3afc48a19ae06b5078b9593161b259a7ea5
-        checksum/config: e15f3bab31d177e426ae9625a079f804a126ddb4b12eda4ee94db620d1b86a39
-        checksum/secret: 5f740c225b67dc05ff8f6add161ab8fceb3c8c2259201cdac9dab7ec38aad83d
+        checksum/init-sysctl: 54780c5b24c203c10788fa86ff061d3326530ab0a718281feebb497c4f74b696
+        checksum/init-fs: 61ad66fdfb77a7c19a8e0022d5146803aa254893de7663f4d6348aedcf74712d
+        checksum/config: 449413ede63a46dc4c70b82b2b50634e17dcb8003a1fb68d58f7b05d307235eb
+        checksum/secret: fd6a28398b707679f5917aa8371455a6e148f5e04c5488d035ecaa53154ae190
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -757,7 +757,7 @@ metadata:
 spec:
   descriptor:
     type: sonarqube-dce
-    version: "2026.4.0-datacenter-app"
+    version: "2026.4.1-datacenter-app"
     description: |-
         [SonarQube](https://www.sonarsource.com/products/sonarqube/) is a self-managed, automatic code review tool that systematically helps you deliver Clean Code.
         As a core element of our [Sonar solution](https://www.sonarsource.com/), SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects.
@@ -811,14 +811,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: application-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: application-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-oracle-jdbc-driver
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -208,7 +208,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -238,7 +238,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -260,7 +260,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -285,7 +285,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -311,7 +311,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 
@@ -338,7 +338,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -347,7 +347,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -364,14 +364,14 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 8bd56cf921930fef007fa207dfdb36d4ff3f79264cf8964f105ad7f335ca7f7e
-        checksum/config: 3e93365933f046d46b57dfc9a58e0a50caf2461456c437c8c2c5e45d69121ae4
-        checksum/secret: 4fcdf56b28c2bb3c1425d9113cc14b48aaeb2c52210ed742587557054ac5e9e6
+        checksum/plugins: fb0cdfc1da33f2126f50d06479066e6b76a59ae86d4f33180c9ddaf647cd0dec
+        checksum/config: 68efd748b62dbd34a8eeb84cffc44b1dc98178db8978d4e5e2658eb5cfb95cc5
+        checksum/secret: 91cd5af5becad075c800285218b5e14cb7299b109cc7f71c445fb238ec214ea7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -405,7 +405,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: install-plugins
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -450,7 +450,7 @@ spec:
                   name: ca-certificates-configmap.yaml-sonarqube-dce-http-proxies
                   key: PLUGINS-NO-PROXY
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -480,7 +480,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -508,7 +508,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-configmap.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -655,7 +655,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-configmap.yaml"
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -693,15 +693,15 @@ spec:
         release: ca-certificates-configmap.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e5ca56d0316a0857195224c6843e4b9925af34e844152478822763c73792a8a3
-        checksum/init-fs: 279f2fcf25688453f2e21f583b181eb993e2c030ee766eeae0c10b7bba440d12
-        checksum/config: 3e93365933f046d46b57dfc9a58e0a50caf2461456c437c8c2c5e45d69121ae4
-        checksum/secret: 4fcdf56b28c2bb3c1425d9113cc14b48aaeb2c52210ed742587557054ac5e9e6
+        checksum/init-sysctl: 4795b1ef0394dbaa2b7166587b653281b22ebf8de03a1fe50627bc5f0a440052
+        checksum/init-fs: efbceb595df4861bd740aaeee36e1c9e67d471cfea285020fd1244c41c4c798c
+        checksum/config: 68efd748b62dbd34a8eeb84cffc44b1dc98178db8978d4e5e2658eb5cfb95cc5
+        checksum/secret: 91cd5af5becad075c800285218b5e14cb7299b109cc7f71c445fb238ec214ea7
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -716,7 +716,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -749,7 +749,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -790,7 +790,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -942,14 +942,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -145,7 +145,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -192,7 +192,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -241,7 +241,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -266,7 +266,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -292,7 +292,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 
@@ -319,7 +319,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -345,14 +345,14 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2255463b55c2a2ee02c964b012789f6a2f4b6f8e24571f653766874267542a5a
-        checksum/config: 1902c6bab5c2a30596233f4173b7e2d183f758ebc5a9daa802ad9cf86d81fca4
-        checksum/secret: a0f36d1b8db88c267b724e1cec24e8aa7f527a25a2a4cbb46cb77f69312257d9
+        checksum/plugins: 5d64bdd211c998928a40952417074ba675aff71e9beb37d7c5d29f95dc263b42
+        checksum/config: 1baa538cf285c1999cefdfde7c3680018df271d8582f1f6d7454fe7e6710e5fa
+        checksum/secret: a70b77f15e5b13a58f1963e1ba2637b85908cd6b451f914850dba1d9a561f6b6
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -389,7 +389,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -417,7 +417,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ca-certificates-secret.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -541,7 +541,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: "ca-certificates-secret.yaml"
@@ -550,7 +550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -579,15 +579,15 @@ spec:
         release: ca-certificates-secret.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: cd2929ab34a1d273859cd0b8ca6984c489280ad6415394b82824d18f2b52038b
-        checksum/init-fs: 0f354a4393aab1494976da642f261c5b4a6139ec9392666d57d2090d8290ca06
-        checksum/config: 1902c6bab5c2a30596233f4173b7e2d183f758ebc5a9daa802ad9cf86d81fca4
-        checksum/secret: a0f36d1b8db88c267b724e1cec24e8aa7f527a25a2a4cbb46cb77f69312257d9
+        checksum/init-sysctl: 805f8bd318d592836ed22a1e3882b83a273b288e4ade1c754fcbbb1edaf495fe
+        checksum/init-fs: f50b11e87315acabfa749b0b0c2f409e4a757d2f24d263ca361a5bb0ca72e24e
+        checksum/config: 1baa538cf285c1999cefdfde7c3680018df271d8582f1f6d7454fe7e6710e5fa
+        checksum/secret: a70b77f15e5b13a58f1963e1ba2637b85908cd6b451f914850dba1d9a561f6b6
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -602,7 +602,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: ca-certs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -635,7 +635,7 @@ spec:
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -676,7 +676,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -823,14 +823,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2f0cda562164399df149ccbd76ef4bf9167cdfaf4c4a83346a944fa42283297a
-        checksum/config: dc143158193e07eb3ca245dd5da48eca81e7129dd1203d8e1c2bfac86df18d13
-        checksum/secret: 4b70778b653df5716f87a18efc14227092ef2f49e952202f77287b47dca818ec
+        checksum/plugins: ca62e89c82e01a10babe48d16c9ce021ac415c49673ee73280b19d27ce5973d3
+        checksum/config: 471937eab15663c6ed03681eb8e56d9bd5895cd1376c7f04d03ff5db46dc3eea
+        checksum/secret: 781d00ed84ca1176fbd99a8627045b34ea06a90c75f3cdc639927ca258990213
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "change-admin-password-hook-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -517,7 +517,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "change-admin-password-hook-values.yaml"
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -555,15 +555,15 @@ spec:
         release: change-admin-password-hook-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e39f184a08be8e0424c7bc3f8e1f8c24ef03cc0c8c2bd266412bd1472cc4d18c
-        checksum/init-fs: 89e70189bf5b2d67e556921f443d5bb7a91fe52f92506a11ab45146096742eaa
-        checksum/config: dc143158193e07eb3ca245dd5da48eca81e7129dd1203d8e1c2bfac86df18d13
-        checksum/secret: 4b70778b653df5716f87a18efc14227092ef2f49e952202f77287b47dca818ec
+        checksum/init-sysctl: 5c81ae6525378bbb259ce55c1b7e238c70d32b4ef42de1775c62a5c78b799bcf
+        checksum/init-fs: cc2536db2e2b760d91a1167d36e7c45e407d589efe9996fd2b556ba1092c6c03
+        checksum/config: 471937eab15663c6ed03681eb8e56d9bd5895cd1376c7f04d03ff5db46dc3eea
+        checksum/secret: 781d00ed84ca1176fbd99a8627045b34ea06a90c75f3cdc639927ca258990213
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -578,7 +578,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -619,7 +619,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -766,14 +766,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -807,7 +807,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: change-admin-password-hook-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.4.0"
+    helm.sh/chart: "sonarqube-dce-2026.4.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -134,7 +134,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -150,7 +150,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -210,7 +210,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -224,7 +224,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 
@@ -246,7 +246,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 
@@ -271,7 +271,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 
@@ -297,7 +297,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -350,14 +350,14 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 1245b36b3ef8ea87ebf2c53e30aadaa0768c5ad87ffbe2dd8735cd30717fc826
-        checksum/config: a98bd84a2c15e476e50fd2906ad6c967f5b4b86e98d26ed4e1c5b0aacd0dc54c
-        checksum/secret: aad5dcbd75f356f0b6f6048216b5a71662d17a11c5f651b61e2ecb5150c05e9e
+        checksum/plugins: bffa2fc3af4480e9d3a0c1701714e558605aa60287d392a30b47675ac40bfd8e
+        checksum/config: f20f885da98f6f6293f7839071ebf07a9a83118d29adf2f9134dbc236d163e31
+        checksum/secret: aef9d2593ab3a01a451b4a5c368ef5c17f321326b4f7bc8b88579d09f9d8eb8f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -396,7 +396,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -424,7 +424,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -570,7 +570,7 @@ metadata:
   name: config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "config-values.yaml"
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -608,15 +608,15 @@ spec:
         release: config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 64fa7a1b514f842a9be88e7233d118da349a199348f3afe542a5b7dab1776e35
-        checksum/init-fs: b1dfcb0fc08801416a027b934c0d8eb59bf1141af6a96177f001f7cfd8243def
-        checksum/config: a98bd84a2c15e476e50fd2906ad6c967f5b4b86e98d26ed4e1c5b0aacd0dc54c
-        checksum/secret: aad5dcbd75f356f0b6f6048216b5a71662d17a11c5f651b61e2ecb5150c05e9e
+        checksum/init-sysctl: 3e212f6d5c1dfad5c0b84648e72a9dcf8c01b2c7745799c7e6f29ef4b310909e
+        checksum/init-fs: 402cf0371dce2294d02ce198d3c52075589208dedfa5dc6ebc173f8cbffdb433
+        checksum/config: f20f885da98f6f6293f7839071ebf07a9a83118d29adf2f9134dbc236d163e31
+        checksum/secret: aef9d2593ab3a01a451b4a5c368ef5c17f321326b4f7bc8b88579d09f9d8eb8f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -631,7 +631,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: concat-properties
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -667,7 +667,7 @@ spec:
           resources:
             {}
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -708,7 +708,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -876,14 +876,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -344,9 +344,9 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 2c06b5fc2dea526d5d9d911c90331e5c21a6577e02a862765f1a30f165a45bb9
-        checksum/config: 624de65d86b4099eb48576f600eca3cd286bc386ae632af0ffaac1748b4123ec
-        checksum/secret: 417c6bc2487bcae9b96ddf7b481c06503a3fa795393b55dca6b251112c491b3c
+        checksum/plugins: 6549be00e59e35546cdd86dffb5dbd3b52d23b36ca3bc3653c86c161d982f3d1
+        checksum/config: a4bde830d1fc47d454ffdfa4f6a77cdb0db9e838fed39a3a8cc95423a86b13c4
+        checksum/secret: c1c6c7b7f96c9df6e96598089870738b334f4085350f8fcb87dae014e1e45776
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "custom-image-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "custom-image-values.yaml"
@@ -541,10 +541,10 @@ spec:
         release: custom-image-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 4803385495aaff9895f5c7e2a02cbd0f346e148217c35fa1cad40ad0d56f7132
-        checksum/init-fs: f4a2499210797687d6e05c5bf51fe91c2f1b0bdbbcef1bdfdd2dbf1644d7a9f3
-        checksum/config: 624de65d86b4099eb48576f600eca3cd286bc386ae632af0ffaac1748b4123ec
-        checksum/secret: 417c6bc2487bcae9b96ddf7b481c06503a3fa795393b55dca6b251112c491b3c
+        checksum/init-sysctl: e1d1bba3537a761e0368b52ce5611998e361e0cb9138505777f476abb52bae13
+        checksum/init-fs: 376b29ae50b7b9c02fbc95ebeee237c770b147852ddfe557864f6dae52474235
+        checksum/config: a4bde830d1fc47d454ffdfa4f6a77cdb0db9e838fed39a3a8cc95423a86b13c4
+        checksum/secret: c1c6c7b7f96c9df6e96598089870738b334f4085350f8fcb87dae014e1e45776
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -752,7 +752,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 29822e3d4bc76b14ff923dc5e9296c4f377c9ae406306079a0900aa3b2de99ba
-        checksum/config: df90168942eadcfc350ae8b5df508707e754bb317870947c4a0c7685b36961b5
-        checksum/secret: e30806b363c821dd37fa58607a210b1604fef7b2cbce9ccb06af4f30571aa1e3
+        checksum/plugins: afe5929377210c8082becacf64fca759cdcecc108b00521edd05d81981b31349
+        checksum/config: 3e686167db3d7c8c635d60faa2fd8c0159b5aa2c752d9c4a23507b775b93765d
+        checksum/secret: 4051e367beb6c30cb889872ec5de3fb5e7c36dfdd9e86620fe03b70b5577ea87
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "default-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -541,15 +541,15 @@ spec:
         release: default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d3325cb9bb682e152b6e1d6192aa6a98a60ac836ef9c5729a2455b9f2aaef235
-        checksum/init-fs: 964f20a2ad266770089a84fe33a1c1cab037f47e4d5fb562899fc6afa3e431c0
-        checksum/config: df90168942eadcfc350ae8b5df508707e754bb317870947c4a0c7685b36961b5
-        checksum/secret: e30806b363c821dd37fa58607a210b1604fef7b2cbce9ccb06af4f30571aa1e3
+        checksum/init-sysctl: 05e12bee6b4450aa6c659d947277190124a7ad930d2d8d066c2a1cb4c9983d70
+        checksum/init-fs: a73ae473ce0fc6b346c8c31edf43ac2f48ae0573d7bb9a58d23fe0b31a4c17bd
+        checksum/config: 3e686167db3d7c8c635d60faa2fd8c0159b5aa2c752d9c4a23507b775b93765d
+        checksum/secret: 4051e367beb6c30cb889872ec5de3fb5e7c36dfdd9e86620fe03b70b5577ea87
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -752,14 +752,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deprecation-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: cd84ba6421b7faf5f92e876f1b4dcaa575a0bc72b240df7a5e30db084c64a6e6
-        checksum/config: 1e82ae4525f14cfac41d1e7fb8e91c640848c2679d59b523fd8281fd9308e31f
-        checksum/secret: b663cd195cefdf29d8d2ef83a1ecf054406aeb8d959f3baa967b93283a5a472c
+        checksum/plugins: 99c21bdd05eadd3aa118f255869f125f9725ff16be1d829c6c6a498906cd3f5a
+        checksum/config: 8508dec2df48a783e05d1709604d40af67922d91420c2d70e5df15e812ed15ac
+        checksum/secret: 388b2bcff666708871435cf490da46acd449b4e1b7b9cd41f56f6b6324a2bc2c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "true"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "deprecation-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: deprecation-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "deprecation-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deprecation-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -541,15 +541,15 @@ spec:
         release: deprecation-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 3dcc27bca6b267ff572a596f4c79139173791040e0c4a3a39a5896f3f1d6e96e
-        checksum/init-fs: 9e76331c68638abdbf23f6de534d286202e5da3e7134a6b3ec5226fb139d28d9
-        checksum/config: 1e82ae4525f14cfac41d1e7fb8e91c640848c2679d59b523fd8281fd9308e31f
-        checksum/secret: b663cd195cefdf29d8d2ef83a1ecf054406aeb8d959f3baa967b93283a5a472c
+        checksum/init-sysctl: 8edb24bfb895cd24c11a8d3821d45561c41fc27030d6dbb2a21b14a61963a278
+        checksum/init-fs: b94f4e028147c2ba60a7a2503b07fc186f9f80f431320a448c365375c06eed7f
+        checksum/config: 8508dec2df48a783e05d1709604d40af67922d91420c2d70e5df15e812ed15ac
+        checksum/secret: 388b2bcff666708871435cf490da46acd449b4e1b7b9cd41f56f6b6324a2bc2c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -752,14 +752,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: deprecation-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deprecation-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: fbde51ae85126e322fe9703529763136123ec2a7f77f44c490b53e708c366e4e
-        checksum/config: c726e34c4f87372e922a5bce6e69575bbb43ca9ccd6dc8f8b4946deb91ec26de
-        checksum/secret: 1a9227d07b7103b406d0b3e4ce901f204df3ac3e1e8a8e2302bd4a9f8a3a340d
+        checksum/plugins: e386b3883e3dbd5572afa019e82f0b2a5e814b445cdcb539f69404fa366bed94
+        checksum/config: bb469c99d163cde3b648259f9c7c2d71c76e4f71407521b504f7d3283f264ac0
+        checksum/secret: ed89a4ac592d5ffe06c86775d4476c2d0770368f41c0679ae503be91edc89e26
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -387,7 +387,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "duplicated-env-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -508,7 +508,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "duplicated-env-values.yaml"
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -546,15 +546,15 @@ spec:
         release: duplicated-env-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a66b0c6c8c2e39777ed386e2275823a53328889379a150e2ad679763ec771630
-        checksum/init-fs: 78d09064f2c41f3291e1a5492855858b7d931264635e8c7b877d554d52871c79
-        checksum/config: c726e34c4f87372e922a5bce6e69575bbb43ca9ccd6dc8f8b4946deb91ec26de
-        checksum/secret: 1a9227d07b7103b406d0b3e4ce901f204df3ac3e1e8a8e2302bd4a9f8a3a340d
+        checksum/init-sysctl: b389ca3214ff1037da14ab741a19f2e90eaca85654bb41cde5ee95679244380c
+        checksum/init-fs: dd90626e900f6c9b648d65dfef2c336e4944c724f9aa3f6ddc3a07d5c6afd38c
+        checksum/config: bb469c99d163cde3b648259f9c7c2d71c76e4f71407521b504f7d3283f264ac0
+        checksum/secret: ed89a4ac592d5ffe06c86775d4476c2d0770368f41c0679ae503be91edc89e26
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -569,7 +569,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -757,14 +757,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: extraconfig-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ce3ea243cbba46c82202718157874885366fb30df11941e4d409b00cf8b829b0
-        checksum/config: 9a51822997e6b07dcc3ccd5500c9013ea64440c3a9d3d24920b0f2704d378398
-        checksum/secret: 18e35daffb86bd977fea857c0edef74a1192d12735b55c481572eff174353fc8
+        checksum/plugins: ea24609b7fb5640cbdb974a52007ad16a517c4330d5486eef5726922e1825658
+        checksum/config: 6f25d4ada63690dd44540d413cc9a2f97d9a94c186c0d637f73938c53e76fc3e
+        checksum/secret: 8c2b4457bde483a4f18220f6652b8aec01da59f3f2a0e1728d2e02d7ad551515
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "extraconfig-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -507,7 +507,7 @@ metadata:
   name: extraconfig-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "extraconfig-values.yaml"
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: extraconfig-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -545,15 +545,15 @@ spec:
         release: extraconfig-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 76834fabb4e5cd23e612ba2728578b83038d4ac235884b5d90549f9b43e2d818
-        checksum/init-fs: cc8f4793316015d654851273213bd2e37da2c019c2add59b73538db2faa5c248
-        checksum/config: 9a51822997e6b07dcc3ccd5500c9013ea64440c3a9d3d24920b0f2704d378398
-        checksum/secret: 18e35daffb86bd977fea857c0edef74a1192d12735b55c481572eff174353fc8
+        checksum/init-sysctl: 1a68333cc82cb578ef669cbdb22b09bbb322c20f646c0eb05d6d8835ebf16222
+        checksum/init-fs: 5d1a51cdb7523f796fc4a8ff908168d06bff3e66cb178a327c8e056c702ebfbe
+        checksum/config: 6f25d4ada63690dd44540d413cc9a2f97d9a94c186c0d637f73938c53e76fc3e
+        checksum/secret: 8c2b4457bde483a4f18220f6652b8aec01da59f3f2a0e1728d2e02d7ad551515
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -568,7 +568,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -609,7 +609,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -761,14 +761,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: extraconfig-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: extraconfig-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: hpa-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   revisionHistoryLimit: 
   strategy:
@@ -343,9 +343,9 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 3bfb318d23f271c70e76bb687b12e7c581080e423bf16e3af94797f6d53ea3c3
-        checksum/config: dc345fc836ba5cac792ddcf1c6e4ad5b1a52bf07da066de9c0c04c782676aaa1
-        checksum/secret: 0af9484ee076128625bccc8a9fc10851ade17456c32def4b8366fab3d85e1b3a
+        checksum/plugins: 8fbdd9fa9f8b222c15d47663f6a3985cc883a7378d6b468eb08d2992148dc703
+        checksum/config: 29f7f950964a69f47d8ad7a23aeb6cebe4ccf040eedfec299fd68a4490b9ac4a
+        checksum/secret: 1abbfd1bed9eedd6642162922041d42f5729584b4c76b192713b845b8fbd07e3
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -353,7 +353,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -381,7 +381,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: IS_HELM_AUTOSCALING_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -537,7 +537,7 @@ metadata:
   name: hpa-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "hpa-values.yaml"
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: hpa-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -575,15 +575,15 @@ spec:
         release: hpa-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 32d21c1866b6c6ab737f6850c2a6cdb3c21b64987feddbda2da5d9720b1f0932
-        checksum/init-fs: dc28743209208870716eeeffa9fa9cf6c7c4a69ff2feba9baf3bf989b41febab
-        checksum/config: dc345fc836ba5cac792ddcf1c6e4ad5b1a52bf07da066de9c0c04c782676aaa1
-        checksum/secret: 0af9484ee076128625bccc8a9fc10851ade17456c32def4b8366fab3d85e1b3a
+        checksum/init-sysctl: 9edc49e0c6406bbe1e1a0041610b6c404a433f5296b6029f35a3865a91ca8f04
+        checksum/init-fs: 844da56dc246511c983a9dcb77016313f76314c3807fdb6118726095f55938e1
+        checksum/config: 29f7f950964a69f47d8ad7a23aeb6cebe4ccf040eedfec299fd68a4490b9ac4a
+        checksum/secret: 1abbfd1bed9eedd6642162922041d42f5729584b4c76b192713b845b8fbd07e3
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -598,7 +598,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -639,7 +639,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -786,14 +786,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: hpa-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: hpa-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: aca97f6e1093818d2ead17a39525571e9437b3418af2de258119f16af059f0ee
-        checksum/config: 98a51d7f4b750010394a8445318b3fc22117cc7f13c7963cc8764ed82ff5fb5d
-        checksum/secret: 0d8e798013a1b62a593d4d9401d312697f7745c31173f0ad5a682c8483276cad
+        checksum/plugins: e77b0f500005d0bd278f7659f0407d18f5f693c9fb2a00f0d92bb453caded09e
+        checksum/config: d32b3a7797613c0156d0737da6c7256beb4d236fcd27df4ba4e71ef8ee196900
+        checksum/secret: c52dc4889457689ad7cc60ba0573834969027197fddab0e57a1ff21fd0ff8b10
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-default-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-default-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -541,15 +541,15 @@ spec:
         release: http-routes-default-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 8ede1f997848ab144ea7d28984a31815b2c7a4dcf863b70f140da8d06eb46f53
-        checksum/init-fs: 3b7c240ce8787b98f3431338bedc04dff3d38119b7817cbc86a7b6d779bd06b7
-        checksum/config: 98a51d7f4b750010394a8445318b3fc22117cc7f13c7963cc8764ed82ff5fb5d
-        checksum/secret: 0d8e798013a1b62a593d4d9401d312697f7745c31173f0ad5a682c8483276cad
+        checksum/init-sysctl: 13eddf3bac1b81b1905921e69aed7337cee8fb5553bb96cf2a7053a99ff3baa0
+        checksum/init-fs: 972fbd1e2c9478090639f79941001b0ccf5f345788169f5ac847b254b9bf61b6
+        checksum/config: d32b3a7797613c0156d0737da6c7256beb4d236fcd27df4ba4e71ef8ee196900
+        checksum/secret: c52dc4889457689ad7cc60ba0573834969027197fddab0e57a1ff21fd0ff8b10
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,7 +748,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -777,14 +777,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 181c4e1bc4d3572a755c39602eb053b6b0210f543e4d44073f95a6542131b6a5
-        checksum/config: 219ad55538bfb3b14402bc52e751e89f9ae50ec4ee250c1fdd79aeeabe22a3c8
-        checksum/secret: f68a966a33cc49e93d7d230cedc37b94af095a9791b849913305611f0bfae4f0
+        checksum/plugins: 6e9c16ccb983bfa3eb9b0f848fbe9fa30c4f92fff6b64e8cf38679d74ea9cacd
+        checksum/config: d0ead53abf0e734d71dcfdf82c5c55b39f5a9682bf3f66d0933f4c0ab75409c0
+        checksum/secret: c325e840612daea9ae5de5521b8e918153d3dcc77e01af1c755c577e7ff12b05
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "http-routes-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "http-routes-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -541,15 +541,15 @@ spec:
         release: http-routes-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 0e127e2f61edae87bbfe17d140f117d41b5cbfa95e11ce4c0d22fe41ac771d89
-        checksum/init-fs: 17e85764f42b1b0eb771e039bcd63113676b6e68b9f0a0e47a5074fcb19c25f6
-        checksum/config: 219ad55538bfb3b14402bc52e751e89f9ae50ec4ee250c1fdd79aeeabe22a3c8
-        checksum/secret: f68a966a33cc49e93d7d230cedc37b94af095a9791b849913305611f0bfae4f0
+        checksum/init-sysctl: 78979997fcaa84f3d17ebde7aa5c1a196c65a0e348f5574f2961964af41152a3
+        checksum/init-fs: 927179e8e0b99452f43518aa12195d670ccecdac6681c4ccb09c92256714b1a9
+        checksum/config: d0ead53abf0e734d71dcfdf82c5c55b39f5a9682bf3f66d0933f4c0ab75409c0
+        checksum/secret: c325e840612daea9ae5de5521b8e918153d3dcc77e01af1c755c577e7ff12b05
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,7 +748,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-dce-http-route
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -778,14 +778,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 032c14cd12bcc732b750fa771c2e8e10a1de9d046fca63a5f08dbdc75cef08c4
-        checksum/config: f48243edd0c40e4fd932fe0c506ef8853dae3f57135e5928a63d57d935a64479
-        checksum/secret: d1e89fd3e427fca9bc139920caad685a641769ccf633dd52b066e24e4466d8f8
+        checksum/plugins: 96bd4ed9463abc6a5d0f5ea128395c9064ba1ba5d113857c157d2160197f7cce
+        checksum/config: 8b5d228c807318792b06aad2877e13faf672cf449b12513b3aa239ac68d32b36
+        checksum/secret: 8491f4029e2c0c770bdc170774dd8f72ca28d71b52590333e5be253d8055defb
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -541,15 +541,15 @@ spec:
         release: ingress-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: fed83bab92f00e514b097df8f4e578eef989dc37b68408dc1a72027d2404ccc3
-        checksum/init-fs: 4787a7f24f5010284eeedff5652c230188b4ad25552bfd1a2d2aa7d71f78821b
-        checksum/config: f48243edd0c40e4fd932fe0c506ef8853dae3f57135e5928a63d57d935a64479
-        checksum/secret: d1e89fd3e427fca9bc139920caad685a641769ccf633dd52b066e24e4466d8f8
+        checksum/init-sysctl: 9366106bfd9a04a005d58726ded7c1c004cf2f9751e07652e2adbad0adfe527d
+        checksum/init-fs: de18c744479cd66f7ad3bf810053e6e750e69ed749bc740ee93f5318e48725e5
+        checksum/config: 8b5d228c807318792b06aad2877e13faf672cf449b12513b3aa239ac68d32b36
+        checksum/secret: 8491f4029e2c0c770bdc170774dd8f72ca28d71b52590333e5be253d8055defb
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -564,7 +564,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -605,7 +605,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -748,7 +748,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -785,14 +785,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-with-controller.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -56,7 +56,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -84,7 +84,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -99,7 +99,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -134,7 +134,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -160,7 +160,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -176,7 +176,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -223,7 +223,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -534,7 +534,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -556,7 +556,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -581,7 +581,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -607,7 +607,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -769,7 +769,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -786,9 +786,9 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 86a2260d659afe25cf0856f27b6f625bc4e6a3e9b9373b6f63d07c059e0b5d33
-        checksum/config: 01ed5b1e6ee29a7b3c67b1d95a02b5241dc1efeb9b74ffdbd281ec82ac7481fa
-        checksum/secret: 2db4d74f64467d54631ce698a89499c11581b5499b19b76ebeaef1c0077b091e
+        checksum/plugins: 9a9e42162733a53b9a6fe2770b1731f6f48e9d12182581cb61a52683c7a1fbca
+        checksum/config: f9a691b61f60b211aff24b9bbfca01bd1b5a4f167bed3fef429459cdfd0a8ec1
+        checksum/secret: 7cecb66ca24c51adc17cfa0648ed709bd73d5d692c35fd77bf187bff63383114
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -796,7 +796,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -824,7 +824,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "ingress-with-controller.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -945,7 +945,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: "ingress-with-controller.yaml"
@@ -954,7 +954,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -983,15 +983,15 @@ spec:
         release: ingress-with-controller.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: bc953ca10838fb3757d609dd71a38843b30e19bf438f07c0ec49118b6985a8e7
-        checksum/init-fs: dec1774b0b15d470fbf15d4d58134ba07b40518c4a37559989347fab5c606c60
-        checksum/config: 01ed5b1e6ee29a7b3c67b1d95a02b5241dc1efeb9b74ffdbd281ec82ac7481fa
-        checksum/secret: 2db4d74f64467d54631ce698a89499c11581b5499b19b76ebeaef1c0077b091e
+        checksum/init-sysctl: 21ac6d4c022c4282750393404735eedde44dccfe5b240ad27d0688b2e1fcfbea
+        checksum/init-fs: 4cd289cbec88586071126d14bdeac9ef854b7e35ad7fde786a60747cb75db717
+        checksum/config: f9a691b61f60b211aff24b9bbfca01bd1b5a4f167bed3fef429459cdfd0a8ec1
+        checksum/secret: 7cecb66ca24c51adc17cfa0648ed709bd73d5d692c35fd77bf187bff63383114
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -1006,7 +1006,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1047,7 +1047,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -1206,7 +1206,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -1408,14 +1408,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 3182b8666aaa2250e88f1e4c3442ed6f7b32101659ededcd97086e055ae8468d
-        checksum/config: 40feda48077a140c18968a109ba3b6d48799069d80e665780250f3b9567c22e9
-        checksum/secret: b331c4107a9acf043fe56824486807fcf9a2abd2b3ff4e409b638731bd7f9e74
+        checksum/plugins: 9f3203220838542011f73007f84af5140fb40e89531b83197e48b9eee3de67f1
+        checksum/config: b28bb7950fd9b7268e0b4ba96645555074081914919b2aa6583e2524d49e3854
+        checksum/secret: 84bfb9eaf8435b73ce1a77a0b50c7094473e75e7cb193a7e1a396aa4c24a6675
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "install-plugins-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -550,7 +550,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "install-plugins-values.yaml"
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -588,15 +588,15 @@ spec:
         release: install-plugins-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: d533ec6bcaa546d0e388886b7606b992bca6e3a9e97a49e5c5d214e1cd4d9210
-        checksum/init-fs: ec6975bd3577c451503a58983ae96a846195d06cf4b4b3907d9475b745980e7d
-        checksum/config: 40feda48077a140c18968a109ba3b6d48799069d80e665780250f3b9567c22e9
-        checksum/secret: b331c4107a9acf043fe56824486807fcf9a2abd2b3ff4e409b638731bd7f9e74
+        checksum/init-sysctl: f3be1af42f883bc51894b78032b0d680788922f76b20ef350a6504988d9ee91a
+        checksum/init-fs: de0d672f43732cfe0fe106e74849df0827f0da7d184b190c93d0d4f08cb57e8b
+        checksum/config: b28bb7950fd9b7268e0b4ba96645555074081914919b2aa6583e2524d49e3854
+        checksum/secret: 84bfb9eaf8435b73ce1a77a0b50c7094473e75e7cb193a7e1a396aa4c24a6675
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -611,7 +611,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -652,7 +652,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -799,14 +799,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -70,7 +70,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -89,7 +89,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -102,7 +102,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -178,7 +178,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -227,7 +227,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -252,7 +252,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -278,7 +278,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -314,7 +314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -331,9 +331,9 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c8b2a9d34bafa6f659bae1c49139671d33dbda899e627b9d166da5f81e9041a2
-        checksum/config: 2452ad372c106417a2865606fc9f6876bb87692073f06e04fb40fe90e7ee046d
-        checksum/secret: 473c05657f0da6adadeba8c0b1658537f4caa3d793865f40825b704662a04819
+        checksum/plugins: 180f5c4581b4268b3a588dc5747ce61f23ac0c5ed58d3b6d3f3c6d6ebf135550
+        checksum/config: 002311a6634ffb54521017ab00f27c14f9203c386a430147a9b0a5ba8bbc9e33
+        checksum/secret: acad4250afe7170ae0ed7d13351cea3de50d8bfdb2dffd6561990062761927b2
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -341,7 +341,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -369,7 +369,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "jdbc-config-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -490,7 +490,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "jdbc-config-values.yaml"
@@ -499,7 +499,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -528,15 +528,15 @@ spec:
         release: jdbc-config-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: b238440ed9e2401747396396f267015a54f0ae5733e639f2dced926bf4db2a43
-        checksum/init-fs: 1fa4b04eb37b50d74cbd68abe2810d1da6f0aabb5202cced7768f157ee51cdd7
-        checksum/config: 2452ad372c106417a2865606fc9f6876bb87692073f06e04fb40fe90e7ee046d
-        checksum/secret: 473c05657f0da6adadeba8c0b1658537f4caa3d793865f40825b704662a04819
+        checksum/init-sysctl: 2e3255ba6eb69da370fa784a4484b71b886119c36293eff8aec3434cc23eb351
+        checksum/init-fs: 192707c37d6b1cbdc77a9a2220a835d2c721979ab500a758252f55cd70422ef9
+        checksum/config: 002311a6634ffb54521017ab00f27c14f9203c386a430147a9b0a5ba8bbc9e33
+        checksum/secret: acad4250afe7170ae0ed7d13351cea3de50d8bfdb2dffd6561990062761927b2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -551,7 +551,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -592,7 +592,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -739,14 +739,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -240,7 +240,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -262,7 +262,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -287,7 +287,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -313,7 +313,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 
@@ -340,7 +340,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -358,7 +358,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -445,7 +445,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-tls-values.yaml
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -471,9 +471,9 @@ spec:
         release: mcp-tls-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 5ce89bb5e1a1d36abaa758f9b4652b2d27f6db5e7e347c1fb00e1199cbd61b29
-        checksum/config: 18cd5ffca3e969fb797333f75bd68d81f59e1d8607d023da016f74179ba01b58
-        checksum/secret: 40909465ca4ff84ab3c6297a0555e080b5807dbd03ba8e8996a429f832114394
+        checksum/plugins: 2aff2656ceaf3d28ab6fba9e2f73a3933313e5295dd6444a8b1f78f2e06ab85a
+        checksum/config: 16b7496b3bc196fa248504279309750ddb167269778ec4af0eec7f7d5746adce
+        checksum/secret: d74d17ba4f483c742c4a1289d6fbbf742c2f1141b6d4ac28044a7f1c4561077c
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -481,7 +481,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -509,7 +509,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-tls-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -634,7 +634,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-tls-values.yaml"
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -672,15 +672,15 @@ spec:
         release: mcp-tls-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a9f695a429a15d881787fabbf85fce06ea2c388aeb88bcfa7aa845c49961d390
-        checksum/init-fs: 1cf03c6d871f293c54c4216dda7c191509c10f77db98715b78f6f1faa4d48a95
-        checksum/config: 18cd5ffca3e969fb797333f75bd68d81f59e1d8607d023da016f74179ba01b58
-        checksum/secret: 40909465ca4ff84ab3c6297a0555e080b5807dbd03ba8e8996a429f832114394
+        checksum/init-sysctl: adfa9d42c8899a1da7d70cff7a968072ffef57afb62d232e447c41d5d71b3070
+        checksum/init-fs: 92b725dc58809081d59ab9aa51078021382fe3b234766e1ec80dbde830f487e0
+        checksum/config: 16b7496b3bc196fa248504279309750ddb167269778ec4af0eec7f7d5746adce
+        checksum/secret: d74d17ba4f483c742c4a1289d6fbbf742c2f1141b6d4ac28044a7f1c4561077c
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -695,7 +695,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -736,7 +736,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -883,14 +883,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-tls-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -236,7 +236,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -258,7 +258,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 
@@ -358,7 +358,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -376,7 +376,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -449,7 +449,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-values.yaml
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -475,9 +475,9 @@ spec:
         release: mcp-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: bcc1e0f996790e852eec74e62c251ce0862b729201517c241fd93809fa958cb2
-        checksum/config: 51aa2a275ae6dc6362b2884beba0e9ad1146bdb460120bd8747ce621a3e9dde6
-        checksum/secret: 8c3f61e5e5cea58c86c6dbe51a1ddf15663fe17770eabe8f38113f134e9aaa91
+        checksum/plugins: 7ecfddb33b0ab706dc0a39d97240e78edc16364d1fe2288dee5546e732629062
+        checksum/config: 4d229a1a038fe89584403aed128ac68a33c869547552f1de9b0d5613ca1a976e
+        checksum/secret: 7b5fb091a911a59f9af4f7569f18be9e4d2b660d855dd959016f7a0e7f5ea68b
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -485,7 +485,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -513,7 +513,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -640,7 +640,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-values.yaml"
@@ -649,7 +649,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -678,15 +678,15 @@ spec:
         release: mcp-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 8859307f8b464ad11e2803c9da1c7e6009ed3ca7c49e27da160b17449c5278a9
-        checksum/init-fs: c44ba4b8f5db8ebab822382102a73859fc67881ccf30c79b3ba0eb6dc197cf80
-        checksum/config: 51aa2a275ae6dc6362b2884beba0e9ad1146bdb460120bd8747ce621a3e9dde6
-        checksum/secret: 8c3f61e5e5cea58c86c6dbe51a1ddf15663fe17770eabe8f38113f134e9aaa91
+        checksum/init-sysctl: 4df457a016b10f63fa0ce8e3ca96aec62212661ed071dd357d742da2ea304057
+        checksum/init-fs: 3deef334b954508ad52f16867208195598139274a85b277408ebdd9b325bf8ce
+        checksum/config: 4d229a1a038fe89584403aed128ac68a33c869547552f1de9b0d5613ca1a976e
+        checksum/secret: 7b5fb091a911a59f9af4f7569f18be9e4d2b660d855dd959016f7a0e7f5ea68b
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -701,7 +701,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -742,7 +742,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -889,14 +889,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -236,7 +236,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -258,7 +258,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -331,7 +331,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 
@@ -358,7 +358,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-mcp
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -376,7 +376,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -449,7 +449,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-web-context-values.yaml
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -475,9 +475,9 @@ spec:
         release: mcp-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 30226f4af72e31f510f5711aa5da329de5e997af14879d0b6828397031b5459f
-        checksum/config: 1ca4e3f02b105e17e0b059f9f9fc050e7ebd410dcc3fd632d99374cde5c24c7c
-        checksum/secret: 157baf9b25733d1a99faf529513bc9165bddb2c876ff610d61c1da14572920c1
+        checksum/plugins: a74d162d22de0c82788b567fafeef086f505cb5c06774d0f1feae70778a8955d
+        checksum/config: b58385ecab404bf9de1a120f931de78ebacdc592ec9cfdddb496d66735e670d8
+        checksum/secret: 4bd28bf31da418c1b20a4d64a3c3c34d2c9f595488aac8be9fce124615909979
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -485,7 +485,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -513,7 +513,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "mcp-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -638,7 +638,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "mcp-web-context-values.yaml"
@@ -647,7 +647,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -676,15 +676,15 @@ spec:
         release: mcp-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 84973d7e8248805f7bc31484730b635d8f597c2f97bc7967b62712fb5439871d
-        checksum/init-fs: 43e8f86c39eca373a77b4032f9e9037ce330242adc8f396b3612b7a7efa75515
-        checksum/config: 1ca4e3f02b105e17e0b059f9f9fc050e7ebd410dcc3fd632d99374cde5c24c7c
-        checksum/secret: 157baf9b25733d1a99faf529513bc9165bddb2c876ff610d61c1da14572920c1
+        checksum/init-sysctl: 67f4edb46e9aef6eab1a19adc22fc6fd67745b695a985a4102194c7662daa2ab
+        checksum/init-fs: cd5b7780d1d7fa21074e2756b65b14445d26009c3620797ed9265e255ab885f9
+        checksum/config: b58385ecab404bf9de1a120f931de78ebacdc592ec9cfdddb496d66735e670d8
+        checksum/secret: 4bd28bf31da418c1b20a4d64a3c3c34d2c9f595488aac8be9fce124615909979
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -699,7 +699,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -740,7 +740,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -887,14 +887,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -64,7 +64,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -118,7 +118,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -158,7 +158,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -206,7 +206,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -220,7 +220,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -235,7 +235,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -254,7 +254,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -267,7 +267,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -280,7 +280,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -296,7 +296,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -343,7 +343,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -356,7 +356,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -370,7 +370,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -392,7 +392,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -417,7 +417,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -443,7 +443,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 
@@ -470,7 +470,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -479,7 +479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -496,9 +496,9 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 795331d6d2ec3267242f8eb70556a0a8862008c3604b714df06685c31d26041a
-        checksum/config: 651c3dd8e67ff276f0517fab5b0a58730ddd88a9e5defd1f4e561fd4979027a5
-        checksum/secret: 532626085ad25b28f4637ede3b9fb568cdaf9810929574e6399e358f2f796d70
+        checksum/plugins: f0ef05630a52cc4644e71c1714946db0b72672f57775fcf8d91d4c4304222b38
+        checksum/config: 6d7abbfafa65601341d8d94ce806931db15768e56aacfee1ed47eb080dcf3220
+        checksum/secret: f93f70dec8cfcb3bc93a30e6b1cc023ee8643a03eeba3c7718c17b289fd7fce2
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -506,7 +506,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -534,7 +534,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-new-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -655,7 +655,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-new-values.yaml"
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -693,15 +693,15 @@ spec:
         release: networkpolicy-new-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a440d5f2a8156cad0f37447544814f23775f8eb1ac18f75f0bd68ceb68d40c97
-        checksum/init-fs: 6ad383587c2b7372e68d6ad7ec7979244ec30c5733e22001063c41e1e991e3d9
-        checksum/config: 651c3dd8e67ff276f0517fab5b0a58730ddd88a9e5defd1f4e561fd4979027a5
-        checksum/secret: 532626085ad25b28f4637ede3b9fb568cdaf9810929574e6399e358f2f796d70
+        checksum/init-sysctl: 2d80a877419ed57de540aa8a41079bce81fb46aa1f5a37f61bb399697d606eac
+        checksum/init-fs: 43f3d29b317aeb700aaae50cc713108f7603e4f1b1a37e97fa1a67336e279c2e
+        checksum/config: 6d7abbfafa65601341d8d94ce806931db15768e56aacfee1ed47eb080dcf3220
+        checksum/secret: f93f70dec8cfcb3bc93a30e6b1cc023ee8643a03eeba3c7718c17b289fd7fce2
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -716,7 +716,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -757,7 +757,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -904,14 +904,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -64,7 +64,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -118,7 +118,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-additional-network-policy
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -158,7 +158,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -192,7 +192,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -206,7 +206,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -220,7 +220,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -235,7 +235,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -254,7 +254,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -267,7 +267,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -280,7 +280,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -296,7 +296,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -343,7 +343,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -356,7 +356,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -370,7 +370,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -392,7 +392,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -417,7 +417,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -443,7 +443,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 
@@ -470,7 +470,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -479,7 +479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -496,9 +496,9 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 009f1f6c218a7cd8b75068ff43301c19f4a9aca0c709c855d6185679f650eb49
-        checksum/config: 621cd2df0877aca18f3f1fa212ee1f49c46b8e004cbe193f9edac7f4766e16ca
-        checksum/secret: 999003bed1f09bbce68f20850c56157956aa71beac9c8e47ee189239d369a71a
+        checksum/plugins: fb500ddba7df6ddf04c15fd6c3d1952415740c5d86b70d49d7ac543dec2df2be
+        checksum/config: 43bb4d47db516cab55caad672e98977aa6ffb6aef4c8cc17dab3e3ba0a196cfb
+        checksum/secret: 2c04fc4d8db045eb93ae8e2f91ab506503b0ffd8e4a813bc257fcb60b410eb88
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -506,7 +506,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -534,7 +534,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "networkpolicy-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -655,7 +655,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "networkpolicy-values.yaml"
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -693,15 +693,15 @@ spec:
         release: networkpolicy-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: a6eeed1c755464d1f99ef653fe0c5f1614b67b8fefb149b6d9097767c2b7cc5b
-        checksum/init-fs: f18f49141de30c3560a32d4a7425f19de6ee677fb817efea24beced087fddcca
-        checksum/config: 621cd2df0877aca18f3f1fa212ee1f49c46b8e004cbe193f9edac7f4766e16ca
-        checksum/secret: 999003bed1f09bbce68f20850c56157956aa71beac9c8e47ee189239d369a71a
+        checksum/init-sysctl: aa5fc0c2d69137be694370a2375a003dcaa6f18839ab8da39cb8b295baff4d1a
+        checksum/init-fs: 6b2f9de41c3a06ad5391b18c5d591786113d61080a0aec91d9225705a1bebf44
+        checksum/config: 43bb4d47db516cab55caad672e98977aa6ffb6aef4c8cc17dab3e3ba0a196cfb
+        checksum/secret: 2c04fc4d8db045eb93ae8e2f91ab506503b0ffd8e4a813bc257fcb60b410eb88
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -716,7 +716,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -757,7 +757,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -904,14 +904,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: node-topology-per-process-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 6ad06982a59454aa4b7c696b1bbd9ceb438f83257bed885a180d803dd37ab09f
-        checksum/config: c18019ae62249e5335e038d0db265784ac0db1c518428fe14e8a7052d692201e
-        checksum/secret: 5fae6292407ba5e0e68ae9ccb3e83f57205dd4b13af5d1a1a662a9cdf0c8c1f4
+        checksum/plugins: 1d9692dd9953f83694c5cc157db3bee23a736ee3200fbf62d3ec0448b25b7d7e
+        checksum/config: 23543a1d3c8821f67b14017b6aec87e706bd6c33529fb02f4eaf9b50db2fadac
+        checksum/secret: a6474374dd07273660f1c8082766cfbc6cae6eb4b367f3c669820eafd96b8b83
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-per-process-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -518,7 +518,7 @@ metadata:
   name: node-topology-per-process-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-per-process-values.yaml"
@@ -527,7 +527,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-per-process-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -556,15 +556,15 @@ spec:
         release: node-topology-per-process-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 146b2e2dc98b2cfd293636cc165048a6f741cd4cd36ae512aa9911c17d2fa93e
-        checksum/init-fs: b17d1640c08b116a53c549e9c16a2ae2717461cd38bf8e7d4be66bf100c1c74d
-        checksum/config: c18019ae62249e5335e038d0db265784ac0db1c518428fe14e8a7052d692201e
-        checksum/secret: 5fae6292407ba5e0e68ae9ccb3e83f57205dd4b13af5d1a1a662a9cdf0c8c1f4
+        checksum/init-sysctl: f028dbaca4366a0763095798bd0a3de2cee894023e83165da4090cb59d505453
+        checksum/init-fs: 1a0ca36feaaa64a45ffe216e2b60e268184230694cda23db847f2e5858490985
+        checksum/config: 23543a1d3c8821f67b14017b6aec87e706bd6c33529fb02f4eaf9b50db2fadac
+        checksum/secret: a6474374dd07273660f1c8082766cfbc6cae6eb4b367f3c669820eafd96b8b83
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -579,7 +579,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -620,7 +620,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -782,14 +782,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-per-process-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-per-process-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -6,7 +6,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: node-topology-values.yml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: df946b9d628140b4a1c88311fd4aff69adfeac4b3a068e62ee204f4e8f0f66e0
-        checksum/config: bb11ad7c4aa802497e27c791f86f1483c4a5f297a431235b4865b1c474d7dce6
-        checksum/secret: 9996aae1896135122737ceee9cbf9d55eb90c2a5a52a62f0cf79cf35a1da3033
+        checksum/plugins: 7373b3e23074ae69e619cc606f4f7cbbc22e2f7e5be59d708b33c28fa4f9f672
+        checksum/config: f92a05c096cd1e47a7eec3da45ed284ccbf8d8c5934f1a681d924ce6c3416a28
+        checksum/secret: bad9d423a1b524e095957a46ef1e0d762de61efd4771b0e11e17400bcb1c825d
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "node-topology-values.yml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -518,7 +518,7 @@ metadata:
   name: node-topology-values.yml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
     app.kubernetes.io/name: "node-topology-values.yml"
@@ -527,7 +527,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: node-topology-values.yml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -556,15 +556,15 @@ spec:
         release: node-topology-values.yml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: f785b8c0925e19d85b97a4494b1ea5eed2f3e025290e49be5bee349dc512311c
-        checksum/init-fs: 78c20cc7eead2e21dbd7e218be4caa40d93b22347a02d1d97d87d4abb877e9c4
-        checksum/config: bb11ad7c4aa802497e27c791f86f1483c4a5f297a431235b4865b1c474d7dce6
-        checksum/secret: 9996aae1896135122737ceee9cbf9d55eb90c2a5a52a62f0cf79cf35a1da3033
+        checksum/init-sysctl: 088d4e37194d94a458bd5bd635f44b19de453f6eb5c300c1bf02ee087dc1d055
+        checksum/init-fs: 93bdb016caad1bd683493cc792c8e93fe5699ec9f7ed39ccb898c719c3be6cdb
+        checksum/config: f92a05c096cd1e47a7eec3da45ed284ccbf8d8c5934f1a681d924ce6c3416a28
+        checksum/secret: bad9d423a1b524e095957a46ef1e0d762de61efd4771b0e11e17400bcb1c825d
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -579,7 +579,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -620,7 +620,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -782,14 +782,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: node-topology-values.yml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: node-topology-values.yml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -248,7 +248,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -270,7 +270,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -295,7 +295,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 
@@ -348,7 +348,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -357,7 +357,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -374,16 +374,16 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: c35566b8221fc45149ef8a6a0d92a7f87abe45e3a594623d8a966d4e2cce3d7f
-        checksum/config: 3c93a8c24fcf723f256232a9a869a0f5c7e5b9c8877eabe93394900c42435e82
-        checksum/secret: d9ab7c5665efa60ea11b3bb771788634caf93556a300ede49990e1d84e5d78f7
-        checksum/prometheus-config: 02a015437189e38b473efecdf1bc5a210e0a4b1dcb2382dc6f94429ba2eaf7ec
-        checksum/prometheus-ce-config: 18a2d1369b59b22e31fd8cd42463141e87627acfb62bfd8d33f9c2dcd99fbe3c
+        checksum/plugins: f1d65d984f4ae0ce1cfb43cecdeff862378b63130098efb4a4087626736dddab
+        checksum/config: f64d190dac1013f02ce2e2d50a5462f0b184363485ffaf1be03d786f71e2805f
+        checksum/secret: 2153c6e6d0d5241986cddbc3b6cfbc2513770b0fa084e5092ef1bec7888c469f
+        checksum/prometheus-config: 4e756a7fd3516aa64ec64881940508a0bf476668743d7f27ec402963f6e4d310
+        checksum/prometheus-ce-config: b378594a38a6e4f3f53be5cc6901f3d7ed246a75bda80dff98da8ee6d13cac40
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -458,7 +458,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "prometheus-monitoring-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -597,7 +597,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "prometheus-monitoring-values.yaml"
@@ -606,7 +606,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -635,15 +635,15 @@ spec:
         release: prometheus-monitoring-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: dfa831afbde1eb0e7c3d727ab2803e54da7cfe2b19584b0d113fc0902bd6d642
-        checksum/init-fs: 2aa205f5bdfd3c87b9807b26edfbc4081df3ec147db5f1a912e699004520a2fd
-        checksum/config: 3c93a8c24fcf723f256232a9a869a0f5c7e5b9c8877eabe93394900c42435e82
-        checksum/secret: d9ab7c5665efa60ea11b3bb771788634caf93556a300ede49990e1d84e5d78f7
+        checksum/init-sysctl: 7903e4b152655e04a31473cf0a92def3e0fe6ff4a8f65a7853ea35886d813acd
+        checksum/init-fs: afdff4594aee8484c457b60a9b329b51acb6b5d732080076503ee67530350d4b
+        checksum/config: f64d190dac1013f02ce2e2d50a5462f0b184363485ffaf1be03d786f71e2805f
+        checksum/secret: 2153c6e6d0d5241986cddbc3b6cfbc2513770b0fa084e5092ef1bec7888c469f
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -658,7 +658,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -699,7 +699,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -883,14 +883,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -243,7 +243,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -268,7 +268,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -294,7 +294,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 
@@ -321,7 +321,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -347,14 +347,14 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ea8bf55002a3dc74102ba5266f3b93c3a4a879b18b71dc91f8db418a6478b53e
-        checksum/config: 4203f4e85b56212446cbaeea2fdf9abc39701c6719303e9dfeadf447453db86c
-        checksum/secret: 79d6150ba4e9ac1697fade6cfc32a98c60f048736fa4413d226c937bb89bf30f
+        checksum/plugins: f86efb9a544a9f66ad46e5636838f07a67498964119f041dce7f0e46ffb7145c
+        checksum/config: bf9cb21d2a33f7eb901f72cad3b481838eb3fe7509ee7cdf450390cc975359d1
+        checksum/secret: 4897c093fb5619ed207c6383bda5ecfdf293de745ee96ead595cdf7386eeef6a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: install-plugins
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -398,7 +398,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -426,7 +426,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -550,7 +550,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-secret-values.yaml"
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -588,15 +588,15 @@ spec:
         release: proxies-secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 1bbc85e50a6a337c212640c9078216897c95e3d6e88caddfa9e266e335e2cb13
-        checksum/init-fs: 28a315a4306d0d44e5f3be77b1189bd8b39dbc2029dd7b5989908f70e7f767f7
-        checksum/config: 4203f4e85b56212446cbaeea2fdf9abc39701c6719303e9dfeadf447453db86c
-        checksum/secret: 79d6150ba4e9ac1697fade6cfc32a98c60f048736fa4413d226c937bb89bf30f
+        checksum/init-sysctl: 211cf8a4469bf3e1b9e66c78f9d71a6e9a76811b2f648bbd724daca2b5e801ce
+        checksum/init-fs: 300bd119d49b70c2793d1fb3b1ab49726493697342e4075de4c31a2037224f00
+        checksum/config: bf9cb21d2a33f7eb901f72cad3b481838eb3fe7509ee7cdf450390cc975359d1
+        checksum/secret: 4897c093fb5619ed207c6383bda5ecfdf293de745ee96ead595cdf7386eeef6a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -611,7 +611,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -652,7 +652,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -799,14 +799,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -207,7 +207,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -221,7 +221,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-ce-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -236,7 +236,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-prometheus-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -251,7 +251,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -273,7 +273,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -298,7 +298,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -324,7 +324,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 
@@ -351,7 +351,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -360,7 +360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -377,16 +377,16 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 08f23825c3f2255271cfa580230c094d1ba17928a8175ea96714937f51735545
-        checksum/config: 795a44b95659fb8ebb46ed06b1e31db3c8a45bd00c2de5c63d7bd6a95bcd4d2e
-        checksum/secret: ef79a4ae37123b4cf7b9e3526411f193757a7056a28b587fc269be90712d6a75
-        checksum/prometheus-config: 52fc952840b330970dba42f515379cd67601c159091b04fee82860a707e601b0
-        checksum/prometheus-ce-config: 0dda8e81decd4a86656e7edbfa8fda81d2325585a32d7f16df4f3cc73922297e
+        checksum/plugins: 3d43a72ae2edee657817e74c646d19f21b7a6f407e06c28f82122e47cb1424da
+        checksum/config: 24d60aa1309fd682edf2908d6e1d2531a76dde2f40f9d161d4718da21b3aa77e
+        checksum/secret: 7b2c95bb554c3fa043d73424e3204763e2370a9d33f50516e6e50b248ce60d88
+        checksum/prometheus-config: bdfc1cfd39711beb65bbb18d299a6732cda097abeb06621b09787bb2f51f2889
+        checksum/prometheus-ce-config: 1380fcbb68354d8d8bcbc3adec225696cafb73ec5eb366994bedd418e2364719
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -424,7 +424,7 @@ spec:
                   name: proxies-values.yaml-sonarqube-dce-http-proxies
                   key: PROMETHEUS-EXPORTER-NO-PROXY
         - name: install-plugins
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: ["sh",
             "-e",
@@ -468,7 +468,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -502,7 +502,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "proxies-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -644,7 +644,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "proxies-values.yaml"
@@ -653,7 +653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -682,15 +682,15 @@ spec:
         release: proxies-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 751865073215fa93e7ed41f903e54bcb03f9073fca8cbdc0983c14311fec6632
-        checksum/init-fs: 66142f41add00cdebdfab5c3a7e52d982bc21df5f7af40e7ad8e2286e1b75e9e
-        checksum/config: 795a44b95659fb8ebb46ed06b1e31db3c8a45bd00c2de5c63d7bd6a95bcd4d2e
-        checksum/secret: ef79a4ae37123b4cf7b9e3526411f193757a7056a28b587fc269be90712d6a75
+        checksum/init-sysctl: 2183e19e749a13f170f064b04e709649673988033edfc68066a65af54846b1a5
+        checksum/init-fs: d69b91ff0fd837cf1d804c128a8b0d35d33560bfbfe640c7683d0272e79a66f2
+        checksum/config: 24d60aa1309fd682edf2908d6e1d2531a76dde2f40f9d161d4718da21b3aa77e
+        checksum/secret: 7b2c95bb554c3fa043d73424e3204763e2370a9d33f50516e6e50b248ce60d88
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -705,7 +705,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -746,7 +746,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -893,14 +893,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d226a5196b9b1dca94753347ca1f7d70791e55e34cbef5bedfacfc049732ccc6
-        checksum/config: 43c848ccf2203f670ea6dee440ae059a9f0fe48ba0af4f56904b0ec0d0a535dd
-        checksum/secret: d6531110d6c58d400d8fa747780d36485052c2ae77eb867daee430be703cd84b
+        checksum/plugins: 6f2f24bf6d297aeb06da83651ac96a2728e6ef46d6172f74c279af657461b98d
+        checksum/config: b683c715b18aca1c33ae30cfdbaf5993f0b8c4c8ced1c746a90a435baf291f3f
+        checksum/secret: 238edcbdfc54b7ec75f9feff4459c33c854e57253f5649673fd924b8a8c873f1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "pvc-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -503,7 +503,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "pvc-values.yaml"
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -543,15 +543,15 @@ spec:
         release: pvc-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 136740e924ca2992784414513569ce86db05ffbdb9ee7033ba9e1dbb35dea917
-        checksum/init-fs: d988abf40f603f8855a745ede46cbff4da3b15e52cca9963498e09992b38ef1b
-        checksum/config: 43c848ccf2203f670ea6dee440ae059a9f0fe48ba0af4f56904b0ec0d0a535dd
-        checksum/secret: d6531110d6c58d400d8fa747780d36485052c2ae77eb867daee430be703cd84b
+        checksum/init-sysctl: ee519103b8fc8579f35925c266d9941575782a7b6c205f9b09131c36e82fd4d0
+        checksum/init-fs: c190a2b9a336dc991a96b54c0196e7d724fd4f2d88521bdf1292b6563028e3d8
+        checksum/config: b683c715b18aca1c33ae30cfdbaf5993f0b8c4c8ced1c746a90a435baf291f3f
+        checksum/secret: 238edcbdfc54b7ec75f9feff4459c33c854e57253f5649673fd924b8a8c873f1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -566,7 +566,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -607,7 +607,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -754,14 +754,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -6,7 +6,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -116,7 +116,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 data:
@@ -157,7 +157,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -179,7 +179,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -204,7 +204,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -230,7 +230,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 
@@ -257,7 +257,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: restricted-openshift.yaml
@@ -283,9 +283,9 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: ca14e258f8898ba217beb9cdaa87729493aeda4cfcffc103862003958c37a4f9
-        checksum/config: c19f39d59d80b7c7879d1e706ce6b55a3fc024ced84e02e5c9396672fbfa2e84
-        checksum/secret: 65513b968d0136df5eda1b08e055746891f809bd7e9fd21f731652f228ab6230
+        checksum/plugins: 77e4e33ec7ec9205725a66e433292b1c00db7badbba107fbaf47458633164513
+        checksum/config: 5ce9a051343a6ddbedb75009dee0c9d18f234028af49b732628805d4a5ff83df
+        checksum/secret: fb7f12336b0e58e0b791e7a77b7b5240cc550a96fa65cb47b3b07bbbc9c605e8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -355,7 +355,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_CLUSTER_SEARCH_HOSTS
@@ -488,7 +488,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
     app.kubernetes.io/name: "restricted-openshift.yaml"
@@ -526,8 +526,8 @@ spec:
         release: restricted-openshift.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/config: c19f39d59d80b7c7879d1e706ce6b55a3fc024ced84e02e5c9396672fbfa2e84
-        checksum/secret: 65513b968d0136df5eda1b08e055746891f809bd7e9fd21f731652f228ab6230
+        checksum/config: 5ce9a051343a6ddbedb75009dee0c9d18f234028af49b732628805d4a5ff83df
+        checksum/secret: fb7f12336b0e58e0b791e7a77b7b5240cc550a96fa65cb47b3b07bbbc9c605e8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -710,7 +710,7 @@ metadata:
   name: restricted-openshift.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: restricted-openshift.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: b80ed077f8dada5804361a38abb1e3e7c86cdd31aa25d59dadd90db2dbb03b61
-        checksum/config: 98af638691949f9f2f0385ff1d9a757b5c9eb1d6963c43ab151dc0de45913a9d
-        checksum/secret: cb478b57a6330851f2bd61b92800f0b808fd39ec2c9433a7ccab9bafdbb686e1
+        checksum/plugins: f8b5905b4fff02c96c6b8ee173b37be6e5034805b4b7198b8b6a102135cc63e3
+        checksum/config: dc663f9748167d747a63ceb3a545193f1d0168a2971fdd917fd12809d0f37509
+        checksum/secret: a29930849493c33473d888c95ea4e57a1fc614ab76e7678f473afafbb1b9b5b1
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "secret-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -517,7 +517,7 @@ metadata:
   name: secret-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "secret-values.yaml"
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -555,15 +555,15 @@ spec:
         release: secret-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: bc1ab474986502d2ccc1160df742de61ba7dad7904511b23d78c947bad4ffe03
-        checksum/init-fs: 9db43ad72232d085f36ad70b571c14a5fc5528946d6a1b15972b703c16167902
-        checksum/config: 98af638691949f9f2f0385ff1d9a757b5c9eb1d6963c43ab151dc0de45913a9d
-        checksum/secret: cb478b57a6330851f2bd61b92800f0b808fd39ec2c9433a7ccab9bafdbb686e1
+        checksum/init-sysctl: 8fbebbaca0a0f24b6406140a12f3c98710f56c4721f55a80a0eecc73d879d2db
+        checksum/init-fs: d998978385957509ec3d0e55fef81506e84ef455f85e4179f2fca3abba4fbc4e
+        checksum/config: dc663f9748167d747a63ceb3a545193f1d0168a2971fdd917fd12809d0f37509
+        checksum/secret: a29930849493c33473d888c95ea4e57a1fc614ab76e7678f473afafbb1b9b5b1
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -578,7 +578,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -619,7 +619,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -766,14 +766,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -807,7 +807,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: secret-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.4.0"
+    helm.sh/chart: "sonarqube-dce-2026.4.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -247,7 +247,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -276,7 +276,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -305,7 +305,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -336,7 +336,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -345,7 +345,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -362,9 +362,9 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 7eb0cc5c5c20e93d4921fe59f08899611c80ca7fd7db76d24930d6a3ef72731a
-        checksum/config: b371b6d255d7481e736c901f2e065b1def1c6adbff42f12b338425e63d8352a0
-        checksum/secret: 788417e5478d08521891bab079bde9cab6d25a32ab9133ff0a80fd64e77285ba
+        checksum/plugins: 1c0310aa751d39f43ee47c87fef2271f0fda929dd662c99ef9599d39a46a2f6a
+        checksum/config: 7c326a6270da2410c75928897212e5efc2c1b2086b9c3c2f3edec0712a635c93
+        checksum/secret: 8ffcab41caca246111641de34100f256e6802fc04192e84320309ce5fa9f1de8
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -372,7 +372,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -400,7 +400,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "service-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -521,7 +521,7 @@ metadata:
   name: service-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "service-values.yaml"
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -559,15 +559,15 @@ spec:
         release: service-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: cae1a24aaeb69c31c71a3b4bf2a7293fb93db1422e8ce40324f0744519d11a96
-        checksum/init-fs: 3ccb3203697d0b549b98e5ce9ca45d24c5521c232279cdd5616cfb44797486fb
-        checksum/config: b371b6d255d7481e736c901f2e065b1def1c6adbff42f12b338425e63d8352a0
-        checksum/secret: 788417e5478d08521891bab079bde9cab6d25a32ab9133ff0a80fd64e77285ba
+        checksum/init-sysctl: 3f46ac61292dab90801d96c8b350f74ff98923c261b0aed21fc1597aa8dfac85
+        checksum/init-fs: ec5aab5ed7b5e2479223629893b2875aed333019074076379ae892d2d5ac4dcc
+        checksum/config: 7c326a6270da2410c75928897212e5efc2c1b2086b9c3c2f3edec0712a635c93
+        checksum/secret: 8ffcab41caca246111641de34100f256e6802fc04192e84320309ce5fa9f1de8
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -582,7 +582,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -623,7 +623,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -770,14 +770,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -49,7 +49,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -63,7 +63,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -77,7 +77,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -92,7 +92,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -111,7 +111,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -124,7 +124,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -153,7 +153,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -200,7 +200,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -213,7 +213,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -227,7 +227,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -249,7 +249,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -274,7 +274,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -300,7 +300,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 
@@ -327,7 +327,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -336,7 +336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -353,9 +353,9 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 0f2d3b2cd51a15f1c5c396b6a2977675cf4196ee8e01d7e54d5c329d40bde33f
-        checksum/config: 95ce1d8cfb0c0a7ecce64d5b60f4477d11ee69a0680388cd1c96048da63be358
-        checksum/secret: af7c0b60bcb0c31b069e899023f4199faee264f3280bcfa3881bfbb9ae93e185
+        checksum/plugins: 2cbfcc0a1e3e52e028ddae11efd2472523906a8040a739cad37d0bda8349ea92
+        checksum/config: a78dfdd0c899a609d506b9ede4736a67278aad9fc062c58b194b330776fa48a2
+        checksum/secret: 994c053b2bf7a4c66b386ae0356c9cc8eea8bb9cc010a46f129affc7d9a49b5a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -363,7 +363,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -391,7 +391,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "serviceaccount-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -512,7 +512,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "serviceaccount-values.yaml"
@@ -521,7 +521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -550,15 +550,15 @@ spec:
         release: serviceaccount-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 2cf175ccdb0be9721db9fc4feb33cc05ee5e1a279724c7befce85bef4f38f9fa
-        checksum/init-fs: 57f1a64cbb8adfaad8a9705ddb2a048c93de2c1c8a463a1ec1088405c6cfe0fd
-        checksum/config: 95ce1d8cfb0c0a7ecce64d5b60f4477d11ee69a0680388cd1c96048da63be358
-        checksum/secret: af7c0b60bcb0c31b069e899023f4199faee264f3280bcfa3881bfbb9ae93e185
+        checksum/init-sysctl: adf4384ed4c86b81a502a42761a9cffb524783d416f971a888a6126f1443e113
+        checksum/init-fs: 9405e7f5d954f74091ee7cb134271f72189c3db1c095560569a49ff090fe8c36
+        checksum/config: a78dfdd0c899a609d506b9ede4736a67278aad9fc062c58b194b330776fa48a2
+        checksum/secret: 994c053b2bf7a4c66b386ae0356c9cc8eea8bb9cc010a46f129affc7d9a49b5a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -573,7 +573,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -614,7 +614,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -761,14 +761,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -143,7 +143,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -159,7 +159,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -206,7 +206,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -219,7 +219,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 data:
@@ -233,7 +233,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -255,7 +255,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -280,7 +280,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -306,7 +306,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 
@@ -333,7 +333,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deprecated-values.yaml
@@ -342,7 +342,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -359,14 +359,14 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: a9bf8349550837b86b8f4dad1acab48c2b8cff693ab533e70f1e92deae7743b2
-        checksum/config: f0c1b0ce2b55f906ad1bce8c13c47a86ef72a6406f91990b959d0cb728aac600
-        checksum/secret: 763637efa6adfe11afc6bb4fa73a91130d6a6e645e32ca875e151eae06e1cdcf
+        checksum/plugins: b6eada687d15f1e1c0111db73b09e6ce46e7b14d59a7b64210a27ea59ecd151d
+        checksum/config: 4438ba63b1e2fbdb67efad9e72e0a9989f37685bc8815a6ac3e800fdcbfbe0d3
+        checksum/secret: a34397aee1fa2387f45cfb2dd0d6ea271c29aaceef1f5828100d7e1e22cc646a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: concat-properties
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           command: 
           - sh
@@ -405,7 +405,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -433,7 +433,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-deprecated-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -566,7 +566,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-deprecated-values.yaml"
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deprecated-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -604,15 +604,15 @@ spec:
         release: sonar-web-context-deprecated-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 83c777e106490e488dab1135161c54d7d33fe486ad306a3ad6b7cb90d0507969
-        checksum/init-fs: 63de4268318f21c25040326650f9cd33a9e13f80f745727a3e0457ef0ddb13a6
-        checksum/config: f0c1b0ce2b55f906ad1bce8c13c47a86ef72a6406f91990b959d0cb728aac600
-        checksum/secret: 763637efa6adfe11afc6bb4fa73a91130d6a6e645e32ca875e151eae06e1cdcf
+        checksum/init-sysctl: 52db094ea6472d4361e8f97859ae62430ebdbb84e54920bff5e4aaee891d7301
+        checksum/init-fs: d1a3bd69e9d2b868d0a9bd50bb28e3c46fe8676c571b6a8fa2c3c9d2110a5c55
+        checksum/config: 4438ba63b1e2fbdb67efad9e72e0a9989f37685bc8815a6ac3e800fdcbfbe0d3
+        checksum/secret: a34397aee1fa2387f45cfb2dd0d6ea271c29aaceef1f5828100d7e1e22cc646a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -627,7 +627,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -668,7 +668,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -811,7 +811,7 @@ metadata:
   name: sonar-web-context-deprecated-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -838,14 +838,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -879,7 +879,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-deprecated-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.4.0"
+    helm.sh/chart: "sonarqube-dce-2026.4.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -899,7 +899,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deprecated-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.4.0-datacenter-app
+        image: sonarqube:2026.4.1-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -82,7 +82,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-admin-password
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -97,7 +97,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -116,7 +116,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -142,7 +142,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -158,7 +158,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -205,7 +205,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -232,7 +232,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -254,7 +254,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -279,7 +279,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -305,7 +305,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 
@@ -332,7 +332,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -341,7 +341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -358,9 +358,9 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: d291d42d828cc17dd8ef2205d9e5971f8c97d8122cd8bd721f3a476dff5058f0
-        checksum/config: 338ab010265906e72c8b62c8982dd1c0cc72e03a051f372809e50d5f64a7423e
-        checksum/secret: d7beeeee3ab03f69a0bade65e17eb0a6249db7c7a5131ef6b720e9aa3c206023
+        checksum/plugins: 409c805116b29eec1157fb18eadfc72722dd88061f77b12d1ddfbbb9db18bf11
+        checksum/config: 871b89931f2a56a241543fa3eba351963d38d4a7d178848a215a179aa4c01c55
+        checksum/secret: 5ae8d618d701ae3fc0adca95e62a8df195fe64bc942be2d4e18c86926d56bd1a
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -368,7 +368,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -396,7 +396,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "sonar-web-context-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -517,7 +517,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "sonar-web-context-values.yaml"
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -555,15 +555,15 @@ spec:
         release: sonar-web-context-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: 041914a7ed09e71192c94347f1c550eb83e7379d0df406c077ce7e2ff3731e66
-        checksum/init-fs: 7dbc5dbe9f2790d7b2818fd8f77fff80b7b1ba39d5e67969e83b14f0b47801ac
-        checksum/config: 338ab010265906e72c8b62c8982dd1c0cc72e03a051f372809e50d5f64a7423e
-        checksum/secret: d7beeeee3ab03f69a0bade65e17eb0a6249db7c7a5131ef6b720e9aa3c206023
+        checksum/init-sysctl: 566ee6d50a904b085ffb35bb3b9c702dc54bf094c15f42088a342e128e578e24
+        checksum/init-fs: 0bd13fe9a63434a8324f01c0da95d98147e4b8e35d5b646e758d172eb5346df4
+        checksum/config: 871b89931f2a56a241543fa3eba351963d38d4a7d178848a215a179aa4c01c55
+        checksum/secret: 5ae8d618d701ae3fc0adca95e62a8df195fe64bc942be2d4e18c86926d56bd1a
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -578,7 +578,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -619,7 +619,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -762,7 +762,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -789,14 +789,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -830,7 +830,7 @@ metadata:
     app: sonarqube-dce
     heritage: Helm
     release: sonar-web-context-values.yaml
-    helm.sh/chart: "sonarqube-dce-2026.4.0"
+    helm.sh/chart: "sonarqube-dce-2026.4.1"
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -850,7 +850,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-dce-change-default-admin-password
-        image: sonarqube:2026.4.0-datacenter-app
+        image: sonarqube:2026.4.1-datacenter-app
         securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
@@ -23,7 +23,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
@@ -40,7 +40,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-monitoring-passcode
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -68,7 +68,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-jwt
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -83,7 +83,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-http-proxies
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 type: Opaque
@@ -102,7 +102,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-init-fs
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-init-sysctl
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -191,7 +191,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-install-plugins
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -204,7 +204,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-jdbc-config
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 data:
@@ -218,7 +218,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -240,7 +240,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -265,7 +265,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -291,7 +291,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search-headless
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 
@@ -318,7 +318,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-app
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
     app.kubernetes.io/name: topology-spread-constraints-values.yaml
@@ -327,7 +327,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: topology-spread-constraints-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-app"
+    app.kubernetes.io/version: "2026.4.1-datacenter-app"
 spec:
   replicas: 2
   revisionHistoryLimit: 
@@ -344,9 +344,9 @@ spec:
         release: topology-spread-constraints-values.yaml
         sonarqube.datacenter/type: "app"
       annotations:
-        checksum/plugins: 180fe929450aa723d8d03053b416eba136a46f80d7dee0d9872281d9064afaba
-        checksum/config: f9be72cd88fe68ac26ed2486b91602b110cba9c46e2fe7ee9f784ca6929753db
-        checksum/secret: 627c2b5185ccb109e1f5754a95d7093037c54843a8bb1efdd7c8a7b5e99ac61d
+        checksum/plugins: c6ad8d86ba5389f3e77d61e246ec323fe80b7bec0883570dca2d3fcbe2b65bc0
+        checksum/config: fc0f06d79e3d49d17c1ba83c3e8dad4bb77090c9fe4b710a8aa554f057c7ca37
+        checksum/secret: 5f9ade04f0b88637e8497fc6aee54456b109437ff862ff2526ca2b49793d8e69
     spec:
       automountServiceAccountToken: false
       initContainers:
@@ -354,7 +354,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -382,7 +382,7 @@ spec:
             - name: SONAR_LOG_JSONOUTPUT
               value: "false"
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_CLUSTER_SEARCH_HOSTS
               value: "topology-spread-constraints-values.yaml-sonarqube-dce-search"
             - name: SONAR_CLUSTER_KUBERNETES
@@ -511,7 +511,7 @@ metadata:
   name: topology-spread-constraints-values.yaml-sonarqube-dce-search
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
     app.kubernetes.io/name: "topology-spread-constraints-values.yaml"
@@ -520,7 +520,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: topology-spread-constraints-values.yaml-sonarqube-dce
-    app.kubernetes.io/version: "2026.4.0-datacenter-search"
+    app.kubernetes.io/version: "2026.4.1-datacenter-search"
 spec:
   podManagementPolicy : Parallel
   replicas: 3
@@ -549,15 +549,15 @@ spec:
         release: topology-spread-constraints-values.yaml
         sonarqube.datacenter/type: "search"
       annotations:
-        checksum/init-sysctl: e0e97de96af12a83513f11cde0342969bdbcadb95e1334f0051e0e1423971146
-        checksum/init-fs: b9d8dbea209dae9186ceb580d4719a6edddd9957bf2a9d24e18e688057469aa0
-        checksum/config: f9be72cd88fe68ac26ed2486b91602b110cba9c46e2fe7ee9f784ca6929753db
-        checksum/secret: 627c2b5185ccb109e1f5754a95d7093037c54843a8bb1efdd7c8a7b5e99ac61d
+        checksum/init-sysctl: ea33820f1fa705ae3aa80de5c006f5c5e52e538e31df601fd24f2b27bcbaadc2
+        checksum/init-fs: c6ce401ea6ff2f3db354d7321e68691aa14ed11993850aa55d2d9e6809a09423
+        checksum/config: fc0f06d79e3d49d17c1ba83c3e8dad4bb77090c9fe4b710a8aa554f057c7ca37
+        checksum/secret: 5f9ade04f0b88637e8497fc6aee54456b109437ff862ff2526ca2b49793d8e69
     spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -572,7 +572,7 @@ spec:
             - name: init-sysctl
               mountPath: /tmp/scripts/
         - name: init-fs
-          image: sonarqube:2026.4.0-datacenter-app
+          image: sonarqube:2026.4.1-datacenter-app
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -613,7 +613,7 @@ spec:
         fsGroup: 0
       containers:
         - name: sonarqube-dce-search
-          image: "sonarqube:2026.4.0-datacenter-search"
+          image: "sonarqube:2026.4.1-datacenter-search"
           imagePullPolicy: IfNotPresent
           ports:
             - name: search-port
@@ -768,14 +768,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube-dce
-    chart: sonarqube-dce-2026.4.0
+    chart: sonarqube-dce-2026.4.1
     release: topology-spread-constraints-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: topology-spread-constraints-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-datacenter-app"
+      image: "sonarqube:2026.4.1-datacenter-app"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-oracle-jdbc-driver
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
@@ -154,7 +154,7 @@ metadata:
   name: ca-certificates-configmap.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-configmap.yaml
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-configmap.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -174,10 +174,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f8aa11f39a0e5d00b8b50d9eaf3ed699745188e09567c2c1c63fc269353a7b50
-        checksum/init-sysctl: 6b529bd8bcc2d60623f4c142ecf474354b0898e76dadc0bc6958c77afe788443
-        checksum/plugins: aa778a5be8a9c931ff4f4db1a6f2ceeea2ab86e76fe4540ef665495a72a2e047
-        checksum/secret: 2c83f97b3e967ed3bb7af7f9ab9c1602c9aecf8b0b67c8df5491c6d4265bf3b2
+        checksum/config: ef301ed05c0465a91283482b65ae9912a7aa8de77d9dd2564f99e20b8a14cc2b
+        checksum/init-sysctl: 8292911ceb2d4a2716416fa9c760e29e310ad5ecad3ab1b3d6d5bb8f6000cc30
+        checksum/plugins: 0e20436268f399acde47d3827e2a191673509d21ebc5128288e155123da19689
+        checksum/secret: 8e1666c81de6180106bfd21c22bb2f3346c1a80ffc45637ad87244d7341e57e7
       labels:
         app: sonarqube
         release: ca-certificates-configmap.yaml
@@ -187,7 +187,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -226,7 +226,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -244,7 +244,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-plugins
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -291,7 +291,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: install-oracle-jdbc-driver
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_oracle_jdbc_driver.sh"]
           securityContext:
@@ -326,7 +326,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -343,7 +343,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -471,14 +471,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-configmap.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-configmap.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ca-certificates-secret.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
     app.kubernetes.io/name: ca-certificates-secret.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ca-certificates-secret.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b78880050714a43d35f042fe01e683150d016f9dc6029fba2188b1276972dea
-        checksum/init-sysctl: d027b010d598347124b4296e2e6dfb852591026a98a7bb411ffcdcd2acbb4638
-        checksum/plugins: 9eaabe13f981cdd65c90af94917c2c3c555b697510ea518acaf5e94668b91304
-        checksum/secret: d768c9544c7824d46e3e4006eae2083fe938bfa486fd9a830160644485343358
+        checksum/config: ed7eea7853f7182001ebc30450219005ad0abaa4efe6bcb7e393ba74558ce298
+        checksum/init-sysctl: 6449269de8615defb019277b8feab040ffa0448fd9959c2e0f7d51a1d73a8049
+        checksum/plugins: 5a46eb8f412037faa3e70427528763a8996b3389ecd49f32ddd3b89947ea2067
+        checksum/secret: 76a43335f04fd978b71d00bb412fac492c17d1c5de9a00ee83e537dbe39cc72a
       labels:
         app: sonarqube
         release: ca-certificates-secret.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: ca-certs
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args:
@@ -207,7 +207,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -226,7 +226,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/opt/sonarqube/certs/cacerts
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -243,7 +243,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -348,14 +348,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ca-certificates-secret.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ca-certificates-secret.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
     app.kubernetes.io/name: change-admin-password-hook-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: change-admin-password-hook-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d3631e22e9ad1c1261a52cf0aee0d920f2de6c8290257b9be1898de5b72c3a64
-        checksum/init-sysctl: 6f3bfb84371d597881cd6732c4821db3daeae660c48b744fc9ec86280ec99de7
-        checksum/plugins: eaacb5c535b24189275fd298b546b065768c71abe69eb5751f7b282dcc303ac7
-        checksum/secret: 94bab275a0b3922436d3a4f7363bdfa1ce1adf11d0761480206e0d9099d6baa0
+        checksum/config: 25dacc956df01903156504cb82e7dd8505038b1331c9831f4883a310c159f7c0
+        checksum/init-sysctl: d0c000a4c914ada55fe18336bd20da08c3e7905f97f5ea715b95bcaaba593c7d
+        checksum/plugins: 1185671e6d4e59e1e11c0ccef91ca4e6f49273770637b1b890cee3d5eca92af0
+        checksum/secret: d45e10e2cf3a576dfd92951437a55c3ef1018055045bde96fdd3646279f7b9c3
       labels:
         app: sonarqube
         release: change-admin-password-hook-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: change-admin-password-hook-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -359,7 +359,7 @@ metadata:
   name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: change-admin-password-hook-values.yaml
     heritage: Helm
   annotations:
@@ -372,7 +372,7 @@ spec:
       name: change-admin-password-hook-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.4.0
+        chart: sonarqube-2026.4.1
         release: change-admin-password-hook-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: community-build-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: community-build-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
     app.kubernetes.io/name: community-build-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3eaa127cc35f561c02063d182ff3fdc0efc20c71a2915864a4be3af5c66fb8ba
-        checksum/init-sysctl: 214b994ee2edf9cd8e1c98992d7d96e3785a6d5bf623000b84b1fa8391794870
-        checksum/plugins: 3b32836c9081ed29751f1c470a262f6b78d75a6deacb36fe1eba4b1fff095de5
-        checksum/secret: a6d77f0805e698b75c44334998e808c7cd76149ba4e2d269d165ce1698321c2e
+        checksum/config: 3f8d5a0723ba674c23e2873929ab17f6aad2a0e5853f949edc169e297abb863b
+        checksum/init-sysctl: 54697ee42049b48ddfb143eaa0d7ff513de52d91925dc69dcc9f056015c18535
+        checksum/plugins: 807fe825ffdee809ec3daac3b3c6bda8066cb3ab885c8c22f307377943c4d1d3
+        checksum/secret: d1bd2ed5b024a718005f362e3c7b8d42dffa99341fcb948e87ba3977e56cacd6
       labels:
         app: sonarqube
         release: community-build-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: community-build-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -58,7 +58,7 @@ metadata:
   name: config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -105,7 +105,7 @@ metadata:
   name: config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
 data:
@@ -118,7 +118,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
 spec:
@@ -139,7 +139,7 @@ metadata:
   name: config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: config-values.yaml
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -159,10 +159,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5fe58941717ed91250c9ce31aacbfa2adee188b4c184a2b863416b2ce0076828
-        checksum/init-sysctl: 47dd9c70e910490f2d27cbd80a29d675ec17544d45a2e8c8905375f68dbdec30
-        checksum/plugins: d6d588edfee491192bb6d0137006a5cfa8fc62495a2ec2c3fb6554400244c913
-        checksum/secret: 4b79d1cfcb4eebf3f625c1001a5cfe097c7d2340f416d916f10b6adf0cbe53c6
+        checksum/config: 15ef24bd743199d63a8fad5e399b0d28208b9b056105027d16c671954ab9826d
+        checksum/init-sysctl: 8c7650b4867adf5688c8d783b5f15c7894f6af0779a44d4732232302725ce611
+        checksum/plugins: 9bd5f1b90a93ad2a71f37f7d992993133998c21fa4aace7cb8f4cb9fc05a4e7b
+        checksum/secret: 41b049bd4319183676247b07e2a75f5a02dd8d7c4e8f144fe8c2aa18b2a81488
       labels:
         app: sonarqube
         release: config-values.yaml
@@ -172,7 +172,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -190,7 +190,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: concat-properties
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -235,7 +235,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -252,7 +252,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -384,14 +384,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: config-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: custom-image-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
     app.kubernetes.io/name: custom-image-values.yaml
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4e3072d9c42dd082315e1385cca4566e4058956cbcd2c5f2e0c1eeab629a375b
-        checksum/init-sysctl: 6a6cc5808cfacecc0d221d99c4fe79bf3fe7e26b18945159cfe7cf0845988cd9
-        checksum/plugins: 723b41f42132706372dcde7d17e01125e067f06bb3ebe864f8259b19475b5088
-        checksum/secret: 131245eb20c3509405980af882e63ad7c1154fb07a21d792e32485d6b4684b4e
+        checksum/config: 855990c159861a13d9b60ff8f67acc9df4583a3e99eb18b70114a631e011caf4
+        checksum/init-sysctl: 8f9b2b1babaf42df740997081e7bdc62f6fd6865106f6f7209dd2b36709554c2
+        checksum/plugins: 440b72a74bb7d83c2f89f2ecef38c0bf43eade7563a7183e5c4879606fc59c84
+        checksum/secret: fe982582cf9a0cb9caad03e201362bae9cccbb0edaf899b7d98251641492af2e
       labels:
         app: sonarqube
         release: custom-image-values.yaml
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,7 +306,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: custom-image-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 10bbd835f3261307730db88828a7071210301b8158a1d942751d42bded4d3f83
-        checksum/init-sysctl: cb24a342eb4fb5cd7bec09cf752daa8b565c3e1f826b4ea18772ad2be25056ef
-        checksum/plugins: 3b319f69f9a1654901aaa085dfe9d630e9ab9ef9e5f3280ce5c3b4872a73a319
-        checksum/secret: 709a1f1323bc7dc1a7b647d6d8f57707216d11c9dbbf186dca580702aeeb7496
+        checksum/config: bd03375d6c628818f96726797cd4047d4f4f0f70400dc403bfd32aa571d73756
+        checksum/init-sysctl: 389e94b5ea54d70aec22740fdf3e691a935b322784ebceb48d440235cab7dd45
+        checksum/plugins: 0f780f697bb880115ea285ffb60fa22661fee7217d408af0b407650a0871ab6b
+        checksum/secret: 13a861273f6a97331c4bb7f5dc481dbd8899bf89d2e57b3dd1eed4bb6f11f337
       labels:
         app: sonarqube
         release: default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -306,14 +306,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: default-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: deployment-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: deployment-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
     app.kubernetes.io/name: deployment-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: deployment-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -156,10 +156,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 440c0ed538977d0b956868c194ba0a2eec3567d563f3cda32f15611a23590b90
-        checksum/init-sysctl: 5ec6aacf7afede0323d753f0f06642060d5e8b9706fadd38801f13261b89ba42
-        checksum/plugins: 658f0be6cba59775a71c469790842027e8cb38f425c9e00fcdc1239831abe9fb
-        checksum/secret: 992c4e176019919954042c6bc86a8bca6c99f0a12636404a56fdb251a4cc7429
+        checksum/config: dac89fe96d799b3ac91c39c6dbf6e3bbc43d148267b3ff3431d5b4ee0671cdf9
+        checksum/init-sysctl: 6fc5c8bae3ea102914a7b2b471257b0084ec95aef960af2a4433f61e0d7d6fb0
+        checksum/plugins: a2774c963abb492ce479014293ed9f13df66494ca2ce2c3deee321754b003868
+        checksum/secret: 962ea29ac5658e771bba5e71600cd40a9a466036dc28a19e2bdd40a38be0e7f1
       labels:
         app: sonarqube
         release: deployment-values.yaml
@@ -169,7 +169,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -188,7 +188,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -205,7 +205,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -307,14 +307,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: deployment-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: deployment-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -129,7 +129,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 data:
@@ -144,7 +144,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
@@ -165,7 +165,7 @@ metadata:
   name: duplicated-env-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
     app.kubernetes.io/name: duplicated-env-values.yaml
@@ -173,7 +173,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: duplicated-env-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -185,12 +185,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7fe1069ae7ce59da3db748926c60eedc93c26e8ec27ccd44a24cac2df948fe22
-        checksum/init-sysctl: 12779b4def6cf53c9b44d235bbe0cd5bede2d542bdd67d108f96d68ae7002966
-        checksum/plugins: fda18251dd4e64f41be587785624137698c9a4c2d794a64a16df8b0659cfa6dc
-        checksum/secret: e440e41bd44b851a6eb0af6e700aea9118152639f6716a753449e13802d088bc
-        checksum/prometheus-config: 45c0cbb3c18160bf0fa0104f4c87f1079183465c83fc5494e7591109bcae32c3
-        checksum/prometheus-ce-config: 7b0e9eb6862ffb2eef5e9af8092b2879a6d5318a1b24fe4e13d2e6025b783260
+        checksum/config: 464aac08af0211932e9f49f2b8daee2c1f41740bf3456bdbd4dd5a7862435801
+        checksum/init-sysctl: 7e7203dd4b8f8a3a2594b86a766b79382f489d9e01c1b4627cc153ce270604f7
+        checksum/plugins: 48d5b5d8292efac030686d6e8b8883f86a357a765d289abfa48a6c31293a1747
+        checksum/secret: 2444f9f964a10f6b6257a4b6ab75d3877d7db7cfc532de7f4e3b041e3b632391
+        checksum/prometheus-config: a11751422d231f7bbf6f4f0b2a9e381a2fc3bd64758ac7b7d0640551a29d80bd
+        checksum/prometheus-ce-config: 728d4854485f8e20acb4954aa91bb9f6f7054b9a69cc26d9406d85af6ed2e498
       labels:
         app: sonarqube
         release: duplicated-env-values.yaml
@@ -200,7 +200,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
                 -Xms2G -Xmx2G -DsomeOption=some/Value
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -275,7 +275,7 @@ spec:
                 -Xms2G -Xmx2G -DsomeOption=some/Value
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -298,7 +298,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -425,14 +425,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: duplicated-env-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: duplicated-env-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: host-path-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: host-path-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
     app.kubernetes.io/name: host-path-values.yaml
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0f91e1254cdcbded48b25ba5843f116fa5a84fa7791a80008391d6987cc2007f
-        checksum/init-fs: 6ac4211b045cb9355ba28bc3db2863d7c90618ccd25abf814915951d29bd8636
-        checksum/init-sysctl: a1ba9ee3334f759434f75eb4a842f514b050074e60ac2978f4799b2cd59e5d42
-        checksum/plugins: 2435479faf54e8dbb9be7cd879f72d22bc5024943a3ab9cd5e449e03ff238602
-        checksum/secret: 5db441a28b5d418a3c68e151e185a2c1020465c1a5fdf5548e4dac343b240c0d
+        checksum/config: 499abf333916714beb48c8dcf2836781f0b6a2c2e14ef3577d9de8a949e11fef
+        checksum/init-fs: ee5d172de1b3357173e3008289b8994ade2a2ec3aa8c01b200ab940ed82e0578
+        checksum/init-sysctl: 19f95009fa51ef89e8b2122f21251f12315c586fc5d10e01f758fcfb4596233d
+        checksum/plugins: 6369c432e1a7869b9949fe67a2767edb62dad9a6461b02e5c56d0bb22c2c0808
+        checksum/secret: 99bf48020b4563ba45c920fcec5feae8e6a7d0b5650701019f3fc61b73dffce7
       labels:
         app: sonarqube
         release: host-path-values.yaml
@@ -272,7 +272,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -381,7 +381,7 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: host-path-values.yaml
     heritage: Helm
 spec:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-default-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-default-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6aa60f78497d3cf4449bc300b32eab39e7b08c6c993deedb943e4523762410c3
-        checksum/init-sysctl: 67bf6b909eca710d101ec5e143dfaf7d9a80848b31b012d19eea575eccd01adc
-        checksum/plugins: 4aeb1b7e7a66381560c4330b5371ff9c5dae758209b6ffc426d59c1253ad6cc8
-        checksum/secret: 22442916643a2ec84f993df0df7161bb3c987b4cbcfab490260881cf5974956f
+        checksum/config: b47fb42d0aa46efa8fb405b96249bd35f22b8b886430ab2186be11a756f4e13e
+        checksum/init-sysctl: 35c33590b9f3f75a9260e9dfb235146e4d279f5ef6257f37959d4b2f95f55cf4
+        checksum/plugins: bc1bc77ad80fc2280d7b890d2b112c5f2bf89220225258c396fde90bd9cc1e74
+        checksum/secret: 6edf4c23abab6683015c0d8a360fa2d20bc9809bf024ee9903fcd2a2b78c2bab
       labels:
         app: sonarqube
         release: http-routes-default-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-default-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
     custom: toto
@@ -331,14 +331,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-default-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-default-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
     app.kubernetes.io/name: http-routes-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: http-routes-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a6e3169d3912bafdca440eaff60a44bf6d2594e5c444d09e25861964d0061e7d
-        checksum/init-sysctl: 5b161c68cc1923f65a84d2a27dbbad249c4bfefa96ae441355a12ffbb2e26a67
-        checksum/plugins: 7fef3b3df3c7047114c35cf3b247877a5ef95bacd5c971f21c0a9e8088a23311
-        checksum/secret: 45a38bd00a2eb5d3bc3921b08ceb470264ac83a4fea1e4db456442b463d3dc85
+        checksum/config: ddd8d6b9a438f82157f67a1e1d507d66bbd42b07f6d406470ddefe7277bf393e
+        checksum/init-sysctl: 69b5ab5efa4a2b818711b79669e78ea7eaa45c4db63005a5c9bfe97860acb952
+        checksum/plugins: f6e127dd5b5a6109b5e88a7f1abf3a15cd72438ba6e58772f97e5b3b4f21d214
+        checksum/secret: 55f4871ea39c05863890be681306fe423b2a28db4fa9af03171417e4fd61f91a
       labels:
         app: sonarqube
         release: http-routes-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: http-routes-values.yaml-sonarqube-http-route
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
@@ -332,14 +332,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: http-routes-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: http-routes-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: ingress-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 82f82e79008b3dc2f25722d433e3605ede5b609e85131cef245231b3c0b68792
-        checksum/init-sysctl: ac8e55c8e23e5c8c90deba322e789eb93f64c0286e866a807b1277875ab6d370
-        checksum/plugins: 23fec03a0062f5d2b7232eb5a9107e00c1c017e56b4b9d090bd8ef662a6ba873
-        checksum/secret: 792d2f71a6b909abfcf1e9bdcbfc8fcc2e0bf8a6e7ff81b0ef7d525ec89111b8
+        checksum/config: dad6a44604f94a88aaa35edd1509da72ee88e06fcbb8f770113824a473f2f2cf
+        checksum/init-sysctl: 97a5737272aa4352674b18130614b4a3867854d243b64ddbe2d16858736cedaf
+        checksum/plugins: 0b4177ac498f8bb629e46a3ed61195aa706423ae4c1a0007d1b90273eda56a11
+        checksum/secret: 3997b98189fd86314fdcb45470824f7b35dafd7b317239ef22933487b1ae431d
       labels:
         app: sonarqube
         release: ingress-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -302,7 +302,7 @@ metadata:
   name: ingress-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
     traffic-type: external
@@ -339,14 +339,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-with-controller.yaml
@@ -23,7 +23,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -38,7 +38,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 type: Opaque
@@ -73,7 +73,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -86,7 +86,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -133,7 +133,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 data:
@@ -430,7 +430,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
@@ -577,7 +577,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
     app.kubernetes.io/name: ingress-with-controller.yaml
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: ingress-with-controller.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -597,10 +597,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 525f00aa77e9dfe3d0eaf02370cb7ec027601df83410a4329f409ea043e21ef1
-        checksum/init-sysctl: 19548f564ebf9a0369de5c6f4f5950b46af7b5e50b8939a990de7c397113659a
-        checksum/plugins: 5e27f98548e31093547dde4c1be36c1d3e047c798b74a21ecf5467c15b86918f
-        checksum/secret: 1b3f3c7f2cbc31c793c0b1c858844677583d62a38f8d9275f291f56f4e128b02
+        checksum/config: d99b58ae5e7c07db0cb1f503ea10ea4fc0547ef16da2e8acf995b1b3711413e0
+        checksum/init-sysctl: 5be3174b5bddce6709d10cf70513a5fceb32f906e5c0cfb5ca70a39adf96cc19
+        checksum/plugins: 71baba9319cdb6226525c04b160ade58c05ae86320d95a12cedb1221a63c0dda
+        checksum/secret: 91a263158051d841e76d98011cc588cc65a23b0bda0fe2534306fb6402daa3b1
       labels:
         app: sonarqube
         release: ingress-with-controller.yaml
@@ -610,7 +610,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -629,7 +629,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -646,7 +646,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -760,7 +760,7 @@ metadata:
   name: ingress-with-controller.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
     traffic-type: external
@@ -962,14 +962,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: ingress-with-controller.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: ingress-with-controller.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: install-plugins-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
     app.kubernetes.io/name: install-plugins-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: install-plugins-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 33ad198aff9726c2ec0a51169cc18aa5bf2b60f65774bd3d42a980c2c8207006
-        checksum/init-sysctl: ea3b788e07750bcdd68b4de74b79d52f22255a37ac08dae26c9ef0850975a787
-        checksum/plugins: bbf71281cd30eb417bf8546f614fac10ef009510022da169d14bc5d75b8b496b
-        checksum/secret: 4becc4315c935463958a5234a5f821969c955a5db9e870de7720de980d238fe5
+        checksum/config: 948e378e8c787d56347a43bc38ca8a1987b11bcd68e414bc795987b98b627eea
+        checksum/init-sysctl: 34238f172fc911068cc3e10048d6cd0fa8fd59b31d120ea1af363bfb589ca524
+        checksum/plugins: 6c5f46d7cca41db9887e715f1820f51f6f523944d792e4571a320663b3da44cc
+        checksum/secret: c66b0cf06c3e374c70d736da7d55a4bbebe2865c02cfa7e40a2a45ec295942e4
       labels:
         app: sonarqube
         release: install-plugins-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: install-plugins-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: install-plugins-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -20,7 +20,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -35,7 +35,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 type: Opaque
@@ -54,7 +54,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -127,7 +127,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube-jdbc-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 data:
@@ -141,7 +141,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
@@ -162,7 +162,7 @@ metadata:
   name: jdbc-config-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
     app.kubernetes.io/name: jdbc-config-values.yaml
@@ -170,7 +170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: jdbc-config-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -182,10 +182,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edd02d22f721c29e3f9d2d0c350c9495eba7bf4f635b583ea1c38c0b8f7111f7
-        checksum/init-sysctl: ea3d38e8925405063ef8097050cf091af37bbcb8b7b4f304c7b708f98251019c
-        checksum/plugins: f0ea3ca4fbceab603ab4796331343c6e9bc74c2a1bfc11a5d3e6fe43ec21c9da
-        checksum/secret: 25afb9d3d3ee52a293b09751dcac852bbcd6e0b6d99561498b6890ac56f1421e
+        checksum/config: af7447d0da6e1b858133cd40060596ff8a0629808009e55c331328cc8273a444
+        checksum/init-sysctl: 1d2c289f800d3c7667911ea7023a7f45295bffbe4a0c75b471f22ff09fb1bc73
+        checksum/plugins: 782d14ba854240e38ae5a4ada0d854dd76bbb070099fbabbeb5b4168be88842b
+        checksum/secret: e704abd7dadd18ccba912f1a5bf4dec628837e0cbe1f2cc341f20c3f84b33a42
       labels:
         app: sonarqube
         release: jdbc-config-values.yaml
@@ -195,7 +195,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -214,7 +214,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -231,7 +231,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -340,14 +340,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: jdbc-config-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: jdbc-config-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -136,7 +136,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
@@ -157,7 +157,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -175,7 +175,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -262,7 +262,7 @@ metadata:
   name: mcp-tls-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-tls-values.yaml
@@ -270,7 +270,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-tls-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -282,10 +282,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fd0cfa6d51a79050d48964d17f6e2a4855515da171f67d944dbdddeb8de26eee
-        checksum/init-sysctl: 3908ecfbf7460ece2c7e65b21f18d558ffb6e4dcdc954cc961b1985b243822b6
-        checksum/plugins: e08a398796e12cd2766e2b67245356a3eba1e8fc0914aed3fc36447ba52e028a
-        checksum/secret: b6dc6d14520a1ae17fb0ed604201517a0f1824027849202ebf07b49858dc8344
+        checksum/config: 3e6e524fe1e806b6edffb6b09ca6bc8a566d2e5c5f70bfe605225bc7f37dc890
+        checksum/init-sysctl: 51a590e8334572eb4613b4254ecc21ebc619f91d98ba1696eb532a81149e6f05
+        checksum/plugins: 31e660725b53fdedab24d6f71e2b745bc7d01e9c54e80e58cb876049fcf73a41
+        checksum/secret: f631930af9ef22cb2810feddf9c6f7fc2672f43a14d418a68ca079abfd1db324
       labels:
         app: sonarqube
         release: mcp-tls-values.yaml
@@ -295,7 +295,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -314,7 +314,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -331,7 +331,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -437,14 +437,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-tls-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-tls-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -132,7 +132,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -154,7 +154,7 @@ metadata:
   name: mcp-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: mcp-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -193,7 +193,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -266,7 +266,7 @@ metadata:
   name: mcp-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-values.yaml
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -286,10 +286,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6a53ccfd2008b444cb66ddca9dd8a19cdabefb6db13680920bbb4bf3317cf42c
-        checksum/init-sysctl: 5367553c49449ccd620c30da5cfceed59f95f28a3894535c6875d6b5651a738b
-        checksum/plugins: 8131e6c097a0d22d103145b704ce48f03c0c0e2fdb07eb2b48e8af73935ecd12
-        checksum/secret: aa9979660cf9988c77012501f94ba51019af71582579f07c77594e2805683b98
+        checksum/config: 92b9a5cd24c2abbfbce3c7f0bdab21055f4dd8f67a576d3e22a9d715343666e6
+        checksum/init-sysctl: 6ef8716c123bc55d7000ab614b35d20bd0681dc9257425ef6578cae73a0d2df6
+        checksum/plugins: 8fa417c249042e6180304fdada4e17ef978443d40efa262599afe11accf286fd
+        checksum/secret: 205df75e5e31b69af33745e8c6e27e1d35f42fe9c5635c2bdf84622d36be0625
       labels:
         app: sonarqube
         release: mcp-values.yaml
@@ -299,7 +299,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -318,7 +318,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -335,7 +335,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -443,14 +443,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -132,7 +132,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -154,7 +154,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
@@ -175,7 +175,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube-mcp
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/component: mcp
@@ -193,7 +193,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -266,7 +266,7 @@ metadata:
   name: mcp-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: mcp-web-context-values.yaml
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: mcp-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -286,10 +286,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ec6bd9a00b0fdb00d9afb2fd188972b80314353a7dddd80abb2764d1f4971ac2
-        checksum/init-sysctl: 7c76d68326cc9568b569bbc0be96de86606f847a5ccabb92009d4bd31b5395a2
-        checksum/plugins: 45ee15eb39000dd902a1aaa4ab64b8a024ec1304aa7a4ea4b6040c2056a1eb89
-        checksum/secret: d4423feefade02fd78c36ffdf775d76e13e44266f5641982c77c3132f382a793
+        checksum/config: 8c582106d3a68e7dab99ca3fbd9d32611031b1929da0b36b5fe7fe6d9d5130c4
+        checksum/init-sysctl: af50e31020509c68a8f4ff27f09728eeabed6bafc4be3cbf2a0b257876b246c5
+        checksum/plugins: b4445505b225e7092faa89eeb7035623ee40e7472e0b81878c503e0c99b97d86
+        checksum/secret: 2eb0e72f9d9031c29ef5d1b6551d57babed326b6e9199cb0ac7a6bdf41c5de8a
       labels:
         app: sonarqube
         release: mcp-web-context-values.yaml
@@ -299,7 +299,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -318,7 +318,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -335,7 +335,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -441,14 +441,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: mcp-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: mcp-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -49,7 +49,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -90,7 +90,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 type: Opaque
@@ -124,7 +124,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -184,7 +184,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
@@ -218,7 +218,7 @@ metadata:
   name: networkpolicy-new-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-new-values.yaml
@@ -226,7 +226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-new-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -238,10 +238,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 082b34d530e9adaec295435ebd4ab48aa70528710796eb4879e5c2f836222cc3
-        checksum/init-sysctl: cbe2a6055a4a4f5044f8fe27b878795b9ed208f7a85c5ef87ebda46f05348241
-        checksum/plugins: 046a67f75450976cb1ddfe1a512227ebe6b49e7009d16635ed23c998e1669851
-        checksum/secret: fadafb83564f8ef63a382cc5034e7f6ae4402ba851284d912663fb81e9642539
+        checksum/config: 08e34dc8f95fce1bcc42f95749e50a85f2966c00ad73ff7155802a0758701eb9
+        checksum/init-sysctl: 15a36cdcd6eacc1d09893e8ad7a88eeccfc7cbcafec29366798700633c52b05f
+        checksum/plugins: d14b469bf2acdd95b32e6f80b88d3dba109edc23e8a1963ad3e6dacf45967e95
+        checksum/secret: 55ca3ab1969bb4991034ed1d7453865dc61c9a1fa6262ee8f595d11f5a458c39
       labels:
         app: sonarqube
         release: networkpolicy-new-values.yaml
@@ -251,7 +251,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -270,7 +270,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -287,7 +287,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -389,14 +389,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-new-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-new-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -6,7 +6,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -49,7 +49,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-additional-network-policy
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -90,7 +90,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -105,7 +105,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 type: Opaque
@@ -124,7 +124,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -137,7 +137,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -184,7 +184,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 data:
@@ -197,7 +197,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
@@ -218,7 +218,7 @@ metadata:
   name: networkpolicy-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
     app.kubernetes.io/name: networkpolicy-values.yaml
@@ -226,7 +226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: networkpolicy-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -238,10 +238,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 325f94c7640c39dc3bc76083ec7388eae09fa6027eef706cdfcc97109a997aa7
-        checksum/init-sysctl: 216177ef8a69f248a24de3c35d8f99f6650ed9eff911d405935878fe001a638f
-        checksum/plugins: c7081977f858da939832390e6d922fd23d06cba709cced1846d0f2f66f7ecc23
-        checksum/secret: f30024fafffa4d413a71b11728cf2e2fcd28f628d9411e0ccbec3407a4f5f034
+        checksum/config: fd5341e6a207e8b8c5ff64f1786b232211d44c2addae9d7b93b99d4315c48c78
+        checksum/init-sysctl: a92000bd4bbf956683dfaf6f0675da58c01583973cd1839597bfcfc70f8d637d
+        checksum/plugins: aa62c87850115e98882f7462fc87f01a46df55b7a65a255c28666ac11df4a1fb
+        checksum/secret: 81439b99b3ec2a4ea5c505841319922e2eec49ba3784fcbf094896689823f34a
       labels:
         app: sonarqube
         release: networkpolicy-values.yaml
@@ -251,7 +251,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -270,7 +270,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -287,7 +287,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -389,14 +389,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: networkpolicy-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: networkpolicy-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -131,7 +131,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -146,7 +146,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 data:
@@ -161,7 +161,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
@@ -182,7 +182,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: non-default-security-context-values.yaml
@@ -190,7 +190,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: non-default-security-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -202,12 +202,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f34200a6183b6f3e603ac06b204f7f30c792b4ef7c1bd7bb7edd2218f65a8752
-        checksum/init-sysctl: 8dafc63871769f33b77cb93f96df7273d9911778044fa21c2f81cbd86732d9f3
-        checksum/plugins: 3f63d1532675b84a2b732aa5770d0886348a800a03b6a9e9824d3230650f8aa0
-        checksum/secret: 404a25612c4eec4dca12d5d434a32695b00fa161ea457d1e3bd31e2d2988d65e
-        checksum/prometheus-config: 5298921ea04c0954d0df21fb2c41388ab74c8fa6d9ff0161ce2a4e6af259a9de
-        checksum/prometheus-ce-config: a52fe91cabeeae0adef11f18d6ef0311dc98f0dfe7d1dd4b210c3edf01ae4e9d
+        checksum/config: b72409987407e85455756014c9548f85667b11581ea6829c1b7346bf212a6ce7
+        checksum/init-sysctl: 07e2edfab7d5c633fa743ca5bfa3527ece36d550b278ad6833c12e705bfe9a3f
+        checksum/plugins: 88a4123f86f8afd02ba066adbd4ebeed90fdc8ca4c535a2511a40435dcb987a2
+        checksum/secret: 30ac2e2b4aba035dfa2db3a1e2195a18c2e323759fc14eaa96167451572a2db8
+        checksum/prometheus-config: 3ac78a8d5ad312bb87bf3c181b00c1ded91afeec094ad3ad6c623609f57f0688
+        checksum/prometheus-ce-config: 187ec85db50315de33fa06eea6221cbdf1f231e2ef0d7eaf1ba357a561466d83
       labels:
         app: sonarqube
         release: non-default-security-context-values.yaml
@@ -217,7 +217,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -235,7 +235,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -277,7 +277,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -321,7 +321,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -344,7 +344,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -470,14 +470,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: non-default-security-context-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -509,7 +509,7 @@ metadata:
   name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: non-default-security-context-values.yaml
     heritage: Helm
   annotations:
@@ -522,7 +522,7 @@ spec:
       name: non-default-security-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.4.0
+        chart: sonarqube-2026.4.1
         release: non-default-security-context-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: openshift-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
 data:
@@ -67,7 +67,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -88,7 +88,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
     app.kubernetes.io/name: openshift-values.yaml
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: openshift-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -108,9 +108,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2c02e54fb4dae41b5a3031a7507b3ea9993ecf137575e28cb1b1f6b6a7925768
-        checksum/plugins: 6a4a0b81b28a92405c4067ef083e59d240dc5cf90521644b249e9324ff9750f9
-        checksum/secret: 9fa66ae8f1eb8121a2bede3760733a4b8a5173c1b68ab6589bb0bcaced1fda63
+        checksum/config: 3e4a05a9b646a6edaec154a7bacf76730c6e212009b31222b1c9271ca31ff10b
+        checksum/plugins: dd1ccab5f7455c3120c5a2a5509dec061f2b56391d9b50afba5c711eb24c7a66
+        checksum/secret: 9bea294cb808524cdee9822430a37a0bb27c0a09099af3d6a359ef20abae8b7a
       labels:
         app: sonarqube
         release: openshift-values.yaml
@@ -121,7 +121,7 @@ spec:
       initContainers:
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -138,7 +138,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: IS_HELM_OPENSHIFT_ENABLED
               value: "true"
             - name: SONAR_WEB_SYSTEMPASSCODE
@@ -230,7 +230,7 @@ metadata:
   name: openshift-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
 spec:
@@ -256,14 +256,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: openshift-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: openshift-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
@@ -135,7 +135,7 @@ metadata:
   name: prometheus-monitoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: prometheus-monitoring-values.yaml
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: prometheus-monitoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -155,10 +155,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e55654d56b5a863c8188895174fcbb6e516c7c117c8c2ffab131dcadad4608ba
-        checksum/init-sysctl: 7328762211c392b255b511a1787168abfbdb275e9119ceeffaf2c99f9ef907a9
-        checksum/plugins: dd408852aedd98f603bc5592e357b94bb08f0068ef6624c41d7b3b2710c270fc
-        checksum/secret: 8bb1da9e307e67c75f9f0c4869162a6a3ef72c7494e223f19fc4217b714ea78e
+        checksum/config: 9a04418ec8e4c07520c15fdc360dba1dd582f49360c121cdbf89ab9607aae9d3
+        checksum/init-sysctl: 48beb7381f121ce24517a8a33ed47855b4a38a577ab003f97938bbfcfde80c3c
+        checksum/plugins: dd220fab511dc56478db736811b54627cbb64ebb7fb0eb5dcd130b8f108d639f
+        checksum/secret: 8900db09a28d8d812c6862a1babf8e16bba18007d99c82545ebdf9b1e9717357
       labels:
         app: sonarqube
         release: prometheus-monitoring-values.yaml
@@ -168,7 +168,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -187,7 +187,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -204,7 +204,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -333,14 +333,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: prometheus-monitoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: prometheus-monitoring-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
@@ -138,7 +138,7 @@ metadata:
   name: proxies-secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-secret-values.yaml
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -158,10 +158,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c3bce9e39c1aec78b180f857df4d75aff4a9b78bb8d0aba48f1fc90e0dd62494
-        checksum/init-sysctl: b08261d44b1cbce3fa124187d6716b7315978ba40f025b42a59c34af8faa2a61
-        checksum/plugins: 245263e7f3c5ea756cef51d637eea9ebaf438cd2bf2952c06a7c3273c9adab65
-        checksum/secret: ddb1248c8be0cc098c7b10679a9f6335c6204eeaea671c41006dc23007f9a213
+        checksum/config: 053d763389723b9a2cf5875fcaf2a4e370586b802f8b51bbf05f87d92801f12a
+        checksum/init-sysctl: 79d151b03daf19df43ddd4e33e177e3b5824b1efe052c2a5007fe9ad559daa43
+        checksum/plugins: f2e811ef347fa9a685a667a52e68829b4c0eb4df8f46bbc93292f0260c180028
+        checksum/secret: 6ec333f7694b0f3ccd7bd7e398c2cbc3f8f848c07b79a8012ec95b248c34a6eb
       labels:
         app: sonarqube
         release: proxies-secret-values.yaml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -189,7 +189,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: install-plugins
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -233,7 +233,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -250,7 +250,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -358,14 +358,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-secret-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-ce-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -132,7 +132,7 @@ metadata:
   name: proxies-values.yaml-sonarqube-prometheus-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 data:
@@ -147,7 +147,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: proxies-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
     app.kubernetes.io/name: proxies-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: proxies-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,12 +188,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 73035bf37163f90efca1907070ce3fc9ac16051277784e4e97cf7a12c9011b10
-        checksum/init-sysctl: 8922469ec70002ea53864192d7d9fd0ca4061a405e0f7e91dd5d725c04c66238
-        checksum/plugins: 953ce1bb8dd673745973fa155f91ea99ccc5954bc555da070b87370d96781add
-        checksum/secret: b70f1b595e819c62ac4343622a66d19da1c4e6d7b57fc9aa7556895d24103449
-        checksum/prometheus-config: 140a71ff41b0773c7322e6b67266fad3c8240cc092065d3fec4684a532cac399
-        checksum/prometheus-ce-config: f04dcf5aa9587d5f73eaa5606c6d12105028d9503d7e9f0ad6649a5876fccdf2
+        checksum/config: b4ffcc838e18e83f6586d7d0e11730a68308778415ab6a8df7638f8a93d15b30
+        checksum/init-sysctl: 924381ebabc4418f572f9e916e7caaa3e004682055d86056d02466ae65e719e5
+        checksum/plugins: 254ae1f33c8953a29f14db215780d5b470dc7548f2d605b91069806adef59ca5
+        checksum/secret: e8865a2c40f687d625f05bc8129a10578fda73dd3ce2874e87961c8cb1a8ca41
+        checksum/prometheus-config: e49a1b1aaf0731ab3db5db71ebbb143b41e4c67c50f292a8e3f25c600532b283
+        checksum/prometheus-ce-config: 09aaa3dbb171f3664a964afa7a24e8c91439703f2496f01c4a402c92735e3c46
       labels:
         app: sonarqube
         release: proxies-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -221,7 +221,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: inject-prometheus-exporter
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -263,7 +263,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
         - name: install-plugins
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           command: ["sh", "-e", "/tmp/scripts/install_plugins.sh"]
           securityContext:
@@ -307,7 +307,7 @@ spec:
               value: -javaagent:/opt/sonarqube/data/jmx_prometheus_javaagent.jar=8001:/opt/sonarqube/conf/prometheus-ce-config.yaml
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -330,7 +330,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -456,14 +456,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: proxies-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: proxies-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: pvc-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
   annotations:
@@ -149,7 +149,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
@@ -170,7 +170,7 @@ metadata:
   name: pvc-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
     app.kubernetes.io/name: pvc-values.yaml
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: pvc-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -190,11 +190,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: aae98c8107cca58cf73bb29953945a03fbdb26c2ab76916ea3172b81381feb07
-        checksum/init-fs: 26c31c70f44f07bf1a39202744b37cb7ea7c29677bbea8823ac1a75ca657902b
-        checksum/init-sysctl: 23e0e0bb17a20b2050c08d2336cd71c740f1b6ca65353f4a13372c7ef88f4b59
-        checksum/plugins: 3ad535d263c095e4b8ec152314995c3905e31e8aa075cbacf0c25e22b8c4fc4e
-        checksum/secret: 83be113d55a6fb5f847c246aded0f67c638c906db46a6bad674cf32402d9a298
+        checksum/config: e446e8ea367cffca06cd3fe0ae3de27c7bc1f2ba99976b2c54fd131021b7076f
+        checksum/init-fs: 632323bd5a0a79c3b83463fd7d4b7d83e71bd32863c1627f43931ca460f14f3d
+        checksum/init-sysctl: c95b5fe13e93d98aa1ad8a8e5e1c1cad0cbc447d57ceba76186ea820c52675eb
+        checksum/plugins: f58d81fcbf46114c756586478f93598a131295c85e72e83d0608d03a2cd05741
+        checksum/secret: a4784ec18eaae5d36e9f224b5dc2bcb176b2dbc7a3a2a82746bcb6a9ba5d45a9
       labels:
         app: sonarqube
         release: pvc-values.yaml
@@ -204,7 +204,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -222,7 +222,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -257,7 +257,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -274,7 +274,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -382,14 +382,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: pvc-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: pvc-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: secret-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: secret-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: secret-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: secret-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: secret-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: secret-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: secret-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
     app.kubernetes.io/name: secret-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: secret-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a4b7898832e0cbd07860503f4e4ce312cc5f80c0cec2635a37cee5d2f0960ba2
-        checksum/init-sysctl: 5563ae80cb7cc44bb42e56708d0ce19eaea7aa849dc031f43c773243b40461f6
-        checksum/plugins: 9959988d5b606f4d49b863cf81d75acf7818dc409e814b4d6c893a584409c08c
-        checksum/secret: 53348600a1b4dab74146077043992a5bdecd89652590612bdb45444d562838d4
+        checksum/config: f9ac0f9b0692f550bc9a4b93c752bf62d4cb7da7c57f1884412d93690ff63bec
+        checksum/init-sysctl: 920cfe0259d74acd8ecae618994c600ad61a2c8229bc51b07a252cf5d08ef2f6
+        checksum/plugins: 416036d5e7590e621c6e6b38b0d87e37aeed93ac25d5996199d65b1f42276b76
+        checksum/secret: d613b98cc8482a11992401a93cda08399625a8dbda68cb9adebedb45ccb9166d
       labels:
         app: sonarqube
         release: secret-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: secret-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -359,7 +359,7 @@ metadata:
   name: secret-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: secret-values.yaml
     heritage: Helm
   annotations:
@@ -372,7 +372,7 @@ spec:
       name: secret-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.4.0
+        chart: sonarqube-2026.4.1
         release: secret-values.yaml
         heritage: Helm
       annotations:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: service-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: service-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: service-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: service-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -101,7 +101,7 @@ metadata:
   name: service-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
 data:
@@ -114,7 +114,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
     mylabel: "tutu"
@@ -142,7 +142,7 @@ metadata:
   name: service-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
     app.kubernetes.io/name: service-values.yaml
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: service-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -162,10 +162,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 52148d5dbcbd52e7536aac496eb7c295dad9e07b09f6a8a09ab9b6e771b4a2f7
-        checksum/init-sysctl: 381e63f834b1eeeef9a2c5c27ef041918fd8e54b6e3702c410e6383d19705648
-        checksum/plugins: 4e9517b2be186a144ce4c5e58dec090f5a23a9070f590564bda48f225bad8919
-        checksum/secret: 3178fee1a68ee3a08bcf23d90fd30f924d92ed11a13fa4347365d99c8978eeae
+        checksum/config: 0edc9bd26274eff7823bb0d7ccf955f44ff9e25c04ef540dc277dfe2ca71fb72
+        checksum/init-sysctl: f0a66b584a22162e123e262e3c6b563decb5c340f311f00f73d7eea679d1659d
+        checksum/plugins: 856e70b72e53780fd0a0724e966111b584dc46d4ff5e22f8d9e013a959240a4d
+        checksum/secret: 006823bfafb6d1b1ff5cfbf6ad194f96406efa4952895b7a18d4caf4bfcbc974
       labels:
         app: sonarqube
         release: service-values.yaml
@@ -175,7 +175,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -194,7 +194,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -211,7 +211,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -313,14 +313,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: service-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: service-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -8,7 +8,7 @@ metadata:
     myAnnotation: tutu
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 automountServiceAccountToken: true
@@ -21,7 +21,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: serviceaccount-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
     app.kubernetes.io/name: serviceaccount-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: serviceaccount-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f40aa310ae50839489da2419eb424abab27241d2e766bed689b5c4270caa436e
-        checksum/init-sysctl: a4e32471f335798f90b3cea67cdafe60c038b8de6844dbba9c00240c40e421b6
-        checksum/plugins: 7599f2fa2b21fcce14a78b44ca69f9b5b6415b82f2395269a0961519ee48af77
-        checksum/secret: 591778fe99082fa7be753423878e177e564164bf667f5dacafb3020beac0b2ac
+        checksum/config: 9337cee5daa9d388413c02443ab1ed1df9fe83fb35b916040943d2167ca171d1
+        checksum/init-sysctl: 9a4baacbb0de6181bec5d82eccdc45567a478e174e4c83d81f11d810231e17e0
+        checksum/plugins: d59eee2712f2866433e2dc40aa020c2b47b465ac51cbcb1fd45ace3314fdc57b
+        checksum/secret: 62d44b92b3850057292a3999eef4673aedc52f4bb3122b6b8bf58faf51fb09cc
       labels:
         app: sonarqube
         release: serviceaccount-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -320,14 +320,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: serviceaccount-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: serviceaccount-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-deployment-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -170,10 +170,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e61b0b07ddb7d1f388275c0e1dee9a0ac6c5281b99d48840568d638a60f8645
-        checksum/init-sysctl: 1ad5c508cb14f05229c9ae294de0bd856e4c3b48c9dd380981104974944bdafa
-        checksum/plugins: 4cb063e3d5ba5abfe2dd7badddf3cc822047a8c179719ebe7c555e05cc3ca61d
-        checksum/secret: 9dbc0d09645eea1a210fbbfe3dbe28210357b1a2481b61c5a3ca6674bcfae4da
+        checksum/config: eececbf434f849dea0c401485fefc7ea8058fdd2f58f98a7d834384e1ebfe536
+        checksum/init-sysctl: 0a9336236d6bc95e82809a2ba7b206574976427de8293e82ec4249035d337c8b
+        checksum/plugins: 32ba2683e82a2b4c4e3f65eb9baf4515b3c7f40b246631ca03582eb92da77b53
+        checksum/secret: 6b364065a080964566dfa1d068dfdcb9cfb115e92957494b63ad409b45b2520e
       labels:
         app: sonarqube
         release: sonar-web-context-deployment-deprecated-values.yaml
@@ -183,7 +183,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -202,7 +202,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -219,7 +219,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -317,7 +317,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -344,14 +344,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-deployment-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -383,7 +383,7 @@ metadata:
   name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-deployment-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -395,7 +395,7 @@ spec:
       name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.4.0
+        chart: sonarqube-2026.4.1
         release: sonar-web-context-deployment-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -406,7 +406,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-deployment-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.4.0-enterprise
+        image: sonarqube:2026.4.1-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-sts-deprecated-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-sts-deprecated-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ef6bfa7856429244655c2564a930a07388e4106a9f84f3f4e2e50309534205be
-        checksum/init-sysctl: 0f903cae0d61f392f039f5ccafb0d164f1413c62a67673e32ff55139c6037b03
-        checksum/plugins: 4dba59a122795b0d834643628e16ef96589161b417fac43f159848db0a9d6cac
-        checksum/secret: c392b39565f2ed8f0ee75bea9dc4c893cf65cc65a18bf2b8c64673b3652bfaa2
+        checksum/config: 15f0e441578a97ec0f06263ae67086a487e112599abe89f52154a2801dead00f
+        checksum/init-sysctl: 9c501b4e4959cf14cc73335b2078ed2a2fe0ce50d81e4bb459d193beef3d7e71
+        checksum/plugins: e0814cd6472d52f358ecffb41aa30ba9eeb2d733a8ed3a707d9fa3d1216e7f95
+        checksum/secret: 6393b320f264e5dd02ca989b0950a6e73f42caecf42db80102fb0b5ebf70cbad
       labels:
         app: sonarqube
         release: sonar-web-context-sts-deprecated-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-sts-deprecated-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -382,7 +382,7 @@ metadata:
   name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-sts-deprecated-values.yaml
     heritage: Helm
   annotations:
@@ -394,7 +394,7 @@ spec:
       name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.4.0
+        chart: sonarqube-2026.4.1
         release: sonar-web-context-sts-deprecated-values.yaml
         heritage: Helm
       annotations:
@@ -405,7 +405,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-sts-deprecated-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.4.0-enterprise
+        image: sonarqube:2026.4.1-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -21,7 +21,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-admin-password
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -36,7 +36,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 type: Opaque
@@ -55,7 +55,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -68,7 +68,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -115,7 +115,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 data:
@@ -128,7 +128,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -149,7 +149,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
     app.kubernetes.io/name: sonar-web-context-values.yaml
@@ -157,7 +157,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: sonar-web-context-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -169,10 +169,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e60513625e2be48829bb43695595c09cc5534341f2a20db3768fccede6fb5c4c
-        checksum/init-sysctl: 63275adbafe9014deea669a856116508609c3cbd60212342bc3d4d5a57448753
-        checksum/plugins: ab83f4790e0698e74f8d38e0e17559051beadff5ea4204ef5f9fb6f66c690769
-        checksum/secret: 8c18ea709ac7884411cf7b8f82afa2161ff736dbf402ab5b714cbc31c40e89e2
+        checksum/config: 1f291fd687463d6063dcb0b0f342c6ca5a79a38bba06c51426b46c0ef804154b
+        checksum/init-sysctl: 56d0c46e313e14d604804dfcb169a2d247418badab2a385c9d439d06e8c82501
+        checksum/plugins: 8c3362f392cb5d1292a43eea80b3205246fb2b7291a390c6e841c5883669180b
+        checksum/secret: c20eb09ec437bbaec950449ed86281a59035c5ad8e3c193021f3f26ec7f3d569
       labels:
         app: sonarqube
         release: sonar-web-context-values.yaml
@@ -182,7 +182,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -201,7 +201,7 @@ spec:
               value: ""
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -218,7 +218,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -316,7 +316,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
@@ -343,14 +343,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: sonar-web-context-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [
@@ -382,7 +382,7 @@ metadata:
   name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: sonar-web-context-values.yaml
     heritage: Helm
   annotations:
@@ -394,7 +394,7 @@ spec:
       name: sonar-web-context-values.yaml-sonarqube-change-admin-password-hook
       labels:
         app: sonarqube
-        chart: sonarqube-2026.4.0
+        chart: sonarqube-2026.4.1
         release: sonar-web-context-values.yaml
         heritage: Helm
       annotations:
@@ -405,7 +405,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: sonar-web-context-values.yaml-sonarqube-change-default-admin-password
-        image: sonarqube:2026.4.0-enterprise
+        image: sonarqube:2026.4.1-enterprise
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -7,7 +7,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-monitoring-passcode
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -22,7 +22,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-http-proxies
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 type: Opaque
@@ -41,7 +41,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-config
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -54,7 +54,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-fs
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -70,7 +70,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-init-sysctl
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -117,7 +117,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube-install-plugins
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 data:
@@ -130,7 +130,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -147,7 +147,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
@@ -168,7 +168,7 @@ metadata:
   name: template-refactoring-values.yaml-sonarqube
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
     app.kubernetes.io/name: template-refactoring-values.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: sonarqube
     app.kubernetes.io/component: template-refactoring-values.yaml-sonarqube
-    app.kubernetes.io/version: "2026.4.0-enterprise"
+    app.kubernetes.io/version: "2026.4.1-enterprise"
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -188,11 +188,11 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b1ce8be4fabedd9d304122ceb23ac31d90a340fc7a431cea6fef286973e366a
-        checksum/init-fs: 7494966e6603796588c3f1c5daa962018427f8462936cafb62ebaf58a64bc728
-        checksum/init-sysctl: 242c60f67a6bca364cdd4fe5e7f4efd72307440b7414f9c2661b1afb87b8574f
-        checksum/plugins: 1841c47901dae4670271e69493393ee8b2395a074839cb42c327508f4790f238
-        checksum/secret: 2812b2392e93a8b919d427e1448a8d78a34ea6c1fc3f7da9263a8571d037245e
+        checksum/config: 278c7212764fb9f676a4e7aac57cf729cec047678ff87503df12c0e50ee7f566
+        checksum/init-fs: eed570eb7f8f4b1bf67d10eb8fc3401be933d6ef407991088883decf5ca214fa
+        checksum/init-sysctl: 4472bfea697dd1b1ad8574aae2d01828dd674cede46b35c4172a47a71f1cf2dd
+        checksum/plugins: 179c62576aa26f24b91f5430311c76b0596930bf0aeb0567359dce2179169739
+        checksum/secret: ae92965fc31baf9c0563bea17ce2a7f72cfbfe21306f1b58e55b4d6e48cf1310
       labels:
         app: sonarqube
         release: template-refactoring-values.yaml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 0
       initContainers:
         - name: init-sysctl
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -225,7 +225,7 @@ spec:
             - name: SONAR_CE_JAVAOPTS
               value: ""
         - name: init-fs
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -264,7 +264,7 @@ spec:
               subPath: extensions
       containers:
         - name: sonarqube
-          image: sonarqube:2026.4.0-enterprise
+          image: sonarqube:2026.4.1-enterprise
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -281,7 +281,7 @@ spec:
               memory: 2048M
           env:
             - name: SONAR_HELM_CHART_VERSION
-              value: 2026.4.0
+              value: 2026.4.1
             - name: SONAR_WEB_SYSTEMPASSCODE
               valueFrom:
                 secretKeyRef:
@@ -389,14 +389,14 @@ metadata:
     "sidecar.istio.io/inject": "false"
   labels:
     app: sonarqube
-    chart: sonarqube-2026.4.0
+    chart: sonarqube-2026.4.1
     release: template-refactoring-values.yaml
     heritage: Helm
 spec:
   automountServiceAccountToken: false
   containers:
     - name: template-refactoring-values.yaml-ui-test
-      image: "sonarqube:2026.4.0-enterprise"
+      image: "sonarqube:2026.4.1-enterprise"
       imagePullPolicy: IfNotPresent
       command: ['curl']
       args: [

--- a/tests/unit-test/sonarqube_schema_test.go
+++ b/tests/unit-test/sonarqube_schema_test.go
@@ -110,7 +110,7 @@ func TestShouldUseImageTag(t *testing.T) {
 
 	actualContainers := rendered.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
-	assert.Equal(t, "sonarqube:2026.4.0-enterprise", actualContainers[0].Image)
+	assert.Equal(t, "sonarqube:2026.4.1-enterprise", actualContainers[0].Image)
 }
 
 func TestCustomCommunityTag(t *testing.T) {
@@ -156,7 +156,7 @@ func TestDeveloperEdition(t *testing.T) {
 	rendered := renderSQStsTemplate(t, "test-cases-values/sonarqube/test-developer-edition.yaml", newSQHelmOptions())
 	actualContainers := rendered.Spec.Template.Spec.Containers
 	assert.Equal(t, 1, len(actualContainers))
-	assert.Equal(t, "sonarqube:2026.4.0-developer", actualContainers[0].Image)
+	assert.Equal(t, "sonarqube:2026.4.1-developer", actualContainers[0].Image)
 }
 
 func findVolumeByName(volumes []v1.Volume, name string) *v1.Volume {

--- a/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube/test-image-tag-developer.yaml
@@ -3,4 +3,4 @@ community:
 
 edition: developer
 image:
-  tag: 2026.4.0-enterprise
+  tag: 2026.4.1-enterprise


### PR DESCRIPTION
----
## Summary by Gitar

- **Release Updates:**
    - Upgraded Helm chart and application versions to `2026.4.1` across charts and marketplace manifests
    - Updated image tags and fixture test assertions to reference `2026.4.1` images

<sub>This will update automatically on new commits.</sub>