### PR TITLE
SONAR-32028 Mount agentic signing secret into three components

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -10,6 +10,7 @@ All changes to this chart will be documented in this file.
 * Auto-wire the Hunter Agent's `SCRIPT_PATH` (detection mode) from `hunterAgent.scriptPath`, symmetric with the Remediation Agent's `REMEDIATION_SCRIPT_PATH`
 * Add `agentOrchestrator.env`/`extraVolumes`/`extraVolumeMounts`, and a `agentOrchestrator.storage.type`/`vortex.storage.filesystem.baseDir` FILESYSTEM/NFS backend for the shared agentic job storage
 * Mount the `sonarSecretKey` settings-encryption secret into the Agent Orchestrator pod, exposing its path via the `AGENTIC_SECRET_KEY_PATH` env var
+* Add `agenticSigningSecretKey` to mount an agentic signing secret into SonarQube Server, the Agent Orchestrator, and Vortex, exposing its path via `sonar.agentic.signing.secretFile`/`SONAR_AGENTIC_SIGNING_SECRET_FILE`
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0

--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -770,6 +770,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `noProxy`                | No proxy for downloading JMX agent and install plugins, will superseed initContainer specific no proxy variables      | ``      |
 | `nodeEncryption.enabled` | Secure the communication between Application and Search nodes using TLS                                               | `false` |
 | `sonarSecretKey`         | Name of existing secret used for settings encryption. When `agentOrchestrator.enabled`, this secret is also mounted into the orchestrator, with its path exposed via the `AGENTIC_SECRET_KEY_PATH` env var | `None`  |
+| `agenticSigningSecretKey` | Name of existing secret containing the agentic signing secret, shared by SonarQube Server, the Agent Orchestrator, and Vortex to sign/verify agentic requests to each other | `None`  |
 
 ### NetworkPolicies
 

--- a/charts/sonarqube-dce/templates/agent-orchestrator.yaml
+++ b/charts/sonarqube-dce/templates/agent-orchestrator.yaml
@@ -88,6 +88,10 @@ spec:
             - name: AGENTIC_SECRET_KEY_PATH
               value: "/sonarcloud/secret/sonar-secret.txt"
             {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: SONAR_AGENTIC_SIGNING_SECRET_FILE
+              value: "/sonarcloud/secret-agentic-signing/sonar-agentic-signing-secret.txt"
+            {{- end }}
             {{- /* CORE DB (SonarQube's database) connection for the orchestrator. Each field is
                    independently configurable via agentOrchestrator.coreDb, defaulting to
                    the shared jdbcOverwrite so it targets the same DB as SonarQube out of the box.
@@ -174,7 +178,7 @@ spec:
           {{- with .Values.agentOrchestrator.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agentOrchestrator.extraVolumeMounts }}
+          {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agenticSigningSecretKey .Values.agentOrchestrator.extraVolumeMounts }}
           volumeMounts:
             {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
             - name: tmp
@@ -183,6 +187,10 @@ spec:
             {{- if .Values.sonarSecretKey }}
             - name: secret
               mountPath: /sonarcloud/secret/
+            {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: agentic-signing-secret
+              mountPath: /sonarcloud/secret-agentic-signing/
             {{- end }}
             {{- with .Values.agentOrchestrator.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -200,7 +208,7 @@ spec:
 {{ . | indent 6 }}
       {{- end }}
       serviceAccountName: {{ include "sonarqube.agentOrchestrator.serviceAccountName" . }}
-      {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agentOrchestrator.extraVolumes }}
+      {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agenticSigningSecretKey .Values.agentOrchestrator.extraVolumes }}
       volumes:
         {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
         - name: tmp
@@ -213,6 +221,14 @@ spec:
             items:
             - key: sonar-secret.txt
               path: sonar-secret.txt
+        {{- end }}
+        {{- if .Values.agenticSigningSecretKey }}
+        - name: agentic-signing-secret
+          secret:
+            secretName: {{ .Values.agenticSigningSecretKey }}
+            items:
+            - key: sonar-agentic-signing-secret.txt
+              path: sonar-agentic-signing-secret.txt
         {{- end }}
         {{- with .Values.agentOrchestrator.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/sonarqube-dce/templates/config.yaml
+++ b/charts/sonarqube-dce/templates/config.yaml
@@ -19,6 +19,9 @@ data:
   {{- if .Values.sonarSecretKey }}
     sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
   {{- end }}
+  {{- if .Values.agenticSigningSecretKey }}
+    sonar.agentic.signing.secretFile={{ .Values.sonarqubeFolder }}/secret-agentic-signing/sonar-agentic-signing-secret.txt
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -36,4 +39,7 @@ data:
   {{- end }}
   {{- if .Values.sonarSecretKey }}
     sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
+  {{- end }}
+  {{- if .Values.agenticSigningSecretKey }}
+    sonar.agentic.signing.secretFile={{ .Values.sonarqubeFolder }}/secret-agentic-signing/sonar-agentic-signing-secret.txt
   {{- end }}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -101,7 +101,7 @@ spec:
           {{- end }}
       {{- end }}
       {{- $hasMergedProps := or .Values.ApplicationNodes.sonarProperties .Values.ApplicationNodes.port .Values.ApplicationNodes.webPort .Values.ApplicationNodes.cePort .Values.agentOrchestrator.enabled .Values.vortex.enabled }}
-      {{- if or $hasMergedProps .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey }}
+      {{- if or $hasMergedProps .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
         - name: concat-properties
           image: {{ default (include "sonarqube.image" .) .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.ApplicationNodes.image.pullPolicy  }}
@@ -120,7 +120,7 @@ spec:
               awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
             fi
           volumeMounts:
-          {{- if or $hasMergedProps .Values.sonarSecretKey }}
+          {{- if or $hasMergedProps .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
             - mountPath: /tmp/props/sonar.properties
               name: config
               subPath: sonar.properties
@@ -383,7 +383,7 @@ spec:
           securityContext: {{- . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if or $hasMergedProps .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey }}
+            {{- if or $hasMergedProps .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
               subPath: sonar.properties
               name: concat-dir
@@ -391,6 +391,10 @@ spec:
             {{- if .Values.sonarSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
               name: secret
+            {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - mountPath: {{ .Values.sonarqubeFolder }}/secret-agentic-signing/
+              name: agentic-signing-secret
             {{- end }}
             {{- if .Values.caCerts.enabled }}
             - mountPath: {{ .Values.sonarqubeFolder }}/certs
@@ -464,7 +468,7 @@ spec:
     {{- end }}
       serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       volumes:
-      {{- if or $hasMergedProps .Values.sonarSecretKey }}
+      {{- if or $hasMergedProps .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
       - name: config
         configMap:
           name: {{ template "sonarqube.fullname" . }}-app-config
@@ -487,6 +491,14 @@ spec:
           items:
           - key: sonar-secret.txt
             path: sonar-secret.txt
+      {{- end }}
+      {{- if .Values.agenticSigningSecretKey }}
+      - name: agentic-signing-secret
+        secret:
+          secretName: {{ .Values.agenticSigningSecretKey }}
+          items:
+          - key: sonar-agentic-signing-secret.txt
+            path: sonar-agentic-signing-secret.txt
       {{- end }}
       {{- include "sonarqube.volumes.caCerts" . | nindent 6 }}
       {{- if .Values.ApplicationNodes.plugins.netrcCreds }}
@@ -542,7 +554,7 @@ spec:
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
       - name : tmp-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
-        {{- if or $hasMergedProps .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey }}
+        {{- if or $hasMergedProps .Values.ApplicationNodes.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
       - name : concat-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 -}}
         {{- end }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -145,7 +145,7 @@ spec:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey }}
+      {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
         - name: concat-properties
           image: {{ default (include "sonarqube.image" .) .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.searchNodes.image.pullPolicy  }}
@@ -164,7 +164,7 @@ spec:
               awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
             fi
           volumeMounts:
-          {{- if or .Values.searchNodes.sonarProperties .Values.sonarSecretKey }}
+          {{- if or .Values.searchNodes.sonarProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
             - mountPath: /tmp/props/sonar.properties
               name: config
               subPath: sonar.properties
@@ -413,7 +413,7 @@ spec:
 {{- if .Values.searchNodes.persistence.mounts }}
 {{ toYaml .Values.searchNodes.persistence.mounts | indent 12 }}
 {{- end }}
-            {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey }}
+            {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/conf/sonar.properties
               subPath: sonar.properties
               name: concat-dir
@@ -421,6 +421,11 @@ spec:
             {{- if .Values.sonarSecretKey }}
             - mountPath: {{ .Values.sonarqubeFolder }}/secret/
               name: secret
+              readOnly: true
+            {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - mountPath: {{ .Values.sonarqubeFolder }}/secret-agentic-signing/
+              name: agentic-signing-secret
               readOnly: true
             {{- end }}
             {{- if .Values.searchNodes.searchAuthentication.enabled }}
@@ -486,7 +491,15 @@ spec:
           - key: sonar-secret.txt
             path: sonar-secret.txt
       {{- end }}
-      {{- if or .Values.searchNodes.sonarProperties .Values.sonarSecretKey }}
+      {{- if .Values.agenticSigningSecretKey }}
+      - name: agentic-signing-secret
+        secret:
+          secretName: {{ .Values.agenticSigningSecretKey }}
+          items:
+          - key: sonar-agentic-signing-secret.txt
+            path: sonar-agentic-signing-secret.txt
+      {{- end }}
+      {{- if or .Values.searchNodes.sonarProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
       - name: config
         configMap:
           name: {{ template "sonarqube.fullname" . }}-search-config
@@ -532,7 +545,7 @@ spec:
       {{- end }}
       - name : tmp-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 }}
-        {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey }}
+        {{- if or .Values.searchNodes.sonarProperties .Values.searchNodes.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey }}
       - name : concat-dir
         emptyDir: {{- toYaml .Values.emptyDir | nindent 10 -}}
         {{- end }}

--- a/charts/sonarqube-dce/templates/vortex.yaml
+++ b/charts/sonarqube-dce/templates/vortex.yaml
@@ -81,6 +81,10 @@ spec:
                   name: {{ default (include "sonarqube.vortex.fullname" .) $vortex.storage.existingSecret }}
                   key: SONAR_AGENTIC_STORAGE_SECRET_KEY
             {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: SONAR_AGENTIC_SIGNING_SECRET_FILE
+              value: "/etc/sonar-agentic-signing/sonar-agentic-signing-secret.txt"
+            {{- end }}
             {{- with $vortex.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -103,15 +107,32 @@ spec:
               path: /health
               port: http
             periodSeconds: 30
-          {{- with $vortex.extraVolumeMounts }}
+          {{- if or $vortex.extraVolumeMounts .Values.agenticSigningSecretKey }}
           volumeMounts:
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: agentic-signing-secret
+              mountPath: /etc/sonar-agentic-signing/
+              readOnly: true
+            {{- end }}
+            {{- with $vortex.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
       {{- with (include "sonarqube.agent.scheduling" (dict "ctx" . "component" $vortex)) }}
 {{ . | indent 6 }}
       {{- end }}
-      {{- with $vortex.extraVolumes }}
+      {{- if or $vortex.extraVolumes .Values.agenticSigningSecretKey }}
       volumes:
+        {{- if .Values.agenticSigningSecretKey }}
+        - name: agentic-signing-secret
+          secret:
+            secretName: {{ .Values.agenticSigningSecretKey }}
+            items:
+            - key: sonar-agentic-signing-secret.txt
+              path: sonar-agentic-signing-secret.txt
+        {{- end }}
+        {{- with $vortex.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -691,6 +691,14 @@ emptyDir: {}
 # path exposed via the AGENTIC_SECRET_KEY_PATH env var.
 # sonarSecretKey: "settings-encryption-secret"
 
+# Kubernetes secret containing the agentic signing secret, shared by SonarQube Server, the Agent
+# Orchestrator, and Vortex to sign/verify agentic requests to each other.
+# The secret must contain the key 'sonar-agentic-signing-secret.txt'.
+# The 'sonar.agentic.signing.secretFile' property will be set automatically on SonarQube Server;
+# when the orchestrator/Vortex are enabled, this secret is also mounted into them, with its path
+# exposed via the SONAR_AGENTIC_SIGNING_SECRET_FILE env var.
+# agenticSigningSecretKey: "agentic-signing-secret"
+
 ## Override JDBC values
 ## for external Databases
 jdbcOverwrite:

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -9,6 +9,7 @@ All changes to this chart will be documented in this file.
 * Add the SonarQube Agent Orchestrator, Hunter Agent and Remediation Agent via `agentOrchestrator.enabled`, `hunterAgent.enabled` and `remediationAgent.enabled`
 * Auto-wire the Hunter Agent's `SCRIPT_PATH` (detection mode) from `hunterAgent.scriptPath`, symmetric with the Remediation Agent's `REMEDIATION_SCRIPT_PATH`
 * Add `agentOrchestrator.env`/`extraVolumes`/`extraVolumeMounts`, and a `agentOrchestrator.storage.type`/`vortex.storage.filesystem.baseDir` FILESYSTEM/NFS backend for the shared agentic job storage
+* Add `agenticSigningSecretKey` to mount an agentic signing secret into SonarQube Server, the Agent Orchestrator, and Vortex, exposing its path via `sonar.agentic.signing.secretFile`/`SONAR_AGENTIC_SIGNING_SECRET_FILE`
 
 ## [2026.4.0]
 * Upgrade Chart's version to 2026.4.0

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -744,6 +744,7 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `sonarProperties`              | Custom `sonar.properties` key-value pairs (e.g., "sonarProperties.sonar.log.level=DEBUG")                                       | `None`           |
 | `sonarSecretProperties`        | Additional `sonar.properties` key-value pairs to load from a secret                                                                      | `None`           |
 | `sonarSecretKey`               | Name of existing secret used for settings encryption                                                                                     | `None`           |
+| `agenticSigningSecretKey`      | Name of existing secret containing the agentic signing secret, shared by SonarQube Server, the Agent Orchestrator, and Vortex to sign/verify agentic requests to each other | `None`           |
 | `monitoringPasscode`           | Value for sonar.web.systemPasscode needed for LivenessProbes                                                                             | `None`           |
 | `monitoringPasscodeSecretName` | Name of the secret where to load `monitoringPasscode`                                                                                    | `None`           |
 | `monitoringPasscodeSecretKey`  | Key of an existing secret containing `monitoringPasscode`                                                                                | `None`           |

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -92,7 +92,7 @@ spec:
       env:
         {{- (include "sonarqube.combined_env" . | fromJsonArray) | toYaml | trim | nindent 8 }}
     {{- end }}
-    {{- if or $hasMergedProps .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
+    {{- if or $hasMergedProps .Values.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
     - name: concat-properties
       image: {{ default (include "sonarqube.image" $) .Values.initContainers.image }}
       imagePullPolicy: {{ .Values.image.pullPolicy  }}
@@ -113,7 +113,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp/result
           name: concat-dir
-        {{- if or $hasMergedProps .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
+        {{- if or $hasMergedProps .Values.sonarSecretKey .Values.agenticSigningSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
         - mountPath: /tmp/props/sonar.properties
           name: config
           subPath: sonar.properties
@@ -364,13 +364,17 @@ spec:
           subPath: logs
         - mountPath: /tmp
           name: tmp-dir
-        {{- if or $hasMergedProps .Values.sonarSecretProperties .Values.sonarSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
+        {{- if or $hasMergedProps .Values.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey (not .Values.elasticsearch.bootstrapChecks) }}
         - mountPath: {{ .Values.sonarqubeFolder }}/conf/
           name: concat-dir
         {{- end }}
         {{- if .Values.sonarSecretKey }}
         - mountPath: {{ .Values.sonarqubeFolder }}/secret/
           name: secret
+        {{- end }}
+        {{- if .Values.agenticSigningSecretKey }}
+        - mountPath: {{ .Values.sonarqubeFolder }}/secret-agentic-signing/
+          name: agentic-signing-secret
         {{- end }}
         {{- if .Values.caCerts.enabled }}
         - mountPath: {{ .Values.sonarqubeFolder }}/certs
@@ -417,7 +421,7 @@ spec:
     {{- with .Values.extraVolumes }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if or $hasMergedProps .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
+    {{- if or $hasMergedProps .Values.sonarSecretKey .Values.agenticSigningSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
     - name: config
       configMap:
         name: {{ include "sonarqube.fullname" . }}-config
@@ -440,6 +444,14 @@ spec:
         items:
         - key: sonar-secret.txt
           path: sonar-secret.txt
+    {{- end }}
+    {{- if .Values.agenticSigningSecretKey }}
+    - name: agentic-signing-secret
+      secret:
+        secretName: {{ .Values.agenticSigningSecretKey }}
+        items:
+        - key: sonar-agentic-signing-secret.txt
+          path: sonar-agentic-signing-secret.txt
     {{- end }}
     {{- include "sonarqube.volumes.caCerts" . | nindent 4 }}
     {{- if .Values.plugins.netrcCreds }}
@@ -517,7 +529,7 @@ spec:
       {{- end }}
     - name : tmp-dir
       emptyDir: {{- toYaml .Values.emptyDir | nindent 8 }}
-      {{- if or $hasMergedProps .Values.sonarSecretProperties .Values.sonarSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
+      {{- if or $hasMergedProps .Values.sonarSecretProperties .Values.sonarSecretKey .Values.agenticSigningSecretKey ( not .Values.elasticsearch.bootstrapChecks) }}
     - name : concat-dir
       emptyDir: {{- toYaml .Values.emptyDir | nindent 8 }}
       {{- end }}

--- a/charts/sonarqube/templates/agent-orchestrator.yaml
+++ b/charts/sonarqube/templates/agent-orchestrator.yaml
@@ -86,6 +86,10 @@ spec:
             - name: AGENTIC_SECRET_KEY_PATH
               value: "/sonarcloud/secret/sonar-secret.txt"
             {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: SONAR_AGENTIC_SIGNING_SECRET_FILE
+              value: "/sonarcloud/secret-agentic-signing/sonar-agentic-signing-secret.txt"
+            {{- end }}
             {{- /* CORE DB (SonarQube's database) connection for the orchestrator. Each field is
                    independently configurable via agentOrchestrator.coreDb, defaulting to
                    the shared jdbcOverwrite so it targets the same DB as SonarQube out of the box.
@@ -172,7 +176,7 @@ spec:
           {{- with .Values.agentOrchestrator.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agentOrchestrator.extraVolumeMounts }}
+          {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agenticSigningSecretKey .Values.agentOrchestrator.extraVolumeMounts }}
           volumeMounts:
             {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
             - name: tmp
@@ -181,6 +185,10 @@ spec:
             {{- if .Values.sonarSecretKey }}
             - name: secret
               mountPath: /sonarcloud/secret/
+            {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: agentic-signing-secret
+              mountPath: /sonarcloud/secret-agentic-signing/
             {{- end }}
             {{- with .Values.agentOrchestrator.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -198,7 +206,7 @@ spec:
 {{ . | indent 6 }}
       {{- end }}
       serviceAccountName: {{ include "sonarqube.agentOrchestrator.serviceAccountName" . }}
-      {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agentOrchestrator.extraVolumes }}
+      {{- if or $orchestratorSecurityContext.readOnlyRootFilesystem .Values.sonarSecretKey .Values.agenticSigningSecretKey .Values.agentOrchestrator.extraVolumes }}
       volumes:
         {{- if $orchestratorSecurityContext.readOnlyRootFilesystem }}
         - name: tmp
@@ -211,6 +219,14 @@ spec:
             items:
             - key: sonar-secret.txt
               path: sonar-secret.txt
+        {{- end }}
+        {{- if .Values.agenticSigningSecretKey }}
+        - name: agentic-signing-secret
+          secret:
+            secretName: {{ .Values.agenticSigningSecretKey }}
+            items:
+            - key: sonar-agentic-signing-secret.txt
+              path: sonar-agentic-signing-secret.txt
         {{- end }}
         {{- with .Values.agentOrchestrator.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/sonarqube/templates/config.yaml
+++ b/charts/sonarqube/templates/config.yaml
@@ -14,3 +14,6 @@ data:
   {{- if .Values.sonarSecretKey }}
     sonar.secretKeyPath={{ .Values.sonarqubeFolder }}/secret/sonar-secret.txt
   {{- end }}
+  {{- if .Values.agenticSigningSecretKey }}
+    sonar.agentic.signing.secretFile={{ .Values.sonarqubeFolder }}/secret-agentic-signing/sonar-agentic-signing-secret.txt
+  {{- end }}

--- a/charts/sonarqube/templates/vortex.yaml
+++ b/charts/sonarqube/templates/vortex.yaml
@@ -81,6 +81,10 @@ spec:
                   name: {{ default (include "sonarqube.vortex.fullname" .) $vortex.storage.existingSecret }}
                   key: SONAR_AGENTIC_STORAGE_SECRET_KEY
             {{- end }}
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: SONAR_AGENTIC_SIGNING_SECRET_FILE
+              value: "/etc/sonar-agentic-signing/sonar-agentic-signing-secret.txt"
+            {{- end }}
             {{- with $vortex.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -103,15 +107,32 @@ spec:
               path: /health
               port: http
             periodSeconds: 30
-          {{- with $vortex.extraVolumeMounts }}
+          {{- if or $vortex.extraVolumeMounts .Values.agenticSigningSecretKey }}
           volumeMounts:
+            {{- if .Values.agenticSigningSecretKey }}
+            - name: agentic-signing-secret
+              mountPath: /etc/sonar-agentic-signing/
+              readOnly: true
+            {{- end }}
+            {{- with $vortex.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
       {{- with (include "sonarqube.agent.scheduling" (dict "ctx" . "component" $vortex)) }}
 {{ . | indent 6 }}
       {{- end }}
-      {{- with $vortex.extraVolumes }}
+      {{- if or $vortex.extraVolumes .Values.agenticSigningSecretKey }}
       volumes:
+        {{- if .Values.agenticSigningSecretKey }}
+        - name: agentic-signing-secret
+          secret:
+            secretName: {{ .Values.agenticSigningSecretKey }}
+            items:
+            - key: sonar-agentic-signing-secret.txt
+              path: sonar-agentic-signing-secret.txt
+        {{- end }}
+        {{- with $vortex.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -518,6 +518,14 @@ emptyDir:
 # path exposed via the AGENTIC_SECRET_KEY_PATH env var.
 # sonarSecretKey: "settings-encryption-secret"
 
+# Kubernetes secret containing the agentic signing secret, shared by SonarQube Server, the Agent
+# Orchestrator, and Vortex to sign/verify agentic requests to each other.
+# The secret must contain the key 'sonar-agentic-signing-secret.txt'.
+# The 'sonar.agentic.signing.secretFile' property will be set automatically on SonarQube Server;
+# when the orchestrator/Vortex are enabled, this secret is also mounted into them, with its path
+# exposed via the SONAR_AGENTIC_SIGNING_SECRET_FILE env var.
+# agenticSigningSecretKey: "agentic-signing-secret"
+
 ## Override JDBC values
 ## for external Databases
 jdbcOverwrite:

--- a/tests/unit-test/agent_orchestrator_test.go
+++ b/tests/unit-test/agent_orchestrator_test.go
@@ -275,6 +275,75 @@ func TestAgentOrchestratorEncryptionKeyMount(t *testing.T) {
 	}
 }
 
+// When the agentic signing secret (.Values.agenticSigningSecretKey) is set, it must be mounted
+// into the orchestrator, with its path exposed via SONAR_AGENTIC_SIGNING_SECRET_FILE (SONAR-32028).
+// It uses its own volume/mount, distinct from the sonarSecretKey one.
+func TestAgentOrchestratorSigningSecretMount(t *testing.T) {
+	for _, chart := range agentCharts {
+		t.Run(chart.name, func(t *testing.T) {
+			t.Run("unset renders no signing secret env var, volume, or volumeMount", func(t *testing.T) {
+				deployment := renderAgentOrchestrator(t, chart, nil)
+				container := deployment.Spec.Template.Spec.Containers[0]
+				assert.Nil(t, findEnvByName(container, "SONAR_AGENTIC_SIGNING_SECRET_FILE"))
+				assert.Nil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+				assert.Nil(t, findVolumeByName(deployment.Spec.Template.Spec.Volumes, "agentic-signing-secret"))
+			})
+
+			t.Run("set mounts the secret and exposes its path", func(t *testing.T) {
+				deployment := renderAgentOrchestrator(t, chart, map[string]string{
+					"agenticSigningSecretKey": "agentic-signing-secret",
+				})
+				podSpec := deployment.Spec.Template.Spec
+				container := podSpec.Containers[0]
+
+				env := findEnvByName(container, "SONAR_AGENTIC_SIGNING_SECRET_FILE")
+				require.NotNil(t, env)
+				assert.Equal(t, "/sonarcloud/secret-agentic-signing/sonar-agentic-signing-secret.txt", env.Value)
+
+				volumeMount := findVolumeMountByName(container, "agentic-signing-secret")
+				require.NotNil(t, volumeMount)
+				assert.Equal(t, "/sonarcloud/secret-agentic-signing/", volumeMount.MountPath)
+
+				volume := findVolumeByName(podSpec.Volumes, "agentic-signing-secret")
+				require.NotNil(t, volume)
+				require.NotNil(t, volume.Secret)
+				assert.Equal(t, "agentic-signing-secret", volume.Secret.SecretName)
+				require.Len(t, volume.Secret.Items, 1)
+				assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Key)
+				assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Path)
+			})
+
+			t.Run("set still mounts the secret without readOnlyRootFilesystem", func(t *testing.T) {
+				deployment := renderAgentOrchestrator(t, chart, map[string]string{
+					"agenticSigningSecretKey": "agentic-signing-secret",
+					"agentOrchestrator.containerSecurityContext.readOnlyRootFilesystem": "false",
+				})
+				podSpec := deployment.Spec.Template.Spec
+				container := podSpec.Containers[0]
+
+				assert.NotNil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+				assert.NotNil(t, findVolumeByName(podSpec.Volumes, "agentic-signing-secret"))
+				assert.Nil(t, findVolumeMountByName(container, "tmp"))
+				assert.Nil(t, findVolumeByName(podSpec.Volumes, "tmp"))
+			})
+
+			t.Run("both secrets can be mounted together without collision", func(t *testing.T) {
+				deployment := renderAgentOrchestrator(t, chart, map[string]string{
+					"sonarSecretKey":          "settings-encryption-secret",
+					"agenticSigningSecretKey": "agentic-signing-secret",
+				})
+				podSpec := deployment.Spec.Template.Spec
+				container := podSpec.Containers[0]
+
+				assert.NotNil(t, findVolumeMountByName(container, "secret"))
+				assert.NotNil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+				assert.NotNil(t, findVolumeByName(podSpec.Volumes, "secret"))
+				assert.NotNil(t, findVolumeByName(podSpec.Volumes, "agentic-signing-secret"))
+			})
+		})
+	}
+}
+
 func agentOrchestratorPullSecretNames(deployment appsv1.Deployment) []string {
 	var names []string
 	for _, s := range deployment.Spec.Template.Spec.ImagePullSecrets {

--- a/tests/unit-test/agent_sonar_properties_test.go
+++ b/tests/unit-test/agent_sonar_properties_test.go
@@ -21,23 +21,20 @@ const (
 	hunterOrchestratorURLProperty      = "sonar.hunteragent.orchestrator.url"
 	remediationOrchestratorURLProperty = "sonar.remediationagent.orchestrator.url"
 	vortexAnalysisURLProperty          = "sonar.vortex.analysis.url"
+	agenticSigningSecretFileProperty   = "sonar.agentic.signing.secretFile"
 )
 
-// appSonarProperties renders templates/config.yaml and parses the conf/sonar.properties body of the
-// application nodes' ConfigMap into key/value pairs.
-func appSonarProperties(t *testing.T, chart agentChart, opts *helm.Options) map[string]string {
+// sonarPropertiesFromConfigMap parses the conf/sonar.properties body of the ConfigMap named
+// configMapName out of a rendered templates/config.yaml output into key/value pairs.
+func sonarPropertiesFromConfigMap(t *testing.T, output string, configMapName string) map[string]string {
 	t.Helper()
-	output, err := helm.RenderTemplateE(t, opts, chart.path, chart.release, []string{"templates/config.yaml"})
-	require.NoError(t, err)
-
-	want := chart.fullnamePrefix() + chart.appConfigMapSuffix
 	for _, doc := range strings.Split(output, "\n---") {
 		if strings.TrimSpace(doc) == "" {
 			continue
 		}
 		var cm corev1.ConfigMap
 		helm.UnmarshalK8SYaml(t, doc, &cm)
-		if cm.Name != want {
+		if cm.Name != configMapName {
 			continue
 		}
 		props := map[string]string{}
@@ -49,8 +46,17 @@ func appSonarProperties(t *testing.T, chart agentChart, opts *helm.Options) map[
 		return props
 	}
 
-	t.Fatalf("templates/config.yaml rendered no ConfigMap named %q", want)
+	t.Fatalf("templates/config.yaml rendered no ConfigMap named %q", configMapName)
 	return nil
+}
+
+// appSonarProperties renders templates/config.yaml and parses the conf/sonar.properties body of the
+// application nodes' ConfigMap into key/value pairs.
+func appSonarProperties(t *testing.T, chart agentChart, opts *helm.Options) map[string]string {
+	t.Helper()
+	output, err := helm.RenderTemplateE(t, opts, chart.path, chart.release, []string{"templates/config.yaml"})
+	require.NoError(t, err)
+	return sonarPropertiesFromConfigMap(t, output, chart.fullnamePrefix()+chart.appConfigMapSuffix)
 }
 
 func agentPropertiesOptions(chart agentChart, fixture string, setValues map[string]string) *helm.Options {
@@ -117,4 +123,52 @@ func TestUserSonarPropertiesOverrideAgentUrls(t *testing.T) {
 			assert.Equal(t, chart.orchestratorURL(), props[remediationOrchestratorURLProperty])
 		})
 	}
+}
+
+// The agentic signing secret (.Values.agenticSigningSecretKey) follows the same sonar.properties-file
+// pattern as sonarSecretKey (SONAR-31416): a SONAR_* env var override is silently ignored unless the
+// property already has a properties-file line, so sonar.agentic.signing.secretFile must be written
+// here too rather than only exposed as an env var (SONAR-32028). It must reach every node that reads
+// conf/sonar.properties directly - the single ConfigMap in sonarqube, and both the app and search
+// ConfigMaps in sonarqube-dce.
+func TestAgenticSigningSecretFileInSonarProperties(t *testing.T) {
+	for _, chart := range agentCharts {
+		t.Run(chart.name, func(t *testing.T) {
+			t.Run("unset renders no property", func(t *testing.T) {
+				props := appSonarProperties(t, chart, agentPropertiesOptions(chart, "agent-all-disabled.yaml", nil))
+				assert.NotContains(t, props, agenticSigningSecretFileProperty)
+			})
+
+			t.Run("set renders the property pointing at the mounted file", func(t *testing.T) {
+				props := appSonarProperties(t, chart, agentPropertiesOptions(chart, "agent-all-disabled.yaml", map[string]string{
+					"agenticSigningSecretKey": "agentic-signing-secret",
+				}))
+				assert.Equal(t, "/opt/sonarqube/secret-agentic-signing/sonar-agentic-signing-secret.txt", props[agenticSigningSecretFileProperty])
+			})
+		})
+	}
+
+	t.Run("sonarqube-dce search-config", func(t *testing.T) {
+		dce := agentCharts[0]
+		require.Equal(t, "sonarqube-dce", dce.name)
+		searchConfigMap := dce.fullnamePrefix() + "-search-config"
+
+		t.Run("unset renders no property", func(t *testing.T) {
+			opts := agentPropertiesOptions(dce, "agent-all-disabled.yaml", nil)
+			output, err := helm.RenderTemplateE(t, opts, dce.path, dce.release, []string{"templates/config.yaml"})
+			require.NoError(t, err)
+			props := sonarPropertiesFromConfigMap(t, output, searchConfigMap)
+			assert.NotContains(t, props, agenticSigningSecretFileProperty)
+		})
+
+		t.Run("set renders the property pointing at the mounted file", func(t *testing.T) {
+			opts := agentPropertiesOptions(dce, "agent-all-disabled.yaml", map[string]string{
+				"agenticSigningSecretKey": "agentic-signing-secret",
+			})
+			output, err := helm.RenderTemplateE(t, opts, dce.path, dce.release, []string{"templates/config.yaml"})
+			require.NoError(t, err)
+			props := sonarPropertiesFromConfigMap(t, output, searchConfigMap)
+			assert.Equal(t, "/opt/sonarqube/secret-agentic-signing/sonar-agentic-signing-secret.txt", props[agenticSigningSecretFileProperty])
+		})
+	})
 }

--- a/tests/unit-test/sonarqube_dce_schema_test.go
+++ b/tests/unit-test/sonarqube_dce_schema_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
@@ -91,4 +92,75 @@ func TestApplicationNodeExtraInitContainers(t *testing.T) {
 	rendered := renderDCEAppTemplate(t, "test-cases-values/sonarqube-dce/test-app-extra-init-containers.yaml", dceHelmOptions)
 	container := findInitContainerByName(rendered.Spec.Template.Spec.InitContainers, "extra-app-init")
 	assert.NotNil(t, container, "Expected 'extra-app-init' init container to be present in application pod")
+}
+
+// When the agentic signing secret (.Values.agenticSigningSecretKey) is set, it must be mounted
+// into the search node, using its own volume/mount distinct from the sonarSecretKey one, mirroring
+// that mount's own readOnly: true (SONAR-32028).
+func TestSearchNodeSigningSecretMount(t *testing.T) {
+	t.Run("unset renders no signing secret volume or volumeMount", func(t *testing.T) {
+		dceHelmOptions := &helm.Options{Logger: logger.Discard}
+		rendered := renderDCESearchTemplate(t, "test-cases-values/sonarqube-dce/agent-all-disabled.yaml", dceHelmOptions)
+		container := rendered.Spec.Template.Spec.Containers[0]
+		assert.Nil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+		assert.Nil(t, findVolumeByName(rendered.Spec.Template.Spec.Volumes, "agentic-signing-secret"))
+	})
+
+	t.Run("set mounts the secret read-only", func(t *testing.T) {
+		dceHelmOptions := &helm.Options{
+			Logger:    logger.Discard,
+			SetValues: map[string]string{"agenticSigningSecretKey": "agentic-signing-secret"},
+		}
+		rendered := renderDCESearchTemplate(t, "test-cases-values/sonarqube-dce/agent-all-disabled.yaml", dceHelmOptions)
+		podSpec := rendered.Spec.Template.Spec
+		container := podSpec.Containers[0]
+
+		volumeMount := findVolumeMountByName(container, "agentic-signing-secret")
+		require.NotNil(t, volumeMount)
+		assert.Equal(t, "/opt/sonarqube/secret-agentic-signing/", volumeMount.MountPath)
+		assert.True(t, volumeMount.ReadOnly)
+
+		volume := findVolumeByName(podSpec.Volumes, "agentic-signing-secret")
+		require.NotNil(t, volume)
+		require.NotNil(t, volume.Secret)
+		assert.Equal(t, "agentic-signing-secret", volume.Secret.SecretName)
+		require.Len(t, volume.Secret.Items, 1)
+		assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Key)
+		assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Path)
+	})
+}
+
+// Same as TestSearchNodeSigningSecretMount, but for the application node, which mirrors its own
+// sonarSecretKey mount by NOT setting readOnly (SONAR-32028).
+func TestApplicationNodeSigningSecretMount(t *testing.T) {
+	t.Run("unset renders no signing secret volume or volumeMount", func(t *testing.T) {
+		dceHelmOptions := &helm.Options{Logger: logger.Discard}
+		rendered := renderDCEAppTemplate(t, "test-cases-values/sonarqube-dce/agent-all-disabled.yaml", dceHelmOptions)
+		container := rendered.Spec.Template.Spec.Containers[0]
+		assert.Nil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+		assert.Nil(t, findVolumeByName(rendered.Spec.Template.Spec.Volumes, "agentic-signing-secret"))
+	})
+
+	t.Run("set mounts the secret", func(t *testing.T) {
+		dceHelmOptions := &helm.Options{
+			Logger:    logger.Discard,
+			SetValues: map[string]string{"agenticSigningSecretKey": "agentic-signing-secret"},
+		}
+		rendered := renderDCEAppTemplate(t, "test-cases-values/sonarqube-dce/agent-all-disabled.yaml", dceHelmOptions)
+		podSpec := rendered.Spec.Template.Spec
+		container := podSpec.Containers[0]
+
+		volumeMount := findVolumeMountByName(container, "agentic-signing-secret")
+		require.NotNil(t, volumeMount)
+		assert.Equal(t, "/opt/sonarqube/secret-agentic-signing/", volumeMount.MountPath)
+		assert.False(t, volumeMount.ReadOnly)
+
+		volume := findVolumeByName(podSpec.Volumes, "agentic-signing-secret")
+		require.NotNil(t, volume)
+		require.NotNil(t, volume.Secret)
+		assert.Equal(t, "agentic-signing-secret", volume.Secret.SecretName)
+		require.Len(t, volume.Secret.Items, 1)
+		assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Key)
+		assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Path)
+	})
 }

--- a/tests/unit-test/sonarqube_schema_test.go
+++ b/tests/unit-test/sonarqube_schema_test.go
@@ -9,6 +9,7 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
@@ -183,4 +184,36 @@ func TestPersistenceWithoutHostpath(t *testing.T) {
 	assert.NotNil(t, volume, "Volume 'sonarqube' should exist but was not found")
 	assert.Nil(t, volume.HostPath, "sonarqube volume should NOT have a HostPath source")
 	assert.Equal(t, "sonarqube-sonarqube", volume.PersistentVolumeClaim.ClaimName)
+}
+
+// When the agentic signing secret (.Values.agenticSigningSecretKey) is set, it must be mounted
+// into the main SonarQube pod, using its own volume/mount distinct from the sonarSecretKey one
+// (SONAR-32028).
+func TestMainPodSigningSecretMount(t *testing.T) {
+	t.Run("unset renders no signing secret volume or volumeMount", func(t *testing.T) {
+		rendered := renderSQStsTemplate(t, "test-cases-values/sonarqube/agent-all-disabled.yaml", newSQHelmOptions())
+		container := rendered.Spec.Template.Spec.Containers[0]
+		assert.Nil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+		assert.Nil(t, findVolumeByName(rendered.Spec.Template.Spec.Volumes, "agentic-signing-secret"))
+	})
+
+	t.Run("set mounts the secret", func(t *testing.T) {
+		opts := newSQHelmOptions()
+		opts.SetValues["agenticSigningSecretKey"] = "agentic-signing-secret"
+		rendered := renderSQStsTemplate(t, "test-cases-values/sonarqube/agent-all-disabled.yaml", opts)
+		podSpec := rendered.Spec.Template.Spec
+		container := podSpec.Containers[0]
+
+		volumeMount := findVolumeMountByName(container, "agentic-signing-secret")
+		require.NotNil(t, volumeMount)
+		assert.Equal(t, "/opt/sonarqube/secret-agentic-signing/", volumeMount.MountPath)
+
+		volume := findVolumeByName(podSpec.Volumes, "agentic-signing-secret")
+		require.NotNil(t, volume)
+		require.NotNil(t, volume.Secret)
+		assert.Equal(t, "agentic-signing-secret", volume.Secret.SecretName)
+		require.Len(t, volume.Secret.Items, 1)
+		assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Key)
+		assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Path)
+	})
 }

--- a/tests/unit-test/vortex_test.go
+++ b/tests/unit-test/vortex_test.go
@@ -66,6 +66,22 @@ func vortexContainerEnv(container corev1.Container) map[string]corev1.EnvVar {
 	return env
 }
 
+func vortexDeploymentWithValues(t *testing.T, chart agentChart, fixture string, setValues map[string]string) appsv1.Deployment {
+	t.Helper()
+	opts := &helm.Options{
+		Logger:      logger.Discard,
+		ValuesFiles: []string{chart.valuesDir + "/" + fixture},
+		SetValues:   setValues,
+	}
+	output, err := helm.RenderTemplateE(t, opts, chart.path, chart.release, []string{"templates/vortex.yaml"})
+	require.NoError(t, err)
+
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, output, &deployment)
+	require.NotEmpty(t, deployment.Name, "no Deployment rendered by templates/vortex.yaml")
+	return deployment
+}
+
 // Off by default, so an existing install picks up nothing new until vortex.enabled is set.
 func TestVortexDisabledByDefault(t *testing.T) {
 	for _, chart := range agentCharts {
@@ -242,6 +258,69 @@ func TestVortexStorageExistingSecret(t *testing.T) {
 			output, err := renderVortex(t, chart, "vortex-storage-existing-secret.yaml", "templates/vortex-secret.yaml")
 			require.Error(t, err, "no Secret may be rendered when both the token and the storage credentials come from an existingSecret")
 			assert.Empty(t, strings.TrimSpace(output))
+		})
+	}
+}
+
+// When the agentic signing secret (.Values.agenticSigningSecretKey) is set, it must be mounted
+// into Vortex too, with its path exposed via SONAR_AGENTIC_SIGNING_SECRET_FILE (SONAR-32028).
+// Vortex has no image-intrinsic base path convention, so it uses a dedicated, convention-free
+// mount point rather than the orchestrator's /sonarcloud one.
+func TestVortexSigningSecretMount(t *testing.T) {
+	for _, chart := range agentCharts {
+		t.Run(chart.name, func(t *testing.T) {
+			t.Run("unset renders no signing secret env var, volume, or volumeMount", func(t *testing.T) {
+				deployment := vortexDeployment(t, chart, "vortex-enabled.yaml")
+				container := deployment.Spec.Template.Spec.Containers[0]
+				env := vortexContainerEnv(container)
+
+				_, hasEnv := env["SONAR_AGENTIC_SIGNING_SECRET_FILE"]
+				assert.False(t, hasEnv)
+				assert.Nil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+				assert.Nil(t, findVolumeByName(deployment.Spec.Template.Spec.Volumes, "agentic-signing-secret"))
+			})
+
+			t.Run("set mounts the secret and exposes its path", func(t *testing.T) {
+				deployment := vortexDeploymentWithValues(t, chart, "vortex-enabled.yaml", map[string]string{
+					"agenticSigningSecretKey": "agentic-signing-secret",
+				})
+				podSpec := deployment.Spec.Template.Spec
+				container := podSpec.Containers[0]
+				env := vortexContainerEnv(container)
+
+				require.Contains(t, env, "SONAR_AGENTIC_SIGNING_SECRET_FILE")
+				assert.Equal(t, "/etc/sonar-agentic-signing/sonar-agentic-signing-secret.txt", env["SONAR_AGENTIC_SIGNING_SECRET_FILE"].Value)
+
+				volumeMount := findVolumeMountByName(container, "agentic-signing-secret")
+				require.NotNil(t, volumeMount)
+				assert.Equal(t, "/etc/sonar-agentic-signing/", volumeMount.MountPath)
+				assert.True(t, volumeMount.ReadOnly)
+
+				volume := findVolumeByName(podSpec.Volumes, "agentic-signing-secret")
+				require.NotNil(t, volume)
+				require.NotNil(t, volume.Secret)
+				assert.Equal(t, "agentic-signing-secret", volume.Secret.SecretName)
+				require.Len(t, volume.Secret.Items, 1)
+				assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Key)
+				assert.Equal(t, "sonar-agentic-signing-secret.txt", volume.Secret.Items[0].Path)
+			})
+
+			t.Run("set still renders alongside user-supplied extraVolumeMounts/extraVolumes", func(t *testing.T) {
+				deployment := vortexDeploymentWithValues(t, chart, "vortex-enabled.yaml", map[string]string{
+					"agenticSigningSecretKey":                "agentic-signing-secret",
+					"vortex.extraVolumeMounts[0].name":       "custom-volume",
+					"vortex.extraVolumeMounts[0].mountPath":  "/custom",
+					"vortex.extraVolumes[0].name":            "custom-volume",
+					"vortex.extraVolumes[0].emptyDir.medium": "",
+				})
+				podSpec := deployment.Spec.Template.Spec
+				container := podSpec.Containers[0]
+
+				assert.NotNil(t, findVolumeMountByName(container, "agentic-signing-secret"))
+				assert.NotNil(t, findVolumeMountByName(container, "custom-volume"))
+				assert.NotNil(t, findVolumeByName(podSpec.Volumes, "agentic-signing-secret"))
+				assert.NotNil(t, findVolumeByName(podSpec.Volumes, "custom-volume"))
+			})
 		})
 	}
 }


### PR DESCRIPTION
Part of EA-523

Mounts a new, distinct agentic signing secret (`agenticSigningSecretKey`) into SonarQube Server, the Agent Orchestrator, and Vortex, so they can sign/verify agentic requests to each other.

- SonarQube Server/search/application nodes: writes `sonar.agentic.signing.secretFile=<path>` directly into rendered `conf/sonar.properties`, mirroring the existing `sonarSecretKey`/`sonar.secretKeyPath` pattern (SONAR-31746).
- Agent Orchestrator and Vortex: exposes the mounted path via `SONAR_AGENTIC_SIGNING_SECRET_FILE`, relying on Spring relaxed binding onto the same `sonar.agentic.signing.secretFile` property.
- Uses its own volume (`agentic-signing-secret`) and directory (`secret-agentic-signing/`), distinct from the existing `sonarSecretKey`/`secret` mount, so both can coexist without collision.
- Applied to both `charts/sonarqube` and `charts/sonarqube-dce`.

## Test plan
- [x] `go test ./...` passes in `tests/unit-test/`, including new coverage for the orchestrator, Vortex, and pod/node mounts
- [x] `helm template` verified for both charts with the value set/unset, confirming correct conditional rendering and no collision with the existing `sonarSecretKey` mount
- [x] CHANGELOG.md and README.md updated for both charts