### PR TITLE
SONAR-31746 Mount the encryption key to the orchestrator on the sonarqube chart

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file.
 * Add optional gVisor (runsc) sandboxing for the agent runtimes
 * Add the SonarQube Agent Orchestrator, Hunter Agent and Remediation Agent via `agentOrchestrator.enabled`, `hunterAgent.enabled` and `remediationAgent.enabled`
 * Auto-wire the Hunter Agent's `SCRIPT_PATH` (detection mode) from `hunterAgent.scriptPath`, symmetric with the Remediation Agent's `REMEDIATION_SCRIPT_PATH`
+* Mount the `sonarSecretKey` settings-encryption secret into the Agent Orchestrator pod, exposing its path via the `AGENTIC_SECRET_KEY_PATH` env var
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -769,6 +769,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `httpsProxy`             | HTTPS proxy for downloading JMX agent and install plugins, will superseed initContainer specific https proxy variable | ``      |
 | `noProxy`                | No proxy for downloading JMX agent and install plugins, will superseed initContainer specific no proxy variables      | ``      |
 | `nodeEncryption.enabled` | Secure the communication between Application and Search nodes using TLS                                               | `false` |
+| `sonarSecretKey`         | Name of existing secret used for settings encryption. When `agentOrchestrator.enabled`, this secret is also mounted into the orchestrator, with its path exposed via the `AGENTIC_SECRET_KEY_PATH` env var | `None`  |
 
 ### NetworkPolicies
 

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -8,6 +8,7 @@ All changes to this chart will be documented in this file.
 * Add optional gVisor (runsc) sandboxing for the agent runtimes
 * Add the SonarQube Agent Orchestrator, Hunter Agent and Remediation Agent via `agentOrchestrator.enabled`, `hunterAgent.enabled` and `remediationAgent.enabled`
 * Auto-wire the Hunter Agent's `SCRIPT_PATH` (detection mode) from `hunterAgent.scriptPath`, symmetric with the Remediation Agent's `REMEDIATION_SCRIPT_PATH`
+* Mount the `sonarSecretKey` settings-encryption secret into the Agent Orchestrator pod, exposing its path via the `AGENTIC_SECRET_KEY_PATH` env var
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -743,7 +743,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `sonarqubeFolder`              | (DEPRECATED) Directory name of SonarQube, Due to 1-1 mapping between helm version and docker version, there is no need for configuration | `/opt/sonarqube` |
 | `sonarProperties`              | Custom `sonar.properties` key-value pairs (e.g., "sonarProperties.sonar.log.level=DEBUG")                                       | `None`           |
 | `sonarSecretProperties`        | Additional `sonar.properties` key-value pairs to load from a secret                                                                      | `None`           |
-| `sonarSecretKey`               | Name of existing secret used for settings encryption                                                                                     | `None`           |
+| `sonarSecretKey`               | Name of existing secret used for settings encryption. When `agentOrchestrator.enabled`, this secret is also mounted into the orchestrator, with its path exposed via the `AGENTIC_SECRET_KEY_PATH` env var | `None`           |
 | `monitoringPasscode`           | Value for sonar.web.systemPasscode needed for LivenessProbes                                                                             | `None`           |
 | `monitoringPasscodeSecretName` | Name of the secret where to load `monitoringPasscode`                                                                                    | `None`           |
 | `monitoringPasscodeSecretKey`  | Key of an existing secret containing `monitoringPasscode`                                                                                | `None`           |

--- a/charts/sonarqube/templates/agent-orchestrator.yaml
+++ b/charts/sonarqube/templates/agent-orchestrator.yaml
@@ -77,12 +77,23 @@ spec:
             - name: SONAR_AGENTIC_ORCHESTRATOR_SCHEDULER_ENABLED
               value: "true"
             {{- end }}
+            {{- /* When the chart-wide encryption key secret (.Values.sonarSecretKey) is set, mount
+                   it into the orchestrator too, mirroring how it's mounted into the SonarQube
+                   application pod and exposed there via the sonar.secretKeyPath property.
+                   /sonarcloud is the orchestrator's own image path convention, independent of
+                   .Values.sonarqubeFolder (which only applies to the SonarQube app image). */}}
+            {{- if .Values.sonarSecretKey }}
+            - name: AGENTIC_SECRET_KEY_PATH
+              value: "/sonarcloud/secret/sonar-secret.txt"
+            {{- end }}
             {{- /* CORE DB (SonarQube's database) connection for the orchestrator. Each field is
                    independently configurable via agentOrchestrator.coreDb, defaulting to
                    the shared jdbcOverwrite so it targets the same DB as SonarQube out of the box.
                    Decoupling matters for the password: SonarQube may store an encrypted `{aes-gcm}`
                    value the orchestrator can't decrypt, or a chart-managed secret your GitOps
-                   doesn't apply — point coreDb.passwordSecret{Name,Key} at a usable secret. */}}
+                   doesn't apply — point coreDb.passwordSecret{Name,Key} at a usable secret. The
+                   sonarSecretKey mounted above (AGENTIC_SECRET_KEY_PATH) is unrelated to this: it
+                   does not let the orchestrator decrypt an `{aes-gcm}` CORE_DB_PASSWORD. */}}
             {{- $coreDb := .Values.agentOrchestrator.coreDb }}
             - name: CORE_DB_READ_WRITE_ENDPOINT
               value: {{ $coreDb.endpoint | default (include "sonarqube.agent.jdbc.endpoint" .) | quote }}
@@ -148,10 +159,16 @@ spec:
           {{- with .Values.agentOrchestrator.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
+          {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey }}
           volumeMounts:
+            {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
             - name: tmp
               mountPath: /tmp
+            {{- end }}
+            {{- if .Values.sonarSecretKey }}
+            - name: secret
+              mountPath: /sonarcloud/secret/
+            {{- end }}
           {{- end }}
           {{- with (include "sonarqube.agent.probe" (dict "probe" .Values.agentOrchestrator.probes.readiness)) }}
           readinessProbe:
@@ -165,9 +182,19 @@ spec:
 {{ . | indent 6 }}
       {{- end }}
       serviceAccountName: {{ include "sonarqube.agentOrchestrator.serviceAccountName" . }}
-      {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
+      {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey }}
       volumes:
+        {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
         - name: tmp
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.sonarSecretKey }}
+        - name: secret
+          secret:
+            secretName: {{ .Values.sonarSecretKey }}
+            items:
+            - key: sonar-secret.txt
+              path: sonar-secret.txt
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -514,6 +514,8 @@ emptyDir:
 # Kubernetes secret that contains the encryption key for the SonarQube instance.
 # The secret must contain the key 'sonar-secret.txt'.
 # The 'sonar.secretKeyPath' property will be set automatically.
+# When agentOrchestrator.enabled, this secret is also mounted into the orchestrator, with its
+# path exposed via the AGENTIC_SECRET_KEY_PATH env var.
 # sonarSecretKey: "settings-encryption-secret"
 
 ## Override JDBC values

--- a/tests/unit-test/agent_orchestrator_test.go
+++ b/tests/unit-test/agent_orchestrator_test.go
@@ -228,53 +228,58 @@ func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
 		return nil
 	}
 
-	t.Run("unset renders no encryption key env var, volume, or volumeMount", func(t *testing.T) {
-		deployment := renderAgentOrchestrator(t, nil)
-		container := deployment.Spec.Template.Spec.Containers[0]
-		assert.Nil(t, findEnv(container, "AGENTIC_SECRET_KEY_PATH"))
-		assert.Nil(t, findVolumeMount(container, "secret"))
-		assert.Nil(t, findVolume(deployment.Spec.Template.Spec, "secret"))
-	})
+	for _, chart := range agentCharts {
+		t.Run(chart.name, func(t *testing.T) {
+			t.Run("unset renders no encryption key env var, volume, or volumeMount", func(t *testing.T) {
+				deployment := renderAgentOrchestrator(t, chart, nil)
+				container := deployment.Spec.Template.Spec.Containers[0]
+				assert.Nil(t, findEnv(container, "AGENTIC_SECRET_KEY_PATH"))
+				assert.Nil(t, findVolumeMount(container, "secret"))
+				assert.Nil(t, findVolume(deployment.Spec.Template.Spec, "secret"))
+			})
 
-	t.Run("set mounts the secret and exposes its path", func(t *testing.T) {
-		deployment := renderAgentOrchestrator(t, map[string]string{
-			"sonarSecretKey": "settings-encryption-secret",
+			t.Run("set mounts the secret and exposes its path", func(t *testing.T) {
+				deployment := renderAgentOrchestrator(t, chart, map[string]string{
+					"sonarSecretKey": "settings-encryption-secret",
+				})
+				podSpec := deployment.Spec.Template.Spec
+				container := podSpec.Containers[0]
+
+				env := findEnv(container, "AGENTIC_SECRET_KEY_PATH")
+				require.NotNil(t, env)
+				assert.Equal(t, "/sonarcloud/secret/sonar-secret.txt", env.Value)
+
+				volumeMount := findVolumeMount(container, "secret")
+				require.NotNil(t, volumeMount)
+				assert.Equal(t, "/sonarcloud/secret/", volumeMount.MountPath)
+
+				volume := findVolume(podSpec, "secret")
+				require.NotNil(t, volume)
+				require.NotNil(t, volume.Secret)
+				assert.Equal(t, "settings-encryption-secret", volume.Secret.SecretName)
+				require.Len(t, volume.Secret.Items, 1)
+				assert.Equal(t, "sonar-secret.txt", volume.Secret.Items[0].Key)
+				assert.Equal(t, "sonar-secret.txt", volume.Secret.Items[0].Path)
+			})
+
+			// The secret volume/volumeMount must still render even without readOnlyRootFilesystem,
+			// since the two are independently gated (SONAR-31746 must not regress SONAR-31523's
+			// tmp-volume fix).
+			t.Run("set still mounts the secret without readOnlyRootFilesystem", func(t *testing.T) {
+				deployment := renderAgentOrchestrator(t, chart, map[string]string{
+					"sonarSecretKey": "settings-encryption-secret",
+					"agentOrchestrator.containerSecurityContext.readOnlyRootFilesystem": "false",
+				})
+				podSpec := deployment.Spec.Template.Spec
+				container := podSpec.Containers[0]
+
+				assert.NotNil(t, findVolumeMount(container, "secret"))
+				assert.NotNil(t, findVolume(podSpec, "secret"))
+				assert.Nil(t, findVolumeMount(container, "tmp"))
+				assert.Nil(t, findVolume(podSpec, "tmp"))
+			})
 		})
-		podSpec := deployment.Spec.Template.Spec
-		container := podSpec.Containers[0]
-
-		env := findEnv(container, "AGENTIC_SECRET_KEY_PATH")
-		require.NotNil(t, env)
-		assert.Equal(t, "/sonarcloud/secret/sonar-secret.txt", env.Value)
-
-		volumeMount := findVolumeMount(container, "secret")
-		require.NotNil(t, volumeMount)
-		assert.Equal(t, "/sonarcloud/secret/", volumeMount.MountPath)
-
-		volume := findVolume(podSpec, "secret")
-		require.NotNil(t, volume)
-		require.NotNil(t, volume.Secret)
-		assert.Equal(t, "settings-encryption-secret", volume.Secret.SecretName)
-		require.Len(t, volume.Secret.Items, 1)
-		assert.Equal(t, "sonar-secret.txt", volume.Secret.Items[0].Key)
-		assert.Equal(t, "sonar-secret.txt", volume.Secret.Items[0].Path)
-	})
-
-	// The secret volume/volumeMount must still render even without readOnlyRootFilesystem, since
-	// the two are independently gated (SONAR-31746 must not regress SONAR-31523's tmp-volume fix).
-	t.Run("set still mounts the secret without readOnlyRootFilesystem", func(t *testing.T) {
-		deployment := renderAgentOrchestrator(t, map[string]string{
-			"sonarSecretKey": "settings-encryption-secret",
-			"agentOrchestrator.containerSecurityContext.readOnlyRootFilesystem": "false",
-		})
-		podSpec := deployment.Spec.Template.Spec
-		container := podSpec.Containers[0]
-
-		assert.NotNil(t, findVolumeMount(container, "secret"))
-		assert.NotNil(t, findVolume(podSpec, "secret"))
-		assert.Nil(t, findVolumeMount(container, "tmp"))
-		assert.Nil(t, findVolume(podSpec, "tmp"))
-	})
+	}
 }
 
 func agentOrchestratorPullSecretNames(deployment appsv1.Deployment) []string {

--- a/tests/unit-test/agent_orchestrator_test.go
+++ b/tests/unit-test/agent_orchestrator_test.go
@@ -199,43 +199,36 @@ func TestAgentOrchestratorProbes(t *testing.T) {
 	}
 }
 
+func findEnvByName(container corev1.Container, name string) *corev1.EnvVar {
+	for i := range container.Env {
+		if container.Env[i].Name == name {
+			return &container.Env[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeMountByName(container corev1.Container, name string) *corev1.VolumeMount {
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == name {
+			return &container.VolumeMounts[i]
+		}
+	}
+	return nil
+}
+
 // When the chart-wide encryption key secret (.Values.sonarSecretKey) is set, it must be mounted
 // into the orchestrator too, mirroring how it's mounted into the SonarQube application/search
 // pods, with its path exposed via AGENTIC_SECRET_KEY_PATH (SONAR-31746).
 func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
-	findEnv := func(container corev1.Container, name string) *corev1.EnvVar {
-		for i := range container.Env {
-			if container.Env[i].Name == name {
-				return &container.Env[i]
-			}
-		}
-		return nil
-	}
-	findVolume := func(podSpec corev1.PodSpec, name string) *corev1.Volume {
-		for i := range podSpec.Volumes {
-			if podSpec.Volumes[i].Name == name {
-				return &podSpec.Volumes[i]
-			}
-		}
-		return nil
-	}
-	findVolumeMount := func(container corev1.Container, name string) *corev1.VolumeMount {
-		for i := range container.VolumeMounts {
-			if container.VolumeMounts[i].Name == name {
-				return &container.VolumeMounts[i]
-			}
-		}
-		return nil
-	}
-
 	for _, chart := range agentCharts {
 		t.Run(chart.name, func(t *testing.T) {
 			t.Run("unset renders no encryption key env var, volume, or volumeMount", func(t *testing.T) {
 				deployment := renderAgentOrchestrator(t, chart, nil)
 				container := deployment.Spec.Template.Spec.Containers[0]
-				assert.Nil(t, findEnv(container, "AGENTIC_SECRET_KEY_PATH"))
-				assert.Nil(t, findVolumeMount(container, "secret"))
-				assert.Nil(t, findVolume(deployment.Spec.Template.Spec, "secret"))
+				assert.Nil(t, findEnvByName(container, "AGENTIC_SECRET_KEY_PATH"))
+				assert.Nil(t, findVolumeMountByName(container, "secret"))
+				assert.Nil(t, findVolumeByName(deployment.Spec.Template.Spec.Volumes, "secret"))
 			})
 
 			t.Run("set mounts the secret and exposes its path", func(t *testing.T) {
@@ -245,15 +238,15 @@ func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
 				podSpec := deployment.Spec.Template.Spec
 				container := podSpec.Containers[0]
 
-				env := findEnv(container, "AGENTIC_SECRET_KEY_PATH")
+				env := findEnvByName(container, "AGENTIC_SECRET_KEY_PATH")
 				require.NotNil(t, env)
 				assert.Equal(t, "/sonarcloud/secret/sonar-secret.txt", env.Value)
 
-				volumeMount := findVolumeMount(container, "secret")
+				volumeMount := findVolumeMountByName(container, "secret")
 				require.NotNil(t, volumeMount)
 				assert.Equal(t, "/sonarcloud/secret/", volumeMount.MountPath)
 
-				volume := findVolume(podSpec, "secret")
+				volume := findVolumeByName(podSpec.Volumes, "secret")
 				require.NotNil(t, volume)
 				require.NotNil(t, volume.Secret)
 				assert.Equal(t, "settings-encryption-secret", volume.Secret.SecretName)
@@ -273,10 +266,10 @@ func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
 				podSpec := deployment.Spec.Template.Spec
 				container := podSpec.Containers[0]
 
-				assert.NotNil(t, findVolumeMount(container, "secret"))
-				assert.NotNil(t, findVolume(podSpec, "secret"))
-				assert.Nil(t, findVolumeMount(container, "tmp"))
-				assert.Nil(t, findVolume(podSpec, "tmp"))
+				assert.NotNil(t, findVolumeMountByName(container, "secret"))
+				assert.NotNil(t, findVolumeByName(podSpec.Volumes, "secret"))
+				assert.Nil(t, findVolumeMountByName(container, "tmp"))
+				assert.Nil(t, findVolumeByName(podSpec.Volumes, "tmp"))
 			})
 		})
 	}


### PR DESCRIPTION
## Summary

Ports the DCE chart's encryption-key mount for the agent orchestrator
(originally implemented only for `charts/sonarqube-dce`) to the standard
`charts/sonarqube` chart.

- `charts/sonarqube/templates/agent-orchestrator.yaml`: when
  `.Values.sonarSecretKey` is set, mount it into the orchestrator and expose
  its path via `AGENTIC_SECRET_KEY_PATH` (`/sonarcloud/secret/sonar-secret.txt`),
  mirroring the main SonarQube pod's `sonar.secretKeyPath` mount.
- `charts/sonarqube/values.yaml`: document the new behavior next to
  `sonarSecretKey`.
- `tests/unit-test/agent_orchestrator_test.go`: fix
  `TestAgentOrchestratorEncryptionKeyMount`, left broken (wrong call arity to
  `renderAgentOrchestrator`) since the `SONAR-31375` chart port, so it covers
  both charts via the existing `agentCharts` parametrization.

## Test plan

- [x] `go vet ./...`
- [x] `go test -run TestAgentOrchestrator -v ./...` (both `sonarqube-dce` and
      `sonarqube` subtests pass)
- [x] `go test ./...` (full suite passes)
- [x] Diffed `helm template` output against committed golden fixtures for the
      affected test-case values files (`remediation-agent-values.yaml`,
      `config-values.yaml`) — no change, no fixture regeneration needed

Jira: https://sonarsource.atlassian.net/browse/SONAR-31746