### PR TITLE
SONAR-31523,SONAR-31525 Fix orchestrator init container pull secrets; document runtime storage egress

### DIFF
--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -1096,7 +1096,7 @@ The optional SonarQube Unified Agentic Harness — an Agent Orchestrator plus on
 | `agenticHarness.runtimes.remediation.remediationScriptPath`      | Remediation-agent entrypoint exposed as `REMEDIATION_SCRIPT_PATH` (`REMEDIATION_RULE_INFO_ENDPOINT` is derived from the orchestrator URL); `""` omits the env var | `/home/agent/app/.venv/lib/python3.13/site-packages/remediation_agent/main.py` |
 | `agenticHarness.runtimes.remediation.resources`                  | Resources for the SonarQube Remediation Agent (SQRA) runtime, sized for repo clone + agent/LLM loop                                      | requests `1` CPU / `2Gi` / `10Gi`, limits `4` CPU / `8Gi` / `50Gi`             |
 
-Each runtime reads/writes job artifacts directly against `agenticHarness.orchestrator.storage` via presigned URLs, bypassing the orchestrator. With `runtimeNetworkPolicy.enabled` (or the top-level `networkPolicy.enabled`), add a peer covering it to that family's `egressAllow`, or jobs fail at the first artifact download.
+Each runtime also reads/writes job artifacts directly against `agenticHarness.orchestrator.storage` via presigned URLs, bypassing the orchestrator. With `runtimeNetworkPolicy.enabled` (or the top-level `networkPolicy.enabled`), add a peer covering it to that family's `egressAllow`, or jobs fail at the first artifact download.
 
 Process-count limits for the runtimes are a node/kubelet setting (`podPidsLimit`), not something a Kubernetes `LimitRange` can express, so they're outside this chart's scope.
 

--- a/charts/sonarqube-dce/templates/agentic-networkpolicy.yaml
+++ b/charts/sonarqube-dce/templates/agentic-networkpolicy.yaml
@@ -137,6 +137,10 @@ spec:
       ports:
         - port: {{ $.Values.agenticHarness.orchestrator.port }}
           protocol: TCP
+    {{- /* The runtime reads/writes job artifacts directly against object storage via presigned URLs,
+           bypassing the orchestrator, so it needs its own egress to reach it - the chart has no way to
+           resolve agenticHarness.orchestrator.storage to a NetworkPolicy peer, so egressAllow must
+           cover it (see the comment on runtimes.<family>.egressAllow in values.yaml). */}}
     {{- range $cfg.egressAllow }}
     - to:
 {{ include "sonarqube.agentic.egressAllow.peer" . | indent 8 }}

--- a/charts/sonarqube-dce/templates/agentic-orchestrator.yaml
+++ b/charts/sonarqube-dce/templates/agentic-orchestrator.yaml
@@ -1,3 +1,5 @@
+{{ $applicationNodes := fromYaml (include "applicationNodes" . ) }}
+{{ $_ := set .Values "ApplicationNodes" $applicationNodes }}
 {{- if .Values.agenticHarness.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/sonarqube-dce/templates/agentic-orchestrator.yaml
+++ b/charts/sonarqube-dce/templates/agentic-orchestrator.yaml
@@ -37,7 +37,7 @@ spec:
         - name: {{ .Values.agenticHarness.orchestrator.image.pullSecret }}
         {{- end }}
         {{- if .Values.agenticHarness.orchestrator.image.pullSecrets }}
-{{ toYaml .Values.agenticHarness.orchestrator.image.pullSecrets | indent 8 }}
+        {{- toYaml .Values.agenticHarness.orchestrator.image.pullSecrets | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- with .Values.agenticHarness.orchestrator.securityContext }}

--- a/charts/sonarqube-dce/templates/agentic-orchestrator.yaml
+++ b/charts/sonarqube-dce/templates/agentic-orchestrator.yaml
@@ -23,8 +23,16 @@ spec:
         sonarqube.agentic/component: orchestrator
     spec:
       automountServiceAccountToken: {{ if .Values.agenticHarness.serviceAccount.create }}{{ .Values.agenticHarness.serviceAccount.automountToken }}{{ else }}{{ .Values.serviceAccount.automountToken }}{{ end }}
-      {{- if or .Values.agenticHarness.orchestrator.image.pullSecrets .Values.agenticHarness.orchestrator.image.pullSecret }}
+      {{- if or .Values.ApplicationNodes.image.pullSecrets .Values.ApplicationNodes.image.pullSecret .Values.agenticHarness.orchestrator.image.pullSecrets .Values.agenticHarness.orchestrator.image.pullSecret }}
       imagePullSecrets:
+        {{- /* The wait-for-sonarqube init container below pulls the SonarQube image, so it needs the
+               application nodes' pull secrets too - the orchestrator's own only cover its own image. */}}
+        {{- if .Values.ApplicationNodes.image.pullSecret }}
+        - name: {{ .Values.ApplicationNodes.image.pullSecret }}
+        {{- end }}
+        {{- with .Values.ApplicationNodes.image.pullSecrets }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.agenticHarness.orchestrator.image.pullSecret }}
         - name: {{ .Values.agenticHarness.orchestrator.image.pullSecret }}
         {{- end }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -1196,8 +1196,10 @@ agenticHarness:
       # - name: custom-ca
       #   mountPath: /custom-ca
       #   readOnly: true
-      # Runtime egress = storage + LLM only, never SonarQube/DB/other runtimes.
-      # Add the CIDR(s) of your LLM provider; e.g. Anthropic publishes 160.79.104.0/23.
+      # Runtime egress = storage + LLM only, never SonarQube/DB/other runtimes. Without a peer here
+      # covering agenticHarness.orchestrator.storage, jobs fail at the first artifact download (real
+      # AWS S3 has no fixed range, so that's typically a 0.0.0.0/0 cidr scoped to port 443). Add the
+      # CIDR(s) of your LLM provider too; e.g. Anthropic publishes 160.79.104.0/23.
       egressAllow: []
       # - cidr: 160.79.104.0/23
     remediation:
@@ -1245,8 +1247,10 @@ agenticHarness:
       env: []
       extraVolumes: []
       extraVolumeMounts: []
-      # Runtime egress = storage + LLM only, never SonarQube/DB/other runtimes.
-      # Add the CIDR(s) of your LLM provider; e.g. Anthropic publishes 160.79.104.0/23.
+      # Runtime egress = storage + LLM only, never SonarQube/DB/other runtimes. Without a peer here
+      # covering agenticHarness.orchestrator.storage, jobs fail at the first artifact download (real
+      # AWS S3 has no fixed range, so that's typically a 0.0.0.0/0 cidr scoped to port 443). Add the
+      # CIDR(s) of your LLM provider too; e.g. Anthropic publishes 160.79.104.0/23.
       egressAllow: []
       # - cidr: 160.79.104.0/23
 

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -1025,6 +1025,8 @@ agenticHarness:
       repository: ""
       tag: ""
       pullPolicy: IfNotPresent
+      # For the orchestrator's own image only; its wait-for-sonarqube init container pulls the
+      # SonarQube image instead, and always gets ApplicationNodes.image.pullSecret(s) for that.
       # pullSecrets:
       #   - name: my-repo-secret
     port: 8080

--- a/tests/unit-test/agentic_networkpolicy_test.go
+++ b/tests/unit-test/agentic_networkpolicy_test.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func renderAgenticRuntimeNetworkPolicy(t *testing.T, setValues map[string]string) (string, error) {
+	t.Helper()
+	opts := &helm.Options{
+		Logger:      logger.Discard,
+		ValuesFiles: []string{"test-cases-values/sonarqube-dce/agentic-networkpolicy-enabled.yaml"},
+		SetValues:   setValues,
+	}
+	return helm.RenderTemplateE(t, opts, dceChartPath, dceReleaseName, []string{"templates/agentic-networkpolicy.yaml"})
+}
+
+// Both hunter and remediation are enabled in the fixture, so the render emits one NetworkPolicy
+// document per family; pick out the one for family.
+func runtimeNetworkPolicy(t *testing.T, family string, setValues map[string]string) networkingv1.NetworkPolicy {
+	t.Helper()
+	output, err := renderAgenticRuntimeNetworkPolicy(t, setValues)
+	require.NoError(t, err)
+
+	for _, doc := range strings.Split(output, "\n---") {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var policy networkingv1.NetworkPolicy
+		helm.UnmarshalK8SYaml(t, doc, &policy)
+		if policy.Labels["sonarqube.agentic/family"] == family {
+			return policy
+		}
+	}
+	require.FailNowf(t, "no NetworkPolicy rendered", "family %q", family)
+	return networkingv1.NetworkPolicy{}
+}
+
+// A runtime reads/writes job artifacts directly against object storage via presigned URLs, so its
+// NetworkPolicy needs its own egress to reach it. The chart can't resolve
+// agenticHarness.orchestrator.storage to a peer on its own, so egressAllow must cover it - this is
+// documented on runtimes.<family>.egressAllow in values.yaml, not enforced by the render
+// (SONAR-31525).
+func TestAgenticRuntimeNetworkPolicyEgressAllow(t *testing.T) {
+	for _, family := range []string{"hunter", "remediation"} {
+		t.Run(family+": empty egressAllow renders no extra egress rule", func(t *testing.T) {
+			policy := runtimeNetworkPolicy(t, family, nil)
+			require.Len(t, policy.Spec.Egress, 2, "DNS and the orchestrator only")
+		})
+
+		t.Run(family+": egressAllow entries render as given", func(t *testing.T) {
+			policy := runtimeNetworkPolicy(t, family, map[string]string{
+				"agenticHarness.runtimes." + family + ".egressAllow[0].cidr":              "0.0.0.0/0",
+				"agenticHarness.runtimes." + family + ".egressAllow[0].ports[0].port":     "443",
+				"agenticHarness.runtimes." + family + ".egressAllow[0].ports[0].protocol": "TCP",
+			})
+
+			require.Len(t, policy.Spec.Egress, 3, "DNS, the orchestrator, and the one egressAllow entry")
+			last := policy.Spec.Egress[2]
+			require.Len(t, last.To, 1)
+			require.NotNil(t, last.To[0].IPBlock)
+			assert.Equal(t, "0.0.0.0/0", last.To[0].IPBlock.CIDR)
+			require.Len(t, last.Ports, 1)
+			assert.Equal(t, int32(443), last.Ports[0].Port.IntVal)
+		})
+	}
+}

--- a/tests/unit-test/agentic_orchestrator_test.go
+++ b/tests/unit-test/agentic_orchestrator_test.go
@@ -92,3 +92,43 @@ func TestAgenticOrchestratorResources(t *testing.T) {
 	assert.Equal(t, "1Gi", container.Resources.Limits.Memory().String())
 	assert.Equal(t, "2Gi", container.Resources.Limits.StorageEphemeral().String())
 }
+
+func agenticOrchestratorPullSecretNames(deployment appsv1.Deployment) []string {
+	var names []string
+	for _, s := range deployment.Spec.Template.Spec.ImagePullSecrets {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+// The wait-for-sonarqube init container pulls the SonarQube image, so it needs the application
+// nodes' pull secrets, not just the orchestrator's own (SONAR-31523).
+func TestAgenticOrchestratorPullSecrets(t *testing.T) {
+	t.Run("none configured renders no imagePullSecrets", func(t *testing.T) {
+		assert.Empty(t, agenticOrchestratorPullSecretNames(renderAgenticOrchestrator(t, nil)))
+	})
+
+	t.Run("application nodes' pull secret and list reach the pod", func(t *testing.T) {
+		names := agenticOrchestratorPullSecretNames(renderAgenticOrchestrator(t, map[string]string{
+			"applicationNodes.image.pullSecret":          "app-secret",
+			"applicationNodes.image.pullSecrets[0].name": "app-secret-list",
+		}))
+		assert.Equal(t, []string{"app-secret", "app-secret-list"}, names)
+	})
+
+	t.Run("orchestrator's own pull secret and list still apply", func(t *testing.T) {
+		names := agenticOrchestratorPullSecretNames(renderAgenticOrchestrator(t, map[string]string{
+			"agenticHarness.orchestrator.image.pullSecret":          "orch-secret",
+			"agenticHarness.orchestrator.image.pullSecrets[0].name": "orch-secret-list",
+		}))
+		assert.Equal(t, []string{"orch-secret", "orch-secret-list"}, names)
+	})
+
+	t.Run("both combine, application nodes first", func(t *testing.T) {
+		names := agenticOrchestratorPullSecretNames(renderAgenticOrchestrator(t, map[string]string{
+			"applicationNodes.image.pullSecret":            "app-secret",
+			"agenticHarness.orchestrator.image.pullSecret": "orch-secret",
+		}))
+		assert.Equal(t, []string{"app-secret", "orch-secret"}, names)
+	})
+}

--- a/tests/unit-test/test-cases-values/sonarqube-dce/agentic-networkpolicy-enabled.yaml
+++ b/tests/unit-test/test-cases-values/sonarqube-dce/agentic-networkpolicy-enabled.yaml
@@ -1,0 +1,22 @@
+monitoringPasscode: test-passcode
+applicationNodes:
+  jwtSecret: test-jwt-secret
+jdbcOverwrite:
+  jdbcUrl: jdbc:postgresql://test-host:5432/testdb
+  jdbcUsername: test-user
+  jdbcPassword: test-password
+agenticHarness:
+  enabled: true
+  runtimeNetworkPolicy:
+    enabled: true
+  orchestrator:
+    image:
+      repository: example.com/agentic/orchestrator
+      tag: "42"
+    storage:
+      bucket: agentic-jobs
+  runtimes:
+    hunter:
+      enabled: true
+    remediation:
+      enabled: true


### PR DESCRIPTION
## Summary
- SONAR-31523: the orchestrator's `wait-for-sonarqube` init container pulls the SonarQube
  image but only ever got the orchestrator's own pull secrets, never
  `applicationNodes.image.pullSecret(s)` — unlike the identical init container in `mcp.yaml`.
  Fixed to include both.
- SONAR-31525: job runtimes (`hunter`/`remediation`) read/write artifacts directly against
  object storage via presigned URLs, bypassing the orchestrator, but nothing documented that
  their NetworkPolicy `egressAllow` must cover it. Documented in `values.yaml` and the README.

## Test plan
- Added/extended Go unit tests covering pull-secret combinations and egress rendering for
  both runtime families (`go test ./...` passing).
- Verified both changes against a live NetworkPolicy-enforcing test cluster, with no
  regressions.