### PR TITLE
Bump GCP deployer image

### DIFF
--- a/google-cloud-marketplace-k8s-app/Dockerfile
+++ b/google-cloud-marketplace-k8s-app/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM=gcr.io/cloud-marketplace-tools/k8s/deployer_helm:0.12.19
+ARG FROM=gcr.io/cloud-marketplace-tools/k8s/deployer_helm:13.0.9
 FROM $FROM
 
 ENV WAIT_FOR_READY_TIMEOUT 1200


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependencies:**
    - Upgraded GCP deployer helm image version in `Dockerfile` to `13.0.9`

<sub>This will update automatically on new commits.</sub>