### PR TITLE
EA-929 Enforce mTLS for chart-owned workloads via Istio ambient mode

### DIFF
--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -1037,6 +1037,41 @@ Usage: {{ include "sonarqube.agent.dnsEgressRule" $ | indent 4 }}
 {{- end -}}
 
 {{/*
+Ingress or egress rule allowing Istio ambient's ztunnel-to-ztunnel HBONE tunnel: cross-node
+ambient traffic is always carried over TCP port 15008, whatever the real destination port is, so
+a NetworkPolicy written only for the app port silently blocks every such hop once the release
+namespace is ambient-enrolled (istio.io/dataplane-mode: ambient). Deliberately unscoped by
+podSelector/ipBlock: ztunnel, not the original pod, is the actual peer on this port, so the
+identity boundary is Istio's own STRICT PeerAuthentication (templates/peerauthentication.yaml),
+not this NetworkPolicy - here it's only the coarse safety net the upstream Istio ambient docs
+call for.
+Usage: {{ include "sonarqube.istio.ambient.hboneRule" $ | indent 4 }} under ingress: or egress:
+*/}}
+{{- define "sonarqube.istio.ambient.hboneRule" -}}
+- ports:
+    - port: 15008
+      protocol: TCP
+{{- end -}}
+
+{{/*
+Ingress rule letting the kubelet's own httpGet/tcpSocket probes reach a real container port
+directly. Istio ambient tags kubelet probe traffic with a well-known link-local source address
+and ztunnel passes it straight through untunneled (so STRICT PeerAuthentication doesn't break
+probes) - but a NetworkPolicy that selects the pod still evaluates that traffic like any other
+ingress and drops it unless explicitly allowed here.
+Parameter: the real container port the probe targets.
+Usage: {{ include "sonarqube.istio.ambient.kubeletProbeIngressRule" $cfg.port | indent 4 }}
+*/}}
+{{- define "sonarqube.istio.ambient.kubeletProbeIngressRule" -}}
+- from:
+    - ipBlock:
+        cidr: 169.254.7.127/32
+  ports:
+    - port: {{ . }}
+      protocol: TCP
+{{- end -}}
+
+{{/*
 Parse the host:port endpoint out of jdbcOverwrite.jdbcUrl (jdbc:postgresql://host:port/db[?params]),
 for the Agent Orchestrator's CORE_DB_READ_WRITE_ENDPOINT env, since it reuses SonarQube's own DB.
 */}}

--- a/charts/sonarqube/templates/agent-egress-proxy-networkpolicy.yaml
+++ b/charts/sonarqube/templates/agent-egress-proxy-networkpolicy.yaml
@@ -23,6 +23,10 @@ spec:
       ports:
         - port: {{ .Values.agentEgressProxy.port }}
           protocol: TCP
+    {{- if .Values.istio.enabled }}
+{{ include "sonarqube.istio.ambient.hboneRule" . | indent 4 }}
+{{ include "sonarqube.istio.ambient.kubeletProbeIngressRule" .Values.agentEgressProxy.port | indent 4 }}
+    {{- end }}
   egress:
 {{ include "sonarqube.agent.dnsEgressRule" . | indent 4 }}
     {{- /* Backs the hardcoded sonarqube_host allow rule in agent-egress-proxy-configmap.yaml,
@@ -52,4 +56,7 @@ spec:
         - port: {{ . }}
           protocol: TCP
         {{- end }}
+    {{- if .Values.istio.enabled }}
+{{ include "sonarqube.istio.ambient.hboneRule" . | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/sonarqube/templates/agent-networkpolicy.yaml
+++ b/charts/sonarqube/templates/agent-networkpolicy.yaml
@@ -26,6 +26,10 @@ spec:
       ports:
         - port: {{ $cfg.port }}
           protocol: TCP
+    {{- if $.Values.istio.enabled }}
+{{ include "sonarqube.istio.ambient.hboneRule" $ | indent 4 }}
+{{ include "sonarqube.istio.ambient.kubeletProbeIngressRule" $cfg.port | indent 4 }}
+    {{- end }}
   egress:
 {{ include "sonarqube.agent.dnsEgressRule" $ | indent 4 }}
     {{- /* All other runtime egress - including reaching the orchestrator and reading/writing job
@@ -38,5 +42,8 @@ spec:
       ports:
         - port: {{ $.Values.agentEgressProxy.port }}
           protocol: TCP
+    {{- if $.Values.istio.enabled }}
+{{ include "sonarqube.istio.ambient.hboneRule" $ | indent 4 }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -49,6 +49,9 @@ spec:
         - port: {{ .Values.service.internalPort }}
           protocol: TCP
     {{- end }}
+    {{- if .Values.istio.enabled }}
+{{ include "sonarqube.istio.ambient.hboneRule" . | indent 4 }}
+    {{- end }}
   egress:
     - to:
         - namespaceSelector:

--- a/charts/sonarqube/templates/peerauthentication.yaml
+++ b/charts/sonarqube/templates/peerauthentication.yaml
@@ -1,0 +1,88 @@
+{{- /*
+Enforces STRICT mTLS for every chart-owned mesh workload via Istio ambient mode. Unlike sidecar
+injection, ambient's per-node ztunnel doesn't need iptables manipulation inside the pod, so it
+covers the gVisor-sandboxed hunter/remediation runtimes the same way as everything else - there's
+no PERMISSIVE exception to carve out here.
+
+Enrolling workloads in ambient mode itself (labelling the release namespace
+istio.io/dataplane-mode: ambient) is Istio's own mechanism and isn't managed by this chart.
+*/}}
+{{- if .Values.istio.enabled }}
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "sonarqube.selectorLabels" . | nindent 6 }}
+  mtls:
+    mode: STRICT
+{{- if .Values.agentOrchestrator.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.agentOrchestrator.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "sonarqube.agentOrchestrator.selectorLabels" . | nindent 6 }}
+  mtls:
+    mode: STRICT
+{{- end }}
+{{- if .Values.mcp.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.mcp.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "sonarqube.name" . }}-mcp
+      release: {{ .Release.Name }}
+  mtls:
+    mode: STRICT
+{{- end }}
+{{- if .Values.vortex.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.vortex.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "sonarqube.name" . }}-vortex
+      release: {{ .Release.Name }}
+  mtls:
+    mode: STRICT
+{{- end }}
+{{- if include "sonarqube.agentEgressProxy.required" . }}
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.agentEgressProxy.fullname" . }}
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "sonarqube.agentEgressProxy.selectorLabels" . | nindent 6 }}
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "sonarqube.fullname" . }}-agent-runtime
+  labels: {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "sonarqube.agentRuntime.commonSelectorLabels" . | nindent 6 }}
+  mtls:
+    mode: STRICT
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/values.schema.json
+++ b/charts/sonarqube/values.schema.json
@@ -29,6 +29,14 @@
                 }
             }
         },
+        "istio": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "OpenShift": {
             "type": "object",
             "properties": {

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -133,6 +133,15 @@ networkPolicy:
   # expects https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicyspec-v1-networking-k8s-io
   # additionalNetworkPolicies:
 
+# Set enabled to true when the release namespace is enrolled in Istio ambient mode (label the
+# namespace istio.io/dataplane-mode: ambient - Istio's own mechanism, not managed by this chart).
+# Renders a STRICT PeerAuthentication for every chart-owned workload, including the gVisor-sandboxed
+# hunter/remediation runtimes: ambient mode enforces mTLS via a per-node ztunnel rather than a
+# per-pod sidecar, so it doesn't need the iptables setup inside the pod that gVisor's runsc runtime
+# can't support.
+istio:
+  enabled: false
+
 # will be used as default for ingress/httproute path and probes path, will be injected in .Values.env as SONAR_WEB_CONTEXT
 # if .Values.env.SONAR_WEB_CONTEXT is set, this value will be ignored
 sonarWebContext: ""


### PR DESCRIPTION
## Summary

Alternative to #944 (sidecar-based mTLS), for side-by-side comparison. Instead of injecting an Istio sidecar into every chart-owned pod, this enrolls the release namespace in Istio **ambient mode** (`istio.io/dataplane-mode: ambient`, Istio's own mechanism, not managed by this chart - same shape as `istio-injection=enabled` in #944). mTLS is then enforced by the per-node `ztunnel` DaemonSet instead of a per-pod sidecar.

The chart only ever used Istio for L4 `PeerAuthentication` (no `VirtualService`/`AuthorizationPolicy`/L7 features), so ambient's default L4-only profile (no waypoint proxy) is a full replacement.

## Comparison with #944 (sidecar)

| | #944 sidecar | #946 ambient (this PR) |
|---|---|---|
| mTLS enforced by | per-pod Envoy sidecar | per-node `ztunnel` DaemonSet |
| Namespace/pod opt-in | `istio-injection=enabled` (or revision label) | `istio.io/dataplane-mode: ambient` |
| Chart value | `istio.enabled` / `istio.namespace` | `istio.enabled` / `istio.namespace` (same) |
| hunter/remediation (gVisor) | **excluded from the mesh** - `sidecar.istio.io/inject: "false"`, stay plaintext | **included** - ambient capture is node/CNI-level, outside the gVisor sandbox boundary |
| `PeerAuthentication` | STRICT everywhere except a `portLevelMtls: PERMISSIVE` exception on the egress proxy's port (to accept the gVisor pods' plaintext) | STRICT everywhere, **no exception** |
| istiod reachability | needs an explicit NetworkPolicy egress rule (port 15012) on every agent NetworkPolicy, since the sidecar itself talks to istiod | not needed - `ztunnel`, not the pod, talks to istiod |
| Egress proxy port | renamed `http-proxy` → `tcp-proxy` so Istio treats Squid's CONNECT tunnel as opaque TCP instead of misapplying HTTP processing | no rename - ambient's L4-only ztunnel hop doesn't do Envoy protocol detection |
| New NetworkPolicy rules needed | istiod egress (15012) | ztunnel HBONE tunnel (15008, ingress+egress) + kubelet link-local probe bypass (ingress) - see below |
| New templates | none (existing `peerauthentication.yaml` extended) | `peerauthentication.yaml` |
| L7 features (retries, header routing, JWT `AuthorizationPolicy`) | available automatically (sidecar) | would require adding a waypoint proxy (not needed today - chart uses none) |

This closes the one real gap #944 has to leave open: hunter/remediation can't take a sidecar at all (`istio-init`'s iptables setup needs capabilities gVisor's userspace netstack doesn't support), so #944 falls back to a `PERMISSIVE` exception for that hop. Ambient's traffic capture happens at the node/CNI level, outside the gVisor sandbox boundary, so it covers those runtimes the same way as everything else - **no PERMISSIVE exception needed anywhere**.

Tradeoff: a future need for L7 Istio features would require adding a waypoint proxy under ambient, whereas sidecars get L7 automatically. Not a concern today since nothing in the chart uses L7.

## Installing Istio in the cluster

Both #944 and this PR assume Istio is already installed cluster-wide - neither manages that. Verified live on `speedboat-test-xx` (all charts pinned to `1.30.3`):

```
helm repo add istio https://istio-release.storage.googleapis.com/charts
helm repo update

# Shared control plane - required for BOTH #944 (sidecar) and this PR (ambient)
helm install istio-base istio/base -n istio-system --create-namespace --version 1.30.3
helm install istiod istio/istiod -n istio-system --set profile=ambient --version 1.30.3

# Ambient-only additions (this PR) - #944 needs neither of these
helm install istio-cni istio/cni -n istio-system --set profile=ambient --version 1.30.3
helm install ztunnel istio/ztunnel -n istio-system --version 1.30.3
```

The `profile=ambient` flag on `istiod` only turns on the ztunnel XDS endpoint inside Pilot - it does **not** remove or gate the sidecar-injection webhook. Confirmed live: `kubectl get mutatingwebhookconfiguration istio-sidecar-injector -o yaml` on this same ambient-profile `istiod` release shows all four standard injection rules intact, gated only on the `istio-injection`/`istio.io/rev` namespace labels and `sidecar.istio.io/inject` pod label - none of them reference `profile` at all. In other words, one `istio-base` + `istiod` install serves both PRs; `istio-cni` and `ztunnel` are the only pieces specific to ambient mode, and installing them doesn't disable sidecar injection for namespaces that opt into #944's mechanism instead. This cluster currently runs both mechanisms side by side on the one control plane.

## Setting up Istio

Two things are required, one outside the chart and one in it - same shape as #944, different mechanism:

1. **Enroll the namespace in ambient mode**: label it `istio.io/dataplane-mode: ambient`. This is Istio's own mechanism and isn't managed by the chart (in #944 the equivalent is `istio-injection=enabled`).
2. **Set `istio.enabled: true`** in the chart values (`istio.namespace` defaults to `istio-system`, same as #944). This renders the `PeerAuthentication` resources that enforce STRICT mTLS per chart-owned workload, and adds the ambient-specific NetworkPolicy allowances below. Unlike #944, no istiod NetworkPolicy egress rule is needed on any chart-owned pod, since `ztunnel` - not the pod itself - talks to istiod.

With both set, ambient's per-node `ztunnel` transparently captures traffic to and from every pod in the namespace - no injection webhook, no init container, no per-pod opt-out required for gVisor.

## Excluded components

**None.** Every chart-owned workload, including the gVisor-scheduled hunter/remediation runtimes, is covered by ambient capture and STRICT mTLS. This is the direct contrast with #944, where those two runtimes stay off the mesh entirely.

## mTLS enforcement topology

```
 ┌────────┐  mTLS   ┌──────────────┐   mTLS   ┌─────┐
 │ vortex │◄───────►│  sonarqube   │          │ mcp │  STRICT
 └────────┘         └──────┬───────┘          └─────┘  (no in-chart caller)
                       mTLS │ ▲
                            ▼ │
                   ┌───────────────────┐
                   │ agent-orchestrator│
                   └──────┬─────┬──────┘
                mTLS      │     │      mTLS
                          ▼     ▼
                    ┌────────┐ ┌─────────────┐
                    │ hunter │ │ remediation │  STRICT (gVisor-sandboxed,
                    └───┬────┘ └──────┬──────┘  same as every other workload)
                        │    mTLS     │
                        └──────┬──────┘
                               ▼
                  ┌─────────────────────────┐
                  │   agent-egress-proxy    │  STRICT everywhere, no exception
                  └────────────┬────────────┘
                               │ real TLS to origin
                               │ (Squid CONNECT tunnel,
                               │  not Istio mTLS)
                               ▼
                    external allowlisted domains
```

Every arrow is STRICT mTLS, enforced transparently by the source and destination pods' node-local `ztunnel`s - including the two hops (`agent-orchestrator` → hunter/remediation → `agent-egress-proxy`) that #944's diagram shows as plaintext-only.

### NetworkPolicy fix found during live verification

Live testing on `speedboat-test-xx-std` surfaced two NetworkPolicy gaps that only show up once the namespace is actually ambient-enrolled (not visible from `helm template` alone), analogous to #944's istiod-egress-rule requirement but for ambient's own control paths:

- **Cross-node ztunnel-to-ztunnel traffic is always tunneled over TCP 15008**, regardless of the real destination port. NetworkPolicies scoped only to the app port silently dropped this, breaking `sonarqube` &rarr; `postgresql`-adjacent traffic and any cross-node agent-runtime hop.
- **Kubelet's own probes bypass the tunnel**, arriving from a well-known link-local source (`169.254.7.127/32`) directly on the real container port. NetworkPolicies selecting the pod still evaluate that traffic and dropped it, failing liveness/readiness/startup probes.

Fixed via two new shared helpers (`sonarqube.istio.ambient.hboneRule`, `sonarqube.istio.ambient.kubeletProbeIngressRule`) applied to the three chart-owned NetworkPolicy templates that needed it: main `networkpolicy.yaml` (ingress-only, no probe on that pod), `agent-networkpolicy.yaml` (hunter/remediation), and `agent-egress-proxy-networkpolicy.yaml`. `agentOrchestrator`/`vortex`/`mcp` have no dedicated NetworkPolicy template in this chart, so nothing to change there.

## Test plan
- [x] `helm template` with `istio.enabled=true` and every agentic workload enabled renders one STRICT `PeerAuthentication` per workload (sonarqube, agent-orchestrator, mcp, vortex, agent-egress-proxy, agent-runtime).
- [x] `helm template` with `istio.enabled=false` (default) renders nothing from the new template.
- [x] Full chart renders cleanly with all agentic features enabled.
- [x] Existing Go unit test suite (`tests/unit-test`) passes unchanged.
- [x] Live cluster verification on `speedboat-test-xx-std` (ambient mode, gVisor-sandboxed hunter/remediation included): all 14 pods `Running`/`Ready` with 0 restarts, `sonarqube` &rarr; `postgresql` DB connectivity confirmed, ambient enrollment genuine (`ambient.istio.io/redirection: enabled`).
- [x] mTLS enforcement verified live: a plaintext request to a STRICT-protected pod from a non-mesh source (`istio.io/dataplane-mode: none`) is TCP-accepted by `ztunnel` then reset once real traffic is sent (`Recv failure: Connection reset by peer`); the identical request from an ambient-enrolled pod succeeds transparently (`HTTP 200`) - including hunter/remediation, which #944 cannot enforce mTLS on at all.

