### PR TITLE
SONAR-31879 Default fsGroup and HOME for MCP pod so /data is writable by non-root MCP process

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2026.5.0]
 * Upgrade Chart's version to 2026.5.0
+* Set a default MCP pod `securityContext` (`fsGroup: 0`), a default `HOME=/data`, and an optional `mcp.initContainers` hook so the non-root MCP server can write to `/data`
 * **Breaking**: Remove the deprecated `ingress-nginx.enabled`/`nginx.enabled` bundled ingress-nginx controller subchart dependency. `ingress.enabled` remains supported for use with a self-managed ingress controller; `httproute.enabled` (Gateway API) is also available
 * Add `gateway-api-migration-scripts/nginx-to-istio-migration.sh` to help migrate from the bundled ingress-nginx controller to Gateway API
 * Add optional gVisor (runsc) sandboxing for the agent runtimes

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -35,6 +35,8 @@ maintainers:
     email: navya.otturu@sonarsource.com
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "Set a default MCP pod securityContext (fsGroup: 0), a default HOME=/data, and an optional mcp.initContainers hook so the non-root MCP server can write to /data"
     - kind: changed
       description: "Upgrade Chart's version to 2026.5.0"
     - kind: removed

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -925,7 +925,9 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `mcp.tls.passwordSecretName`            | Name of the Secret containing the keystore password                                                      | `""`                                                                   |
 | `mcp.tls.passwordSecretKey`             | Key inside the password Secret                                                                           | `password`                                                             |
 | `mcp.tls.keystoreType`                  | Keystore format (`PKCS12` or `JKS`)                                                                      | `PKCS12`                                                               |
+| `mcp.podSecurityContext`                | Pod-level security context for the MCP pod. `fsGroup` makes `/data` group-writable (omitted on OpenShift) | `{fsGroup: 0}`                                                         |
 | `mcp.containerSecurityContext`          | Security context for the MCP container                                                                   | [Restricted podSecurityStandard](#kubernetes---pod-security-standards) |
+| `mcp.initContainers`                    | Additional init containers for the MCP pod (e.g. to chown `/data` when the storage driver ignores `fsGroup`) | `[]`                                                                   |
 | `mcp.env`                               | Additional environment variables for the MCP container                                                   | `[]`                                                                   |
 | `mcp.resources`                         | CPU/memory resource requests and limits for the MCP container                                            | `{}`                                                                   |
 | `mcp.annotations`                       | Annotations for the MCP pod                                                                              | `{}`                                                                   |
@@ -933,6 +935,27 @@ The following table lists the configurable parameters of the SonarQube chart and
 ### MCP (Model Context Protocol) Server
 
 When `mcp.enabled` is set to `true`, the chart deploys a separate MCP server pod alongside the SonarQube application nodes and automatically wires the two together via `SONAR_MCP_ENABLED` and `SONAR_MCP_SERVERURL` environment variables.
+
+**Storage permissions:**
+
+The MCP server runs as a non-root user (UID 1000, GID 0) and must write to `/data`. The chart sets `mcp.podSecurityContext.fsGroup: 0` by default so the mounted volume is group-writable by the MCP process.
+
+**Your storage provider must honor filesystem group ownership changes (`fsGroup`).** Drivers such as NFS, hostPath, CSI drivers configured with `fsGroupPolicy: None`, and many pre-provisioned or `existingClaim` volumes ignore `fsGroup`. In those cases the volume stays root-owned and MCP fails to start with errors like `Cannot create directory` under `/data`. To handle them, either pre-provision a `/data` volume writable by group `0` (or UID `1000`), or add an ownership-fixing init container:
+
+```yaml
+mcp:
+  initContainers:
+    - name: chown-data
+      image: busybox:1.36
+      command: ["sh", "-c", "chown -R 1000:0 /data && chmod -R g+rwX /data"]
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - name: mcp-data
+          mountPath: /data
+```
+
+On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`.
 
 **TLS (encrypted communication):**
 

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -955,7 +955,7 @@ mcp:
           mountPath: /data
 ```
 
-On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`.
+On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`. Note that the `chown` init container above runs as root and is therefore rejected by the `restricted` Pod Security Standard and by OpenShift's default SCC; in those environments, pre-provision a `/data` volume already writable by group `0` (or UID `1000`) instead.
 
 **TLS (encrypted communication):**
 

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -955,7 +955,7 @@ mcp:
           mountPath: /data
 ```
 
-On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`. Note that the `chown` init container above runs as root and is therefore rejected by the `restricted` Pod Security Standard and by OpenShift's default SCC; in those environments, pre-provision a `/data` volume already writable by group `0` (or UID `1000`) instead.
+On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns the UID from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`. Note that the `chown` init container above runs as root and is therefore rejected by the `restricted` Pod Security Standard and by OpenShift's default SCC; in those environments, pre-provision a `/data` volume writable by group `0` instead — the MCP image's process runs under group `0` regardless of which UID the SCC assigns, so a UID-specific owner will not work.
 
 **TLS (encrypted communication):**
 

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -570,6 +570,28 @@ Remove incompatible user/group values that do not work in Openshift out of the b
 {{- end -}}
 
 {{/*
+Remove incompatible user/group values that do not work in Openshift out of the box
+*/}}
+{{- define "sonarqube.mcp.securityContext" -}}
+{{- $adaptedMcpSecurityContext := .Values.mcp.podSecurityContext -}}
+  {{- if .Values.OpenShift.enabled -}}
+    {{- $adaptedMcpSecurityContext = omit $adaptedMcpSecurityContext "fsGroup" "runAsUser" "runAsGroup" -}}
+  {{- end -}}
+{{- toYaml $adaptedMcpSecurityContext -}}
+{{- end -}}
+
+{{/*
+Remove incompatible user/group values that do not work in Openshift out of the box
+*/}}
+{{- define "sonarqube.mcp.containerSecurityContext" -}}
+{{- $adaptedMcpContainerSecurityContext := .Values.mcp.containerSecurityContext -}}
+  {{- if .Values.OpenShift.enabled -}}
+    {{- $adaptedMcpContainerSecurityContext = omit $adaptedMcpContainerSecurityContext "fsGroup" "runAsUser" "runAsGroup" -}}
+  {{- end -}}
+{{- toYaml $adaptedMcpContainerSecurityContext -}}
+{{- end -}}
+
+{{/*
   generate caCerts volume
 */}}
 {{- define "sonarqube.volumes.caCerts" -}}

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -592,6 +592,20 @@ Remove incompatible user/group values that do not work in Openshift out of the b
 {{- end -}}
 
 {{/*
+Returns non-empty when mcp.env already defines a HOME entry, so the chart's
+default HOME=/data env can be skipped instead of emitted twice.
+*/}}
+{{- define "sonarqube.mcp.envHasHome" -}}
+{{- $found := false -}}
+{{- range .Values.mcp.env -}}
+  {{- if eq .name "HOME" -}}
+    {{- $found = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if $found -}}true{{- end -}}
+{{- end -}}
+
+{{/*
   generate caCerts volume
 */}}
 {{- define "sonarqube.volumes.caCerts" -}}

--- a/charts/sonarqube-dce/templates/mcp.yaml
+++ b/charts/sonarqube-dce/templates/mcp.yaml
@@ -63,11 +63,13 @@ spec:
           env:
             - name: STORAGE_PATH
               value: /data
+            {{- if not (include "sonarqube.mcp.envHasHome" .) }}
             # HOME is set so SonarLint (SLCORE) resolves its user home under the
             # writable /data volume instead of "/", which is not writable for the
             # non-root MCP user. Overridable via mcp.env below.
             - name: HOME
               value: /data
+            {{- end }}
             - name: SONARQUBE_URL
               value: {{ printf "http://%s:%d%s" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) (trimSuffix "/" (include "sonarqube.webcontext" .)) }}
             - name: SONARQUBE_HTTP_HOST

--- a/charts/sonarqube-dce/templates/mcp.yaml
+++ b/charts/sonarqube-dce/templates/mcp.yaml
@@ -20,6 +20,9 @@ spec:
         app: {{ include "sonarqube.name" . }}-mcp
         release: {{ .Release.Name }}
     spec:
+      {{- with (fromYaml (include "sonarqube.mcp.securityContext" .)) }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.ApplicationNodes.image.pullSecrets .Values.ApplicationNodes.image.pullSecret .Values.mcp.image.pullSecrets }}
       imagePullSecrets:
         {{- if .Values.ApplicationNodes.image.pullSecret }}
@@ -46,6 +49,9 @@ spec:
               until curl -sf "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}{{ include "sonarqube.webcontext" . }}api/system/status" | grep -q '"status":"UP"'; do
                 echo "Waiting for SonarQube to be UP..."; sleep 10;
               done
+        {{- with .Values.mcp.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: mcp
           image: {{ printf "%s:%s" .Values.mcp.image.repository (default "latest" .Values.mcp.image.tag) }}
@@ -56,6 +62,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: {{ printf "http://%s:%d%s" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) (trimSuffix "/" (include "sonarqube.webcontext" .)) }}
@@ -88,7 +99,7 @@ spec:
             periodSeconds: {{ .Values.mcp.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.mcp.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.mcp.livenessProbe.timeoutSeconds }}
-          {{- with .Values.mcp.containerSecurityContext }}
+          {{- with (fromYaml (include "sonarqube.mcp.containerSecurityContext" .)) }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.mcp.resources }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -856,6 +856,9 @@ mcp:
   # Additional init containers for the MCP pod, running before the MCP container.
   # Typical use: chown /data to 1000:0 on storage drivers that ignore fsGroup.
   # Mount the shared volume as "mcp-data" at /data.
+  # NOTE: the example below runs as root and is rejected by the "restricted" Pod
+  # Security Standard and by OpenShift's default SCC. In those environments
+  # pre-provision a /data volume writable by group 0 instead.
   initContainers: []
   # - name: chown-data
   #   image: busybox:1.36

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -830,6 +830,18 @@ mcp:
     # Keystore format: PKCS12 or JKS.
     keystoreType: "PKCS12"
 
+  # Set pod-level security context for the MCP pod.
+  # fsGroup makes the mounted /data volume group-writable so the non-root MCP
+  # process (runAsGroup: 0) can create its logs, plugins and SonarLint home there.
+  # NOTE: your storage provider must honor fsGroup ownership changes. Drivers such
+  # as NFS, hostPath, CSI drivers with fsGroupPolicy: None, and many pre-provisioned
+  # or existingClaim volumes ignore it - for those, pre-provision a writable volume
+  # or add an ownership-fixing init container via mcp.initContainers.
+  # On OpenShift, fsGroup/runAsUser/runAsGroup are removed automatically (the platform
+  # assigns them from the namespace SCC range).
+  podSecurityContext:
+    fsGroup: 0
+
   # Set security context for the MCP container.
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -840,6 +852,19 @@ mcp:
       type: RuntimeDefault
     capabilities:
       drop: ["ALL"]
+
+  # Additional init containers for the MCP pod, running before the MCP container.
+  # Typical use: chown /data to 1000:0 on storage drivers that ignore fsGroup.
+  # Mount the shared volume as "mcp-data" at /data.
+  initContainers: []
+  # - name: chown-data
+  #   image: busybox:1.36
+  #   command: ["sh", "-c", "chown -R 1000:0 /data && chmod -R g+rwX /data"]
+  #   securityContext:
+  #     runAsUser: 0
+  #   volumeMounts:
+  #     - name: mcp-data
+  #       mountPath: /data
 
   # Additional environment variables for the MCP container.
   env: []

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -3,6 +3,7 @@ All changes to this chart will be documented in this file.
 
 ## [2026.5.0]
 * Upgrade Chart's version to 2026.5.0
+* Set a default MCP pod `securityContext` (`fsGroup: 0`), a default `HOME=/data`, and an optional `mcp.initContainers` hook so the non-root MCP server can write to `/data`
 * **Breaking**: Remove the deprecated `ingress-nginx.enabled`/`nginx.enabled` bundled ingress-nginx controller subchart dependency. `ingress.enabled` remains supported for use with a self-managed ingress controller; `httproute.enabled` (Gateway API) is also available
 * Add `gateway-api-migration-scripts/nginx-to-istio-migration.sh` to help migrate from the bundled ingress-nginx controller to Gateway API
 * Add optional gVisor (runsc) sandboxing for the agent runtimes

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -40,6 +40,8 @@ annotations:
     - name: Chart Source
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
+    - kind: added
+      description: "Set a default MCP pod securityContext (fsGroup: 0), a default HOME=/data, and an optional mcp.initContainers hook so the non-root MCP server can write to /data"
     - kind: changed
       description: "Upgrade Chart's version to 2026.5.0"
     - kind: removed

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -491,7 +491,7 @@ mcp:
           mountPath: /data
 ```
 
-On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`. Note that the `chown` init container above runs as root and is therefore rejected by the `restricted` Pod Security Standard and by OpenShift's default SCC; in those environments, pre-provision a `/data` volume already writable by group `0` (or UID `1000`) instead.
+On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns the UID from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`. Note that the `chown` init container above runs as root and is therefore rejected by the `restricted` Pod Security Standard and by OpenShift's default SCC; in those environments, pre-provision a `/data` volume writable by group `0` instead — the MCP image's process runs under group `0` regardless of which UID the SCC assigns, so a UID-specific owner will not work.
 
 **TLS (encrypted communication):**
 

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -472,6 +472,27 @@ mcp:
     enabled: false
 ```
 
+**Storage permissions:**
+
+The MCP server runs as a non-root user (UID 1000, GID 0) and must write to `/data`. The chart sets `mcp.podSecurityContext.fsGroup: 0` by default so the mounted volume is group-writable by the MCP process.
+
+**Your storage provider must honor filesystem group ownership changes (`fsGroup`).** Drivers such as NFS, hostPath, CSI drivers configured with `fsGroupPolicy: None`, and many pre-provisioned or `existingClaim` volumes ignore `fsGroup`. In those cases the volume stays root-owned and MCP fails to start with errors like `Cannot create directory` under `/data`. To handle them, either pre-provision a `/data` volume writable by group `0` (or UID `1000`), or add an ownership-fixing init container:
+
+```yaml
+mcp:
+  initContainers:
+    - name: chown-data
+      image: busybox:1.36
+      command: ["sh", "-c", "chown -R 1000:0 /data && chmod -R g+rwX /data"]
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - name: mcp-data
+          mountPath: /data
+```
+
+On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`.
+
 **TLS (encrypted communication):**
 
 When `mcp.tls.enabled` is set to `true`, the MCP server starts in HTTPS mode using the keystore from `mcp.tls.keystoreSecretName`. SonarQube connects to it over `https://`.
@@ -857,7 +878,9 @@ and set `persistence.hostPath.path` and `persistence.hostPath.type`.
 | `mcp.tls.passwordSecretName`           | Name of the Secret containing the keystore password                                                      | `""`                                                                   |
 | `mcp.tls.passwordSecretKey`            | Key inside the password Secret                                                                           | `password`                                                             |
 | `mcp.tls.keystoreType`                 | Keystore format (`PKCS12` or `JKS`)                                                                     | `PKCS12`                                                               |
+| `mcp.podSecurityContext`               | Pod-level security context for the MCP pod. `fsGroup` makes `/data` group-writable (omitted on OpenShift) | `{fsGroup: 0}`                                                         |
 | `mcp.containerSecurityContext`         | Security context for the MCP container                                                                   | [Restricted podSecurityStandard](#kubernetes---pod-security-standards) |
+| `mcp.initContainers`                   | Additional init containers for the MCP pod (e.g. to chown `/data` when the storage driver ignores `fsGroup`) | `[]`                                                                   |
 | `mcp.env`                              | Additional environment variables for the MCP container                                                   | `[]`                                                                   |
 | `mcp.resources`                        | CPU/memory resource requests and limits for the MCP container                                            | `{}`                                                                   |
 | `mcp.annotations`                      | Annotations for the MCP pod                                                                              | `{}`                                                                   |

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -491,7 +491,7 @@ mcp:
           mountPath: /data
 ```
 
-On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`.
+On OpenShift, do not set `fsGroup`/`runAsUser`/`runAsGroup` — the platform assigns them from the namespace's SCC range, and the chart removes these keys automatically when `OpenShift.enabled=true`. Note that the `chown` init container above runs as root and is therefore rejected by the `restricted` Pod Security Standard and by OpenShift's default SCC; in those environments, pre-provision a `/data` volume already writable by group `0` (or UID `1000`) instead.
 
 **TLS (encrypted communication):**
 

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -374,6 +374,28 @@ Remove incompatible user/group values that do not work in Openshift out of the b
 {{- end -}}
 
 {{/*
+Remove incompatible user/group values that do not work in Openshift out of the box
+*/}}
+{{- define "sonarqube.mcp.securityContext" -}}
+{{- $adaptedMcpSecurityContext := .Values.mcp.podSecurityContext -}}
+  {{- if .Values.OpenShift.enabled -}}
+    {{- $adaptedMcpSecurityContext = omit $adaptedMcpSecurityContext "fsGroup" "runAsUser" "runAsGroup" -}}
+  {{- end -}}
+{{- toYaml $adaptedMcpSecurityContext -}}
+{{- end -}}
+
+{{/*
+Remove incompatible user/group values that do not work in Openshift out of the box
+*/}}
+{{- define "sonarqube.mcp.containerSecurityContext" -}}
+{{- $adaptedMcpContainerSecurityContext := .Values.mcp.containerSecurityContext -}}
+  {{- if .Values.OpenShift.enabled -}}
+    {{- $adaptedMcpContainerSecurityContext = omit $adaptedMcpContainerSecurityContext "fsGroup" "runAsUser" "runAsGroup" -}}
+  {{- end -}}
+{{- toYaml $adaptedMcpContainerSecurityContext -}}
+{{- end -}}
+
+{{/*
   generate caCerts volume
 */}}
 {{- define "sonarqube.volumes.caCerts" -}}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -396,6 +396,20 @@ Remove incompatible user/group values that do not work in Openshift out of the b
 {{- end -}}
 
 {{/*
+Returns non-empty when mcp.env already defines a HOME entry, so the chart's
+default HOME=/data env can be skipped instead of emitted twice.
+*/}}
+{{- define "sonarqube.mcp.envHasHome" -}}
+{{- $found := false -}}
+{{- range .Values.mcp.env -}}
+  {{- if eq .name "HOME" -}}
+    {{- $found = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if $found -}}true{{- end -}}
+{{- end -}}
+
+{{/*
   generate caCerts volume
 */}}
 {{- define "sonarqube.volumes.caCerts" -}}

--- a/charts/sonarqube/templates/mcp.yaml
+++ b/charts/sonarqube/templates/mcp.yaml
@@ -63,11 +63,13 @@ spec:
           env:
             - name: STORAGE_PATH
               value: /data
+            {{- if not (include "sonarqube.mcp.envHasHome" .) }}
             # HOME is set so SonarLint (SLCORE) resolves its user home under the
             # writable /data volume instead of "/", which is not writable for the
             # non-root MCP user. Overridable via mcp.env below.
             - name: HOME
               value: /data
+            {{- end }}
             - name: SONARQUBE_URL
               value: {{ printf "http://%s:%d%s" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) (trimSuffix "/" (include "sonarqube.webcontext" .)) }}
             - name: SONARQUBE_HTTP_HOST

--- a/charts/sonarqube/templates/mcp.yaml
+++ b/charts/sonarqube/templates/mcp.yaml
@@ -20,6 +20,9 @@ spec:
         app: {{ include "sonarqube.name" . }}-mcp
         release: {{ .Release.Name }}
     spec:
+      {{- with (fromYaml (include "sonarqube.mcp.securityContext" .)) }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.image.pullSecrets .Values.image.pullSecret .Values.mcp.image.pullSecrets }}
       imagePullSecrets:
         {{- if .Values.image.pullSecret }}
@@ -46,6 +49,9 @@ spec:
               until curl -sf "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}{{ include "sonarqube.webcontext" . }}api/system/status" | grep -q '"status":"UP"'; do
                 echo "Waiting for SonarQube to be UP..."; sleep 10;
               done
+        {{- with .Values.mcp.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: mcp
           image: {{ printf "%s:%s" .Values.mcp.image.repository (default "latest" .Values.mcp.image.tag) }}
@@ -56,6 +62,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: {{ printf "http://%s:%d%s" (include "sonarqube.fullname" .) (.Values.service.internalPort | int) (trimSuffix "/" (include "sonarqube.webcontext" .)) }}
@@ -88,7 +99,7 @@ spec:
             periodSeconds: {{ .Values.mcp.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.mcp.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.mcp.livenessProbe.timeoutSeconds }}
-          {{- with .Values.mcp.containerSecurityContext }}
+          {{- with (fromYaml (include "sonarqube.mcp.containerSecurityContext" .)) }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.mcp.resources }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -678,6 +678,18 @@ mcp:
     accessMode: ReadWriteOnce
     size: 1Gi
 
+  # Set pod-level security context for the MCP pod.
+  # fsGroup makes the mounted /data volume group-writable so the non-root MCP
+  # process (runAsGroup: 0) can create its logs, plugins and SonarLint home there.
+  # NOTE: your storage provider must honor fsGroup ownership changes. Drivers such
+  # as NFS, hostPath, CSI drivers with fsGroupPolicy: None, and many pre-provisioned
+  # or existingClaim volumes ignore it - for those, pre-provision a writable volume
+  # or add an ownership-fixing init container via mcp.initContainers.
+  # On OpenShift, fsGroup/runAsUser/runAsGroup are removed automatically (the platform
+  # assigns them from the namespace SCC range).
+  podSecurityContext:
+    fsGroup: 0
+
   # Set security context for the MCP container.
   containerSecurityContext:
     allowPrivilegeEscalation: false
@@ -688,6 +700,19 @@ mcp:
       type: RuntimeDefault
     capabilities:
       drop: ["ALL"]
+
+  # Additional init containers for the MCP pod, running before the MCP container.
+  # Typical use: chown /data to 1000:0 on storage drivers that ignore fsGroup.
+  # Mount the shared volume as "mcp-data" at /data.
+  initContainers: []
+  # - name: chown-data
+  #   image: busybox:1.36
+  #   command: ["sh", "-c", "chown -R 1000:0 /data && chmod -R g+rwX /data"]
+  #   securityContext:
+  #     runAsUser: 0
+  #   volumeMounts:
+  #     - name: mcp-data
+  #       mountPath: /data
 
   livenessProbe:
     initialDelaySeconds: 60

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -704,6 +704,9 @@ mcp:
   # Additional init containers for the MCP pod, running before the MCP container.
   # Typical use: chown /data to 1000:0 on storage drivers that ignore fsGroup.
   # Mount the shared volume as "mcp-data" at /data.
+  # NOTE: the example below runs as root and is rejected by the "restricted" Pod
+  # Security Standard and by OpenShift's default SCC. In those environments
+  # pre-provision a /data volume writable by group 0 instead.
   initContainers: []
   # - name: chown-data
   #   image: busybox:1.36

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
@@ -358,6 +358,8 @@ spec:
         app: sonarqube-dce-mcp
         release: mcp-tls-values.yaml
     spec:
+      securityContext:
+        fsGroup: 0
       initContainers:
         - name: wait-for-sonarqube
           image: sonarqube:2026.4.0-datacenter-app
@@ -390,6 +392,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: http://mcp-tls-values.yaml-sonarqube-dce:9000

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
@@ -376,6 +376,8 @@ spec:
         app: sonarqube-dce-mcp
         release: mcp-values.yaml
     spec:
+      securityContext:
+        fsGroup: 0
       initContainers:
         - name: wait-for-sonarqube
           image: sonarqube:2026.4.0-datacenter-app
@@ -408,6 +410,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: http://mcp-values.yaml-sonarqube-dce:9000

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
@@ -376,6 +376,8 @@ spec:
         app: sonarqube-dce-mcp
         release: mcp-web-context-values.yaml
     spec:
+      securityContext:
+        fsGroup: 0
       initContainers:
         - name: wait-for-sonarqube
           image: sonarqube:2026.4.0-datacenter-app
@@ -408,6 +410,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: http://mcp-web-context-values.yaml-sonarqube-dce:9000/sonarqube-pre-prod

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -150,6 +150,46 @@ data:
   SONAR_JDBC_USERNAME: "user"
   SONAR_JDBC_URL: "jdbc:postgresql://myPostgres/myDatabase?socketTimeout=1500"
 ---
+# Source: sonarqube-dce/templates/mcp-pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: restricted-openshift.yaml-sonarqube-dce-mcp
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.5.0
+    release: restricted-openshift.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "1Gi"
+---
+# Source: sonarqube-dce/templates/mcp-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: restricted-openshift.yaml-sonarqube-dce-mcp
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.5.0
+    release: restricted-openshift.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: sonarqube-dce-mcp
+    release: restricted-openshift.yaml
+---
 # Source: sonarqube-dce/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -251,6 +291,98 @@ spec:
   selector:
     app: sonarqube-dce-search
     release: restricted-openshift.yaml
+---
+# Source: sonarqube-dce/templates/mcp.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: restricted-openshift.yaml-sonarqube-dce-mcp
+  labels:
+    app: sonarqube-dce
+    chart: sonarqube-dce-2026.5.0
+    release: restricted-openshift.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarqube-dce-mcp
+      release: restricted-openshift.yaml
+  template:
+    metadata:
+      labels:
+        app: sonarqube-dce-mcp
+        release: restricted-openshift.yaml
+    spec:
+      initContainers:
+        - name: wait-for-sonarqube
+          image: sonarqube:9.9.0-datacenter-app
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "http://restricted-openshift.yaml-sonarqube-dce:9000/api/system/status" | grep -q '"status":"UP"'; do
+                echo "Waiting for SonarQube to be UP..."; sleep 10;
+              done
+      containers:
+        - name: mcp
+          image: sonarsource/sonarqube-mcp:1.22.0.3040
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
+              value: /data
+            - name: SONARQUBE_URL
+              value: http://restricted-openshift.yaml-sonarqube-dce:9000
+            - name: SONARQUBE_HTTP_HOST
+              value: "0.0.0.0"
+            - name: SONARQUBE_HTTP_PORT
+              value: "8080"
+            - name: SONARQUBE_TRANSPORT
+              value: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: mcp-data
+              mountPath: /data
+      volumes:
+        - name: mcp-data
+          persistentVolumeClaim:
+            claimName: restricted-openshift.yaml-sonarqube-dce-mcp
 ---
 # Source: sonarqube-dce/templates/sonarqube-application.yaml
 apiVersion: apps/v1
@@ -389,6 +521,10 @@ spec:
                 secretKeyRef:
                   name: restricted-openshift.yaml-sonarqube-dce-monitoring-passcode
                   key: SONAR_WEB_SYSTEMPASSCODE
+            - name: SONAR_MCP_ENABLED
+              value: "true"
+            - name: SONAR_MCP_SERVERURL
+              value: "http://restricted-openshift.yaml-sonarqube-dce-mcp:8080"
           envFrom:
             - configMapRef:
                 name: restricted-openshift.yaml-sonarqube-dce-jdbc-config

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
@@ -173,6 +173,8 @@ spec:
         app: sonarqube-mcp
         release: mcp-tls-values.yaml
     spec:
+      securityContext:
+        fsGroup: 0
       initContainers:
         - name: wait-for-sonarqube
           image: sonarqube:2026.4.0-enterprise
@@ -205,6 +207,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: http://mcp-tls-values.yaml-sonarqube:9000

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
@@ -191,6 +191,8 @@ spec:
         app: sonarqube-mcp
         release: mcp-values.yaml
     spec:
+      securityContext:
+        fsGroup: 0
       initContainers:
         - name: wait-for-sonarqube
           image: sonarqube:2026.4.0-enterprise
@@ -223,6 +225,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: http://mcp-values.yaml-sonarqube:9000

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
@@ -191,6 +191,8 @@ spec:
         app: sonarqube-mcp
         release: mcp-web-context-values.yaml
     spec:
+      securityContext:
+        fsGroup: 0
       initContainers:
         - name: wait-for-sonarqube
           image: sonarqube:2026.4.0-enterprise
@@ -223,6 +225,11 @@ spec:
               protocol: TCP
           env:
             - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
               value: /data
             - name: SONARQUBE_URL
               value: http://mcp-web-context-values.yaml-sonarqube:9000/sonarqube-pre-prod

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -60,6 +60,46 @@ metadata:
 data:
   install_plugins.sh: |-
 ---
+# Source: sonarqube/templates/mcp-pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: openshift-values.yaml-sonarqube-mcp
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.5.0
+    release: openshift-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "1Gi"
+---
+# Source: sonarqube/templates/mcp-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: openshift-values.yaml-sonarqube-mcp
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.5.0
+    release: openshift-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: sonarqube-mcp
+    release: openshift-values.yaml
+---
 # Source: sonarqube/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -80,6 +120,98 @@ spec:
   selector:
     app: sonarqube
     release: openshift-values.yaml
+---
+# Source: sonarqube/templates/mcp.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openshift-values.yaml-sonarqube-mcp
+  labels:
+    app: sonarqube
+    chart: sonarqube-2026.5.0
+    release: openshift-values.yaml
+    heritage: Helm
+    app.kubernetes.io/component: mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sonarqube-mcp
+      release: openshift-values.yaml
+  template:
+    metadata:
+      labels:
+        app: sonarqube-mcp
+        release: openshift-values.yaml
+    spec:
+      initContainers:
+        - name: wait-for-sonarqube
+          image: sonarqube:2026.4.0-enterprise
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "http://openshift-values.yaml-sonarqube:9000/api/system/status" | grep -q '"status":"UP"'; do
+                echo "Waiting for SonarQube to be UP..."; sleep 10;
+              done
+      containers:
+        - name: mcp
+          image: sonarsource/sonarqube-mcp:1.22.0.3040
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: STORAGE_PATH
+              value: /data
+            # HOME is set so SonarLint (SLCORE) resolves its user home under the
+            # writable /data volume instead of "/", which is not writable for the
+            # non-root MCP user. Overridable via mcp.env below.
+            - name: HOME
+              value: /data
+            - name: SONARQUBE_URL
+              value: http://openshift-values.yaml-sonarqube:9000
+            - name: SONARQUBE_HTTP_HOST
+              value: "0.0.0.0"
+            - name: SONARQUBE_HTTP_PORT
+              value: "8080"
+            - name: SONARQUBE_TRANSPORT
+              value: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: mcp-data
+              mountPath: /data
+      volumes:
+        - name: mcp-data
+          persistentVolumeClaim:
+            claimName: openshift-values.yaml-sonarqube-mcp
 ---
 # Source: sonarqube/templates/sonarqube-sts.yaml
 apiVersion: apps/v1
@@ -146,6 +278,10 @@ spec:
                 secretKeyRef:
                   name: openshift-values.yaml-sonarqube-monitoring-passcode
                   key: SONAR_WEB_SYSTEMPASSCODE
+            - name: SONAR_MCP_ENABLED
+              value: "true"
+            - name: SONAR_MCP_SERVERURL
+              value: "http://openshift-values.yaml-sonarqube-mcp:8080"
             - name: SONAR_WEB_CONTEXT
               value: /
             - name: SONAR_WEB_JAVAOPTS

--- a/tests/unit-compatibility-test/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/sonarqube-dce/restricted-openshift.yaml
@@ -19,6 +19,9 @@ OpenShift:
   route:
     enabled: true
 
+mcp:
+  enabled: true
+
 ApplicationNodes:
   image:
     repository: sonarqube

--- a/tests/unit-compatibility-test/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/sonarqube/openshift-values.yaml
@@ -4,3 +4,6 @@ OpenShift:
   enabled: true
   route:
     enabled: true
+
+mcp:
+  enabled: true


### PR DESCRIPTION
----
## Summary by Gitar

- **MCP Configuration:**
    - Configured default `fsGroup: 0` in `podSecurityContext` and set `HOME=/data` environment variable for the MCP pod
    - Added support for `mcp.initContainers` to handle storage drivers that ignore `fsGroup` restrictions

<sub>This will update automatically on new commits.</sub>