### PR TITLE
SPE-3255 Upgrade ci-github-actions to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,7 +264,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
+      - uses: SonarSource/ci-github-actions/get-build-number@v2
         id: build-number
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3
@@ -317,7 +317,7 @@ jobs:
         with:
           cache_save: false
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
+      - uses: SonarSource/ci-github-actions/get-build-number@v2
         id: build-number
       - name: Download ${{ matrix.chart }} chart artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -342,10 +342,10 @@ jobs:
     runs-on: github-ubuntu-latest-s
     name: Output Build Number
     permissions:
-      contents: read
+      contents: write # required by ci-github-actions/get-build-number@v2 (atomic build-number claim)
     if: ${{ github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) }}
     steps:
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
+      - uses: SonarSource/ci-github-actions/get-build-number@v2
         id: build-number
       - name: Download SonarQube chart artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -9,4 +9,4 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: SonarSource/ci-github-actions/pr_cleanup@v1
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v2


### PR DESCRIPTION
## What

Upgrade all `SonarSource/ci-github-actions/*` references from `@v1` to `@v2`.

`ci-github-actions 2.0.0` fixes a race in `get-build-number`: concurrent runs (e.g. several GitHub Stacked PRs) could be assigned the same build number. Claiming a number now uses an atomic Git-ref compare-and-swap.

## What was done

`get-build-number` (and `config-maven`/`config-pip`/`config-uv`, which call it internally) now require `contents: write` instead of `contents: read`.

Ref: SPE-3255 · https://discuss.sonarsource.com/t/update-ci-github-actions-2-0-0-atomic-build-number-claiming-fixes-a-real-race-under-github-stacked-prs/24373

### Permissions fix
- `build.yml` — `output-build-number` job changed from `contents: read` to `contents: write` (calls `get-build-number@v2`). The `sonarqube-packaging` and `sonarqube-push-to-repox` jobs already had `contents: write`.

### Files
build.yml (get-build-number ×3), pr-cleanup.yml (pr_cleanup).