### PR TITLE
SONAR-31736 Add deprecation notice for prometheus JMX exporter

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [2026.5.0]
 * Upgrade Chart's version to 2026.5.0
 * **Breaking**: Remove the deprecated `ingress-nginx.enabled`/`nginx.enabled` bundled ingress-nginx controller subchart dependency. `ingress.enabled` remains supported for use with a self-managed ingress controller; `httproute.enabled` (Gateway API) is also available
+* Deprecate the Prometheus JMX exporter (`applicationNodes.prometheusExporter`). The exporter remains available in this release and will be removed in a future release
 * Add `gateway-api-migration-scripts/nginx-to-istio-migration.sh` to help migrate from the bundled ingress-nginx controller to Gateway API
 
 ## [2026.4.0]

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -432,6 +432,8 @@ This Helm chart offers the possibility to monitor SonarQube with Prometheus. You
 
 ### Export JMX metrics
 
+**(DEPRECATED)** The Prometheus JMX exporter is deprecated and will be removed in a future release.
+
 The prometheus exporter (`applicationNodes.prometheusExporter.enabled=true`) converts the JMX metrics into a format that Prometheus can understand. After the metrics are exported, you can connect your Prometheus instance and scrape them.
 
 Per default the JMX metrics for the Web Bean and the CE Bean are exposed on port 8000 and 8001. These values can be configured with `applicationNodes.prometheusExporter.webBeanPort` and `applicationNodes.prometheusExporter.ceBeanPort`.

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -280,6 +280,7 @@ applicationNodes:
     # deprecated please use sonarWebContext at the value top level
     # sonarWebContext: /
 
+  # (DEPRECATED) The Prometheus JMX exporter is deprecated and will be removed in a future release.
   prometheusExporter:
     enabled: false
     # jmx_prometheus_javaagent version to download from Maven Central

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -4,6 +4,7 @@ All changes to this chart will be documented in this file.
 ## [2026.5.0]
 * Upgrade Chart's version to 2026.5.0
 * Upgrade SonarQube Community build to 26.8.0.126808
+* Deprecate the Prometheus JMX exporter (`prometheusExporter`). The exporter remains available in this release and will be removed in a future release
 * **Breaking**: Remove the deprecated `ingress-nginx.enabled`/`nginx.enabled` bundled ingress-nginx controller subchart dependency. `ingress.enabled` remains supported for use with a self-managed ingress controller; `httproute.enabled` (Gateway API) is also available
 * Add `gateway-api-migration-scripts/nginx-to-istio-migration.sh` to help migrate from the bundled ingress-nginx controller to Gateway API
 

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -369,6 +369,8 @@ This Helm chart offers the possibility to monitor SonarQube with Prometheus. You
 
 ### Export JMX metrics
 
+**(DEPRECATED)** The Prometheus JMX exporter is deprecated and will be removed in a future release.
+
 The prometheus exporter (`prometheusExporter.enabled=true`) converts the JMX metrics into a format that Prometheus can understand. After the metrics are exported, you can connect your Prometheus instance and scrape them.
 
 Per default the JMX metrics for the Web Bean and the CE Bean are exposed on port 8000 and 8001. These values can be configured with `prometheusExporter.webBeanPort` and `prometheusExporter.ceBeanPort`.

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -348,6 +348,7 @@ initFs:
       add: ["CHOWN"]
     readOnlyRootFilesystem: true
 
+# (DEPRECATED) The Prometheus JMX exporter is deprecated and will be removed in a future release.
 prometheusExporter:
   enabled: false
   # jmx_prometheus_javaagent version to download from Maven Central


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation:**
    - Added deprecation notice for `prometheusExporter` in `values.yaml` for both standard and DCE charts

<sub>This will update automatically on new commits.</sub>