### PR TITLE
SONAR-31416 Also emit agentic health-check URLs into conf/sonar.properties

### DIFF
--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -965,6 +965,11 @@ If the keystore uses a self-signed certificate, SonarQube's JVM will reject the 
 
 ### Vortex Analysis
 
+`sonar.vortex.analysis.url` (like the Agent Orchestrator URLs below) is set both as a pod env var
+and as a real line in the rendered `conf/sonar.properties` — SonarQube's `Configuration` API only
+honours a `SONAR_*` env var override for a property that already has a `conf/sonar.properties`
+line, so the env var alone is silently ignored by anything reading it that way (SONAR-31416).
+
 | Parameter                                       | Description                                                                                                     | Default                                                                |
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
 | `vortexAnalysis.enabled`                        | Deploy the Vortex analysis service and set `sonar.vortex.analysis.url` on the app nodes                          | `false`                                                                |
@@ -999,7 +1004,7 @@ The pod can take several minutes to become ready on a first start, while it load
 
 ### Agentic Harness
 
-The optional SonarQube Unified Agentic Harness — an Agent Orchestrator plus one Deployment/Service per enabled runtime family (`hunter`, `remediation`) — enabled via `agenticHarness.enabled`. When enabled, the chart also points the SonarQube app nodes at the orchestrator (via the `SONAR_HUNTERAGENT_ORCHESTRATOR_URL` / `SONAR_REMEDIATIONAGENT_ORCHESTRATOR_URL` env vars).
+The optional SonarQube Unified Agentic Harness — an Agent Orchestrator plus one Deployment/Service per enabled runtime family (`hunter`, `remediation`) — enabled via `agenticHarness.enabled`. When enabled, the chart also points the SonarQube app nodes at the orchestrator, both via the `SONAR_HUNTERAGENT_ORCHESTRATOR_URL` / `SONAR_REMEDIATIONAGENT_ORCHESTRATOR_URL` env vars and as real `sonar.hunteragent.orchestrator.url` / `sonar.remediationagent.orchestrator.url` lines in the rendered `conf/sonar.properties` — see the note under [Vortex Analysis](#vortex-analysis) for why both are needed (SONAR-31416).
 
 **gVisor sandboxing.** The (untrusted) runtimes can run under the [gVisor](https://gvisor.dev/) (`runsc`) sandbox, via two **off-by-default** toggles under `agenticHarness.gvisor` (the feature is self-contained — any pod can also opt in with `runtimeClassName: gvisor`):
 

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -587,15 +587,36 @@ Hazelcast ports (port, webPort, cePort) are configured, ensuring proper cluster 
 {{- end -}}
 
 {{/*
-Merge user-provided sonarProperties with automatically generated Hazelcast properties.
-User-provided properties take precedence over automatically generated ones.
+Also give these properties a real conf/sonar.properties line — the pod env vars set further down
+aren't picked up by plain Configuration.get() consumers (SONAR-31416). Additive: env vars stay too,
+for consumers like hunter-agent-unified-app that read them via Spring instead.
+*/}}
+{{- define "sonarqube.agenticHealthProperties" -}}
+{{- $props := dict -}}
+{{- if .Values.agenticHarness.enabled -}}
+{{- $_ := set $props "sonar.hunteragent.orchestrator.url" (include "sonarqube.agentic.orchestrator.url" .) -}}
+{{- $_ := set $props "sonar.remediationagent.orchestrator.url" (include "sonarqube.agentic.orchestrator.url" .) -}}
+{{- end -}}
+{{- if .Values.vortexAnalysis.enabled -}}
+{{- $_ := set $props "sonar.vortex.analysis.url" (include "sonarqube.vortexAnalysis.url" .) -}}
+{{- end -}}
+{{- toYaml $props -}}
+{{- end -}}
+
+{{/*
+Merge user-provided sonarProperties with automatically generated properties (Hazelcast, agentic).
+User-provided properties take precedence.
 */}}
 {{- define "sonarqube.mergedSonarProperties" -}}
 {{- $hazelcastProps := fromYaml (include "sonarqube.hazelcastProperties" .) | default dict -}}
+{{- $agenticHealthProps := fromYaml (include "sonarqube.agenticHealthProperties" .) | default dict -}}
 {{- $userProps := .Values.ApplicationNodes.sonarProperties | default dict -}}
 {{- $merged := dict -}}
 {{- /* Start with automatically generated properties */}}
 {{- range $key, $val := $hazelcastProps -}}
+  {{- $_ := set $merged $key $val -}}
+{{- end -}}
+{{- range $key, $val := $agenticHealthProps -}}
   {{- $_ := set $merged $key $val -}}
 {{- end -}}
 {{- /* User properties override automatic ones */}}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -100,7 +100,7 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- $hasMergedProps := or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.port .Values.ApplicationNodes.webPort .Values.ApplicationNodes.cePort .Values.agenticHarness.enabled }}
+      {{- $hasMergedProps := or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.port .Values.ApplicationNodes.webPort .Values.ApplicationNodes.cePort .Values.agenticHarness.enabled .Values.vortexAnalysis.enabled }}
       {{- if or $hasMergedProps .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey }}
         - name: concat-properties
           image: {{ default (include "sonarqube.image" .) .Values.initContainers.image }}
@@ -325,6 +325,7 @@ spec:
               value: {{ .Values.mcp.healthCheckInterval | quote }}
             {{- end }}
             {{- end }}
+            {{- /* Also given a conf/sonar.properties line via mergedSonarProperties (SONAR-31416). */}}
             {{- if .Values.vortexAnalysis.enabled }}
             - name: SONAR_VORTEX_ANALYSIS_URL
               value: {{ include "sonarqube.vortexAnalysis.url" . | quote }}
@@ -345,9 +346,9 @@ spec:
                   name: "{{ template "search.ksPassword" . }}"
                   key: SONAR_CLUSTER_ES_HTTP_SSL_KEYSTOREPASSWORD
             {{- end }}
-            {{- /* Point the agent capabilities at the in-cluster Agent Orchestrator. Set as env vars
-                   (SonarQube maps SONAR_* env to the sonar.hunteragent/remediationagent.orchestrator.url
-                   properties), auto-wired whenever the harness is enabled. */}}
+            {{- /* Points the agent capabilities at the in-cluster Agent Orchestrator. Also given a
+                   conf/sonar.properties line via mergedSonarProperties (SONAR-31416); env var kept
+                   for consumers reading it via Spring instead (e.g. hunter-agent-unified-app). */}}
             {{- if .Values.agenticHarness.enabled }}
             - name: SONAR_HUNTERAGENT_ORCHESTRATOR_URL
               value: {{ include "sonarqube.agentic.orchestrator.url" . | quote }}

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/agentic-harness-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/agentic-harness-values.yaml
@@ -419,6 +419,8 @@ metadata:
     heritage: Helm
 data:
   sonar.properties: |
+    sonar.hunteragent.orchestrator.url=http://agentic-harness-values.yaml-sonarqube-dce-agentic-orchestrator:8080
+    sonar.remediationagent.orchestrator.url=http://agentic-harness-values.yaml-sonarqube-dce-agentic-orchestrator:8080
 ---
 # Source: sonarqube-dce/templates/config.yaml
 apiVersion: v1
@@ -860,7 +862,7 @@ spec:
         sonarqube.datacenter/type: "app"
       annotations:
         checksum/plugins: 2f44a0e3371059960ff78807ae04f02d79251bc98c6eaeeb1d79f54a70770f42
-        checksum/config: 27f95c843017d0662334d387fa5b152a6e9ea9995ee9eb4e2efeb3f2b370f861
+        checksum/config: e36c9a9939b8e3763877daf3eb332a41c52f4d6cad2e0495ab539866b1a620d2
         checksum/secret: d9d496f23922e9a5bf972fc5e7942d18374d91bb473215a43ebd3ffb8c5d3d9c
     spec:
       automountServiceAccountToken: false
@@ -1110,7 +1112,7 @@ spec:
       annotations:
         checksum/init-sysctl: 8127bc8e082fd962c0c33f2b8760eb5ed117f700c7aa97b041a9c08fb598b2ff
         checksum/init-fs: c4ea9d2620a163ff1d3bd0decff182ad1f0c71ab44a9c1e3add63a5e168f5078
-        checksum/config: 27f95c843017d0662334d387fa5b152a6e9ea9995ee9eb4e2efeb3f2b370f861
+        checksum/config: e36c9a9939b8e3763877daf3eb332a41c52f4d6cad2e0495ab539866b1a620d2
         checksum/secret: d9d496f23922e9a5bf972fc5e7942d18374d91bb473215a43ebd3ffb8c5d3d9c
     spec:
       automountServiceAccountToken: false

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/vortex-analysis-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/vortex-analysis-values.yaml
@@ -308,6 +308,7 @@ metadata:
     heritage: Helm
 data:
   sonar.properties: |
+    sonar.vortex.analysis.url=http://vortex-analysis-values.yaml-sonarqube-dce-vortex-analysis:8080
 ---
 # Source: sonarqube-dce/templates/config.yaml
 apiVersion: v1
@@ -570,11 +571,47 @@ spec:
         sonarqube.datacenter/type: "app"
       annotations:
         checksum/plugins: 596e48ecd041ecc6eb4dbbd6293b6ef67a07ead44f365d133a2919bc5838e8ab
-        checksum/config: 5040ab2ed56baa1079bb3f77bab6b4ef218f8b679608f677967b574506adfa89
+        checksum/config: 1a086dd53db67c85b0e2d544885bb083b994aec56568f8a8411c324bc6053fc9
         checksum/secret: 2592e9f1ca6d4b9e0e54df80f95e2bf61bfa6910b9d61709bed080233891c2b6
     spec:
       automountServiceAccountToken: false
       initContainers:
+        - name: concat-properties
+          image: sonarqube:2026.4.0-datacenter-app
+          imagePullPolicy: IfNotPresent
+          command: 
+          - sh
+          - -c
+          - |
+            #!/bin/sh
+            if [ -f /tmp/props/sonar.properties ]; then
+              cat /tmp/props/sonar.properties > /tmp/result/sonar.properties
+            fi
+            if [ -f /tmp/props/secret.properties ]; then
+              cat /tmp/props/secret.properties > /tmp/result/sonar.properties
+            fi
+            if [ -f /tmp/props/sonar.properties -a -f /tmp/props/secret.properties ]; then
+              awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
+            fi
+          volumeMounts:
+            - mountPath: /tmp/props/sonar.properties
+              name: config
+              subPath: sonar.properties
+            - mountPath: /tmp/result
+              name: concat-dir
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            {}
       securityContext:
         fsGroup: 0
       containers:
@@ -696,6 +733,9 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
+            - mountPath: /opt/sonarqube/conf/sonar.properties
+              subPath: sonar.properties
+              name: concat-dir
             - mountPath: /opt/sonarqube/data
               name: sonarqube
               subPath: data
@@ -709,6 +749,12 @@ spec:
               name: tmp-dir
       serviceAccountName: default
       volumes:
+      - name: config
+        configMap:
+          name: vortex-analysis-values.yaml-sonarqube-dce-app-config
+          items:
+          - key: sonar.properties
+            path: sonar.properties
       
       - name: install-plugins
         configMap:
@@ -720,6 +766,9 @@ spec:
         emptyDir:
           {}
       - name : tmp-dir
+        emptyDir:
+          {}
+      - name : concat-dir
         emptyDir:
           {}
 ---
@@ -843,7 +892,7 @@ spec:
       annotations:
         checksum/init-sysctl: 3116085162a6a884158da280c3a8a49a9843a3e13bd752e92c2912d3882f9587
         checksum/init-fs: ea76c3593a1c40f72946ae87e60080fc012232ecae1d4f4a3ddf5232bf9f2535
-        checksum/config: 5040ab2ed56baa1079bb3f77bab6b4ef218f8b679608f677967b574506adfa89
+        checksum/config: 1a086dd53db67c85b0e2d544885bb083b994aec56568f8a8411c324bc6053fc9
         checksum/secret: 2592e9f1ca6d4b9e0e54df80f95e2bf61bfa6910b9d61709bed080233891c2b6
     spec:
       automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

Follow-up to #909 (closed — superseded by @hatem-amairi-sonarsource's SONAR-31376 chart-managed Vortex Analysis deployment). Found this bug while investigating why none of EA-653's 4 agentic health-check sections report healthy on next.sonarqube.com, despite the Agent Orchestrator being genuinely deployed there.

**Root cause:** `SONAR_HUNTERAGENT_ORCHESTRATOR_URL`, `SONAR_REMEDIATIONAGENT_ORCHESTRATOR_URL`, and `SONAR_VORTEX_ANALYSIS_URL` are all set as raw pod env vars only. SonarQube's `Configuration` API (`org.sonar.api.config.Configuration`) only honours a `SONAR_*` env var override for a property that is either a built-in `ProcessProperties.Property` or already has a literal line in `conf/sonar.properties` (`AppSettingsLoaderImpl.load()`/`loadPropertiesFromEnvironment()` in sonar-enterprise, `server/sonar-main`). A bare custom property with neither — like these three — is never even checked against the environment. This runs once in the launcher process before the WebServer JVM (and any CoreExtension) starts, so nothing later can fix it.

Confirmed on Next: Datadog logs show `Agent Orchestrator URL is not configured` / `Agentic Analysis URL is not configured` warnings on both DCE app pods, even though `agenticHarness.enabled: true` and the orchestrator is genuinely running in the same namespace, and the chart correctly sets the env vars.

This exact gotcha is already known and documented in `sonarqube-unification`'s `HunterAgentWebConfiguration.java`, which works around it by reading the property via Spring `@Value` (bypassing `Configuration` entirely) instead — but that's only viable for Spring-based modules. Plain SonarQube `Configuration` consumers (like `core-extension-agents`, EA-653's new health-check code) have no such escape hatch.

## Fix

Also emit `sonar.hunteragent.orchestrator.url`, `sonar.remediationagent.orchestrator.url`, and `sonar.vortex.analysis.url` into the ConfigMap-backed `conf/sonar.properties` (via a new `sonarqube.agenticHealthProperties` helper, merged into the existing `sonarqube.mergedSonarProperties` alongside the Hazelcast auto-properties), in addition to the existing pod env vars — additive, not a replacement, since `hunter-agent-unified-app` still needs the raw env var for its Spring-based read.

Verified via `helm template` with `agenticHarness.enabled`/`vortexAnalysis.enabled`:
- Both properties render correctly into `conf/sonar.properties` when enabled, and are absent when disabled.
- A user-supplied `ApplicationNodes.sonarProperties` entry for the same key still wins (existing override behavior preserved).
- No duplicate env vars introduced.

## Test plan

- [x] `helm template` with `agenticHarness.enabled=true` + `vortexAnalysis.enabled=true`: all 3 properties appear as `conf/sonar.properties` lines with the correct in-cluster URLs, and the existing pod env vars are unchanged (no duplicates).
- [x] `helm template` with both disabled: no agentic lines rendered.
- [x] `helm template` with a user-supplied `ApplicationNodes.sonarProperties["sonar.hunteragent.orchestrator.url"]` override: user value wins over the auto-generated one.
- [x] Existing Go chart tests (`tests/unit-test/`) — couldn't run locally (no Go toolchain available), relying on CI.
