### PR TITLE
Make agentic runtimes compatible with Istio sidecar injection

### DIFF
--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -1037,6 +1037,26 @@ Usage: {{ include "sonarqube.agent.dnsEgressRule" $ | indent 4 }}
 {{- end -}}
 
 {{/*
+The egress rule letting a pod's own injected Istio sidecar reach istiod's control plane (xDS, port
+15012). Callers must gate inclusion behind .Values.istio.enabled themselves - unlike
+sonarqube.agent.dnsEgressRule this isn't unconditional, since most deployments don't run Istio.
+Output is unindented; callers should pipe through `indent`/`nindent` to place it under `egress:`.
+Usage: {{ include "sonarqube.agent.istiodEgressRule" $ | indent 4 }}
+*/}}
+{{- define "sonarqube.agent.istiodEgressRule" -}}
+- to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Values.istio.namespace }}
+      podSelector:
+        matchLabels:
+          app: istiod
+  ports:
+    - port: 15012
+      protocol: TCP
+{{- end -}}
+
+{{/*
 Parse the host:port endpoint out of jdbcOverwrite.jdbcUrl (jdbc:postgresql://host:port/db[?params]),
 for the Agent Orchestrator's CORE_DB_READ_WRITE_ENDPOINT env, since it reuses SonarQube's own DB.
 */}}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -1214,7 +1214,7 @@ Usage: {{- with (include "sonarqube.agent.egressProxy.probe" .Values.agentEgress
 */}}
 {{- define "sonarqube.agent.egressProxy.probe" -}}
 tcpSocket:
-  port: http-proxy
+  port: tcp-proxy
 {{- with .periodSeconds }}
 periodSeconds: {{ . }}
 {{- end }}

--- a/charts/sonarqube/templates/agent-egress-proxy-networkpolicy.yaml
+++ b/charts/sonarqube/templates/agent-egress-proxy-networkpolicy.yaml
@@ -25,6 +25,9 @@ spec:
           protocol: TCP
   egress:
 {{ include "sonarqube.agent.dnsEgressRule" . | indent 4 }}
+    {{- if .Values.istio.enabled }}
+{{ include "sonarqube.agent.istiodEgressRule" . | indent 4 }}
+    {{- end }}
     {{- /* Backs the hardcoded sonarqube_host allow rule in agent-egress-proxy-configmap.yaml,
            which must stay reachable unconditionally - so this rule is not gated behind
            networkPolicy.egressPorts, unlike the allowedDomains rule below. */}}

--- a/charts/sonarqube/templates/agent-egress-proxy-service.yaml
+++ b/charts/sonarqube/templates/agent-egress-proxy-service.yaml
@@ -14,8 +14,8 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.agentEgressProxy.port }}
-      targetPort: http-proxy
+      targetPort: tcp-proxy
       protocol: TCP
-      name: http-proxy
+      name: tcp-proxy
   selector: {{- include "sonarqube.agentEgressProxy.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/sonarqube/templates/agent-egress-proxy.yaml
+++ b/charts/sonarqube/templates/agent-egress-proxy.yaml
@@ -61,7 +61,12 @@ spec:
           {{- end }}
           command: ["squid", "-N", "-f", "/etc/squid/squid.conf"]
           ports:
-            - name: http-proxy
+            {{- /* Named tcp-proxy, not http-proxy: Istio's sidecar infers L7 protocol from the
+                   port name, and an "http"-prefixed name makes it apply HTTP Connection Manager
+                   processing to this port - which doesn't know how to pass through Squid's
+                   CONNECT-tunneled HTTPS traffic and rejects it with a 404. A "tcp"-prefixed name
+                   keeps Istio treating this port as opaque TCP passthrough. */}}
+            - name: tcp-proxy
               containerPort: {{ .Values.agentEgressProxy.port }}
               protocol: TCP
           {{- with .Values.agentEgressProxy.env }}

--- a/charts/sonarqube/templates/agent-networkpolicy.yaml
+++ b/charts/sonarqube/templates/agent-networkpolicy.yaml
@@ -28,6 +28,11 @@ spec:
           protocol: TCP
   egress:
 {{ include "sonarqube.agent.dnsEgressRule" $ | indent 4 }}
+    {{- /* Only when this family actually gets a sidecar: under gVisor it's excluded from
+           injection entirely (see agent-runtime.yaml) and so never needs to reach istiod. */}}
+    {{- if and $.Values.istio.enabled (ne (include "sonarqube.gvisor.enabled" $) "true") }}
+{{ include "sonarqube.agent.istiodEgressRule" $ | indent 4 }}
+    {{- end }}
     {{- /* All other runtime egress - including reaching the orchestrator and reading/writing job
            artifacts against object storage via presigned URLs - transits the Agent Egress Proxy.
            There is no direct-to-orchestrator or direct-to-storage rule here: the proxy's own

--- a/charts/sonarqube/templates/agent-runtime.yaml
+++ b/charts/sonarqube/templates/agent-runtime.yaml
@@ -25,9 +25,18 @@ spec:
     matchLabels: {{- include "sonarqube.agentRuntime.selectorLabels" (dict "ctx" $ "family" $family) | nindent 6 }}
   template:
     metadata:
-      {{- with $cfg.annotations }}
+      {{- $gvisorEnabled := eq (include "sonarqube.gvisor.enabled" $) "true" }}
+      {{- if or $cfg.annotations $gvisorEnabled }}
       annotations:
+        {{- with $cfg.annotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if $gvisorEnabled }}
+        {{- /* Istio's iptables-based istio-init container needs NET_ADMIN/raw sockets, which
+               gVisor's runsc runtime does not support - its sidecar would permanently
+               CrashLoopBackOff. Opt these pods out of injection rather than mesh membership. */}}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
       {{- end }}
       labels:
         {{- include "sonarqube.agentRuntime.selectorLabels" (dict "ctx" $ "family" $family) | nindent 8 }}

--- a/charts/sonarqube/templates/peerauthentication.yaml
+++ b/charts/sonarqube/templates/peerauthentication.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.istio.enabled }}
+{{- /* The mesh's own PERMISSIVE default lets any plaintext caller reach these pods, which defeats
+       the point of being in the mesh at all - so require mTLS explicitly for every workload this
+       chart owns, scoped per-workload rather than as a namespace-wide default so other release(s)
+       sharing the namespace (postgresql, gvisor-installer, ...) aren't affected. */}}
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "sonarqube.selectorLabels" . | nindent 6 }}
+  mtls:
+    mode: STRICT
+{{- if .Values.agentOrchestrator.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.agentOrchestrator.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "sonarqube.agentOrchestrator.selectorLabels" . | nindent 6 }}
+  mtls:
+    mode: STRICT
+{{- end }}
+{{- if .Values.mcp.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.mcp.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "sonarqube.name" . }}-mcp
+      release: {{ .Release.Name }}
+  mtls:
+    mode: STRICT
+{{- end }}
+{{- if .Values.vortex.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.vortex.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "sonarqube.name" . }}-vortex
+      release: {{ .Release.Name }}
+  mtls:
+    mode: STRICT
+{{- end }}
+{{- if include "sonarqube.agentEgressProxy.required" . }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.agentEgressProxy.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "sonarqube.agentEgressProxy.selectorLabels" . | nindent 6 }}
+  mtls:
+    mode: STRICT
+  {{- /* hunter/remediation run under gVisor and are therefore excluded from sidecar injection
+         entirely (see agent-runtime.yaml) - they can never present a client cert, so their only
+         ingress point into the mesh has to stay reachable in plaintext on its own port. */}}
+  portLevelMtls:
+    {{ .Values.agentEgressProxy.port | quote }}:
+      mode: PERMISSIVE
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/values.schema.json
+++ b/charts/sonarqube/values.schema.json
@@ -29,6 +29,17 @@
                 }
             }
         },
+        "istio": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
         "OpenShift": {
             "type": "object",
             "properties": {

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -133,6 +133,16 @@ networkPolicy:
   # expects https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicyspec-v1-networking-k8s-io
   # additionalNetworkPolicies:
 
+# Set enabled to true when this namespace has Istio sidecar injection turned on (e.g. the
+# istio-injection=enabled namespace label). The agent NetworkPolicies (agentEgressProxy.networkPolicy,
+# agentOrchestrator's hunter/remediation runtime networkPolicy) are explicit egress allow-lists, so
+# without this a pod's own injected sidecar can never reach istiod's control plane and the pod stays
+# NotReady forever. Has no effect on any NetworkPolicy left at its default enabled: false.
+istio:
+  enabled: false
+  # Namespace istiod runs in.
+  namespace: "istio-system"
+
 # will be used as default for ingress/httproute path and probes path, will be injected in .Values.env as SONAR_WEB_CONTEXT
 # if .Values.env.SONAR_WEB_CONTEXT is set, this value will be ignored
 sonarWebContext: ""


### PR DESCRIPTION
## Summary
- Exclude gVisor-scheduled agent runtimes (hunter/remediation) from Istio sidecar injection, since `istio-init`'s iptables setup isn't supported under `runsc`; add `istio.enabled`/`istio.namespace` values and istiod egress rules for every other sidecar-equipped agent pod
- Enforce STRICT mTLS via `PeerAuthentication` for every chart-owned mesh workload (sonarqube, agent-orchestrator, mcp, vortex, agent-egress-proxy), with a `portLevelMtls` PERMISSIVE exception on the egress proxy's port since gVisor-excluded pods can't present a client cert
- Rename the egress proxy's container/service port from `http-proxy` to `tcp-proxy` so Istio treats it as opaque TCP passthrough instead of misapplying HTTP processing to Squid's CONNECT-tunneled traffic

## Setting up Istio

Two things are required, one outside the chart and one in it:

1. **Enable sidecar injection on the namespace** the release is installed into (e.g. label it `istio-injection=enabled`, or the revision-based equivalent). This is Istio's own mechanism and isn't managed by the chart.
2. **Set `istio.enabled: true`** in the chart values (`istio.namespace` defaults to `istio-system`; override it if istiod runs elsewhere). This flag is what makes the chart's own resources Istio-aware:
   - adds an istiod egress rule (port `15012`) to every agent NetworkPolicy, which are otherwise closed allow-lists that would leave an injected sidecar unable to reach the control plane
   - renders the `PeerAuthentication` resources that enforce STRICT mTLS per chart-owned workload

With both set, Istio's mutating webhook injects a sidecar into every pod the chart creates, except the ones explicitly excluded below.

## Excluded components

**hunter and remediation agent runtimes** are excluded from sidecar injection, via a `sidecar.istio.io/inject: "false"` pod annotation applied only when they are gVisor-scheduled (`gvisor.enabled: true` alongside `hunterAgent.enabled`/`remediationAgent.enabled`). Every other chart-owned workload (sonarqube, agent-orchestrator, mcp, vortex, agent-egress-proxy) is injected normally and covered by STRICT mTLS.

**Why gVisor rejects the sidecar:** Istio's injection relies on an `istio-init` container that manipulates iptables/netfilter rules inside the pod's network namespace (NET_ADMIN + raw sockets) to transparently redirect traffic to and from the injected Envoy proxy. gVisor's `runsc` runtime replaces the kernel a container sees with a userspace syscall emulation layer (the sentry process) that does not implement this netfilter functionality — `istio-init`'s iptables setup fails, and a forced sidecar permanently CrashLoopBackOffs, taking the whole pod down with it.

Since these two are the only workloads the chart schedules under gVisor, the fix opts them out of injection rather than out of gVisor: they stay off the mesh (no mTLS), but remain confined by their existing NetworkPolicy egress allow-list and reachable only from the orchestrator on ingress — an acceptable trade-off to keep them Ready.

## mTLS enforcement topology

```
 ┌────────┐  mTLS   ┌──────────────┐   mTLS   ┌─────┐
 │ vortex │◄───────►│  sonarqube   │          │ mcp │  STRICT
 └────────┘         └──────┬───────┘          └─────┘  (no in-chart caller)
                       mTLS │ ▲
                            ▼ │
                   ┌───────────────────┐
                   │ agent-orchestrator│
                   └──────┬─────┬──────┘
              plaintext   │     │   plaintext
            (no sidecar)  │     │  (no sidecar)
                          ▼     ▼
                    ┌────────┐ ┌─────────────┐
                    │ hunter │ │ remediation │
                    └───┬────┘ └──────┬──────┘
                        │  plaintext  │
                        │ (PERMISSIVE │
                        │  exception) │
                        └──────┬──────┘
                               ▼
                  ┌─────────────────────────┐
                  │   agent-egress-proxy    │  STRICT everywhere else
                  └────────────┬────────────┘
                               │ real TLS to origin
                               │ (Squid CONNECT tunnel,
                               │  not Istio mTLS)
                               ▼
                    external allowlisted domains
```

Every arrow into a pod without a sidecar (hunter, remediation) is necessarily plaintext — mTLS is receiver-enforced, and a pod that was never injected can't terminate it. Everything else chart-owned is STRICT.

## Test plan
- [x] Deployed with Istio sidecar injection + STRICT mTLS enabled; confirmed all chart-owned workloads reject plaintext and accept mTLS traffic
- [x] Confirmed hunter/remediation pods (gVisor) stay out of the mesh and remain Ready
- [x] Confirmed real HTTPS proxying through the egress proxy to an allowlisted domain succeeds end-to-end after the port rename
