### PR TITLE
SONAR-31746 Mount the encryption key to the orchestrator

### DIFF
--- a/charts/sonarqube-dce/templates/agent-orchestrator.yaml
+++ b/charts/sonarqube-dce/templates/agent-orchestrator.yaml
@@ -81,10 +81,12 @@ spec:
             {{- end }}
             {{- /* When the chart-wide encryption key secret (.Values.sonarSecretKey) is set, mount
                    it into the orchestrator too, mirroring how it's mounted into the SonarQube
-                   application/search pods and exposed there via the sonar.secretKeyPath property. */}}
+                   application/search pods and exposed there via the sonar.secretKeyPath property.
+                   /sonarcloud is the orchestrator's own image path convention, independent of
+                   .Values.sonarqubeFolder (which only applies to the SonarQube app/search image). */}}
             {{- if .Values.sonarSecretKey }}
-            - name: SONAR_SECRET_KEY_PATH
-              value: {{ printf "%s/secret/sonar-secret.txt" .Values.sonarqubeFolder | quote }}
+            - name: AGENTIC_SECRET_KEY_PATH
+              value: "/sonarcloud/secret/sonar-secret.txt"
             {{- end }}
             {{- /* CORE DB (SonarQube's database) connection for the orchestrator. Each field is
                    independently configurable via agentOrchestrator.coreDb, defaulting to
@@ -165,7 +167,7 @@ spec:
             {{- end }}
             {{- if .Values.sonarSecretKey }}
             - name: secret
-              mountPath: {{ .Values.sonarqubeFolder }}/secret/
+              mountPath: /sonarcloud/secret/
             {{- end }}
           {{- end }}
           {{- with (include "sonarqube.agent.probe" (dict "probe" .Values.agentOrchestrator.probes.readiness)) }}

--- a/charts/sonarqube-dce/templates/agent-orchestrator.yaml
+++ b/charts/sonarqube-dce/templates/agent-orchestrator.yaml
@@ -79,6 +79,13 @@ spec:
             - name: SONAR_AGENTIC_ORCHESTRATOR_SCHEDULER_ENABLED
               value: "true"
             {{- end }}
+            {{- /* When the chart-wide encryption key secret (.Values.sonarSecretKey) is set, mount
+                   it into the orchestrator too, mirroring how it's mounted into the SonarQube
+                   application/search pods and exposed there via the sonar.secretKeyPath property. */}}
+            {{- if .Values.sonarSecretKey }}
+            - name: SONAR_SECRET_KEY_PATH
+              value: {{ printf "%s/secret/sonar-secret.txt" .Values.sonarqubeFolder | quote }}
+            {{- end }}
             {{- /* CORE DB (SonarQube's database) connection for the orchestrator. Each field is
                    independently configurable via agentOrchestrator.coreDb, defaulting to
                    the shared jdbcOverwrite so it targets the same DB as SonarQube out of the box.
@@ -150,10 +157,16 @@ spec:
           {{- with .Values.agentOrchestrator.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
+          {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey }}
           volumeMounts:
+            {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
             - name: tmp
               mountPath: /tmp
+            {{- end }}
+            {{- if .Values.sonarSecretKey }}
+            - name: secret
+              mountPath: {{ .Values.sonarqubeFolder }}/secret/
+            {{- end }}
           {{- end }}
           {{- with (include "sonarqube.agent.probe" (dict "probe" .Values.agentOrchestrator.probes.readiness)) }}
           readinessProbe:
@@ -167,9 +180,19 @@ spec:
 {{ . | indent 6 }}
       {{- end }}
       serviceAccountName: {{ include "sonarqube.agentOrchestrator.serviceAccountName" . }}
-      {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
+      {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey }}
       volumes:
+        {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
         - name: tmp
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.sonarSecretKey }}
+        - name: secret
+          secret:
+            secretName: {{ .Values.sonarSecretKey }}
+            items:
+            - key: sonar-secret.txt
+              path: sonar-secret.txt
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/sonarqube-dce/templates/agent-orchestrator.yaml
+++ b/charts/sonarqube-dce/templates/agent-orchestrator.yaml
@@ -93,7 +93,9 @@ spec:
                    the shared jdbcOverwrite so it targets the same DB as SonarQube out of the box.
                    Decoupling matters for the password: SonarQube may store an encrypted `{aes-gcm}`
                    value the orchestrator can't decrypt, or a chart-managed secret your GitOps
-                   doesn't apply — point coreDb.passwordSecret{Name,Key} at a usable secret. */}}
+                   doesn't apply — point coreDb.passwordSecret{Name,Key} at a usable secret. The
+                   sonarSecretKey mounted above (AGENTIC_SECRET_KEY_PATH) is unrelated to this: it
+                   does not let the orchestrator decrypt an `{aes-gcm}` CORE_DB_PASSWORD. */}}
             {{- $coreDb := .Values.agentOrchestrator.coreDb }}
             - name: CORE_DB_READ_WRITE_ENDPOINT
               value: {{ $coreDb.endpoint | default (include "sonarqube.agent.jdbc.endpoint" .) | quote }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -687,6 +687,8 @@ emptyDir: {}
 # Kubernetes secret that contains the encryption key for the sonarqube instance.
 # The secret must contain the key 'sonar-secret.txt'.
 # The 'sonar.secretKeyPath' property will be set automatically.
+# When agentOrchestrator.enabled, this secret is also mounted into the orchestrator, with its
+# path exposed via the SONAR_SECRET_KEY_PATH env var.
 # sonarSecretKey: "settings-encryption-secret"
 
 ## Override JDBC values

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -688,7 +688,7 @@ emptyDir: {}
 # The secret must contain the key 'sonar-secret.txt'.
 # The 'sonar.secretKeyPath' property will be set automatically.
 # When agentOrchestrator.enabled, this secret is also mounted into the orchestrator, with its
-# path exposed via the SONAR_SECRET_KEY_PATH env var.
+# path exposed via the AGENTIC_SECRET_KEY_PATH env var.
 # sonarSecretKey: "settings-encryption-secret"
 
 ## Override JDBC values

--- a/tests/unit-test/agent_orchestrator_test.go
+++ b/tests/unit-test/agent_orchestrator_test.go
@@ -171,6 +171,84 @@ func TestAgentOrchestratorProbes(t *testing.T) {
 	}
 }
 
+// When the chart-wide encryption key secret (.Values.sonarSecretKey) is set, it must be mounted
+// into the orchestrator too, mirroring how it's mounted into the SonarQube application/search
+// pods, with its path exposed via SONAR_SECRET_KEY_PATH (SONAR-31746).
+func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
+	findEnv := func(container corev1.Container, name string) *corev1.EnvVar {
+		for i := range container.Env {
+			if container.Env[i].Name == name {
+				return &container.Env[i]
+			}
+		}
+		return nil
+	}
+	findVolume := func(podSpec corev1.PodSpec, name string) *corev1.Volume {
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].Name == name {
+				return &podSpec.Volumes[i]
+			}
+		}
+		return nil
+	}
+	findVolumeMount := func(container corev1.Container, name string) *corev1.VolumeMount {
+		for i := range container.VolumeMounts {
+			if container.VolumeMounts[i].Name == name {
+				return &container.VolumeMounts[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("unset renders no encryption key env var, volume, or volumeMount", func(t *testing.T) {
+		deployment := renderAgentOrchestrator(t, nil)
+		container := deployment.Spec.Template.Spec.Containers[0]
+		assert.Nil(t, findEnv(container, "SONAR_SECRET_KEY_PATH"))
+		assert.Nil(t, findVolumeMount(container, "secret"))
+		assert.Nil(t, findVolume(deployment.Spec.Template.Spec, "secret"))
+	})
+
+	t.Run("set mounts the secret and exposes its path", func(t *testing.T) {
+		deployment := renderAgentOrchestrator(t, map[string]string{
+			"sonarSecretKey": "settings-encryption-secret",
+		})
+		podSpec := deployment.Spec.Template.Spec
+		container := podSpec.Containers[0]
+
+		env := findEnv(container, "SONAR_SECRET_KEY_PATH")
+		require.NotNil(t, env)
+		assert.Equal(t, "/opt/sonarqube/secret/sonar-secret.txt", env.Value)
+
+		volumeMount := findVolumeMount(container, "secret")
+		require.NotNil(t, volumeMount)
+		assert.Equal(t, "/opt/sonarqube/secret/", volumeMount.MountPath)
+
+		volume := findVolume(podSpec, "secret")
+		require.NotNil(t, volume)
+		require.NotNil(t, volume.Secret)
+		assert.Equal(t, "settings-encryption-secret", volume.Secret.SecretName)
+		require.Len(t, volume.Secret.Items, 1)
+		assert.Equal(t, "sonar-secret.txt", volume.Secret.Items[0].Key)
+		assert.Equal(t, "sonar-secret.txt", volume.Secret.Items[0].Path)
+	})
+
+	// The secret volume/volumeMount must still render even without readOnlyRootFilesystem, since
+	// the two are independently gated (SONAR-31746 must not regress SONAR-31523's tmp-volume fix).
+	t.Run("set still mounts the secret without readOnlyRootFilesystem", func(t *testing.T) {
+		deployment := renderAgentOrchestrator(t, map[string]string{
+			"sonarSecretKey": "settings-encryption-secret",
+			"agentOrchestrator.containerSecurityContext.readOnlyRootFilesystem": "false",
+		})
+		podSpec := deployment.Spec.Template.Spec
+		container := podSpec.Containers[0]
+
+		assert.NotNil(t, findVolumeMount(container, "secret"))
+		assert.NotNil(t, findVolume(podSpec, "secret"))
+		assert.Nil(t, findVolumeMount(container, "tmp"))
+		assert.Nil(t, findVolume(podSpec, "tmp"))
+	})
+}
+
 func agentOrchestratorPullSecretNames(deployment appsv1.Deployment) []string {
 	var names []string
 	for _, s := range deployment.Spec.Template.Spec.ImagePullSecrets {

--- a/tests/unit-test/agent_orchestrator_test.go
+++ b/tests/unit-test/agent_orchestrator_test.go
@@ -173,7 +173,7 @@ func TestAgentOrchestratorProbes(t *testing.T) {
 
 // When the chart-wide encryption key secret (.Values.sonarSecretKey) is set, it must be mounted
 // into the orchestrator too, mirroring how it's mounted into the SonarQube application/search
-// pods, with its path exposed via SONAR_SECRET_KEY_PATH (SONAR-31746).
+// pods, with its path exposed via AGENTIC_SECRET_KEY_PATH (SONAR-31746).
 func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
 	findEnv := func(container corev1.Container, name string) *corev1.EnvVar {
 		for i := range container.Env {
@@ -203,7 +203,7 @@ func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
 	t.Run("unset renders no encryption key env var, volume, or volumeMount", func(t *testing.T) {
 		deployment := renderAgentOrchestrator(t, nil)
 		container := deployment.Spec.Template.Spec.Containers[0]
-		assert.Nil(t, findEnv(container, "SONAR_SECRET_KEY_PATH"))
+		assert.Nil(t, findEnv(container, "AGENTIC_SECRET_KEY_PATH"))
 		assert.Nil(t, findVolumeMount(container, "secret"))
 		assert.Nil(t, findVolume(deployment.Spec.Template.Spec, "secret"))
 	})
@@ -215,13 +215,13 @@ func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
 		podSpec := deployment.Spec.Template.Spec
 		container := podSpec.Containers[0]
 
-		env := findEnv(container, "SONAR_SECRET_KEY_PATH")
+		env := findEnv(container, "AGENTIC_SECRET_KEY_PATH")
 		require.NotNil(t, env)
-		assert.Equal(t, "/opt/sonarqube/secret/sonar-secret.txt", env.Value)
+		assert.Equal(t, "/sonarcloud/secret/sonar-secret.txt", env.Value)
 
 		volumeMount := findVolumeMount(container, "secret")
 		require.NotNil(t, volumeMount)
-		assert.Equal(t, "/opt/sonarqube/secret/", volumeMount.MountPath)
+		assert.Equal(t, "/sonarcloud/secret/", volumeMount.MountPath)
 
 		volume := findVolume(podSpec, "secret")
 		require.NotNil(t, volume)


### PR DESCRIPTION
## Summary
- When `sonarSecretKey` is set, mount the same encryption-key secret into the agent orchestrator (at `/sonarcloud/secret/`, the orchestrator image's own path convention), mirroring how it's already mounted into the SonarQube application/search pods.
- Expose the mounted file's path to the orchestrator via a new `AGENTIC_SECRET_KEY_PATH` env var.

## Test plan
- [x] `helm template` rendered with `sonarSecretKey` set, unset, and combined with `readOnlyRootFilesystem: false` to confirm the volume/volumeMount/env var gate independently of the existing `tmp` volume.
- [x] Added `TestAgentOrchestratorEncryptionKeyMount` unit test covering unset/set/readOnlyRootFilesystem-false cases.
- [x] `go test ./...` passes in `tests/unit-test`.
- [x] Verified against the real orchestrator container image on the speedboat-test-xx cluster: deployed a throwaway pod (real image, fake `sonarSecretKey`) and confirmed `AGENTIC_SECRET_KEY_PATH` resolves to `/sonarcloud/secret/sonar-secret.txt` and the file is readable there with the expected content.

Jira: https://sonarsource.atlassian.net/browse/SONAR-31746