### PR TITLE
SONAR-24525 Size chart memory defaults for the new Web/CE heap defaults

### DIFF
--- a/charts/sonarqube-dce/README.md
+++ b/charts/sonarqube-dce/README.md
@@ -388,12 +388,12 @@ Please find here the default SonarQube Xmx parameters to setup the memory reques
 | Edition                             | Sum of Xmx |
 | ----------------------------------- | ---------- |
 | datacenter edition searchNodes      | 2G         |
-| datacenter edition applicationNodes | 3G         |
+| datacenter edition applicationNodes | 6G         |
 
 To comply with the 80% rule mentioned above, we set the following default values:
 
 * searchNodes.resources.memory.request/limit=3072M
-* applicationNodes.resources.memory.request/limit=4096M
+* applicationNodes.resources.memory.request/limit=8192M
 
 Please feel free to adjust those values to your needs. However, given that memory is a “non-compressible” resource, we advise you to set the memory requests and limits to the **same**, making memory a guaranteed resource. This is needed especially for production use cases.
 
@@ -720,10 +720,10 @@ The following table lists the configurable parameters of the SonarQube chart and
 | `applicationNodes.startupProbe.failureThreshold`                 | StartupProbe threshold for marking as failed                                                                                                                                                                   | `32`                                                                   |
 | `applicationNodes.startupProbe.timeoutSeconds`                   | StartupProbe timeout delay                                                                                                                                                                                     | `1`                                                                    |
 | `applicationNodes.startupProbe.sonarWebContext`                  | (DEPRECATED) SonarQube web context for startupProbe, please use sonarWebContext at the value top level instead                                                                                                 | `/`                                                                    |
-| `applicationNodes.resources.requests.memory`                     | memory request for app Nodes                                                                                                                                                                                   | `4096M`                                                                |
+| `applicationNodes.resources.requests.memory`                     | memory request for app Nodes                                                                                                                                                                                   | `8192M`                                                                |
 | `applicationNodes.resources.requests.cpu`                        | CPU request for app Nodes                                                                                                                                                                                      | `400m`                                                                 |
 | `applicationNodes.resources.requests.ephemeral-storage`          | storage request for app Nodes                                                                                                                                                                                  | `1536M`                                                                |
-| `applicationNodes.resources.limits.memory`                       | memory limit for app Nodes. should not be under 4G                                                                                                                                                             | `4096M`                                                                |
+| `applicationNodes.resources.limits.memory`                       | memory limit for app Nodes. should not be under 6G                                                                                                                                                             | `8192M`                                                                |
 | `applicationNodes.resources.limits.cpu`                          | CPU limit for app Nodes                                                                                                                                                                                        | `800m`                                                                 |
 | `applicationNodes.resources.limits.ephemeral-storage`            | storage limit for app Nodes                                                                                                                                                                                    | `512000M`                                                              |
 | `applicationNodes.prometheusExporter.enabled`                    | Use the Prometheus JMX exporter                                                                                                                                                                                | `false`                                                                |

--- a/charts/sonarqube-dce/values.yaml
+++ b/charts/sonarqube-dce/values.yaml
@@ -367,16 +367,16 @@ applicationNodes:
 
   ## We usually don't make specific resource recommendations, as they are heavily dependent on
   ## the usage of SonarQube and the surrounding infrastructure.
-  ## Those default are based on the default Web -Xmx1G -Xms128m and CE -Xmx2G -Xms128m settings of applicationNode sub processes.
+  ## Those default are based on the default Web -Xmx2G -Xms128m and CE -Xmx4G -Xms128m settings of applicationNode sub processes.
   ## Adjust these values to your needs, you can find more details on the main README of the chart.
   resources:
     limits:
       cpu: 800m
-      memory: 4096M
+      memory: 8192M
       ephemeral-storage: 512000M
     requests:
       cpu: 400m
-      memory: 4096M
+      memory: 8192M
       ephemeral-storage: 1536M
 
   ## Array of extra containers to run alongside the sonarqube application container

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -167,11 +167,11 @@ Please find here the default SonarQube Xmx parameters to setup the memory reques
 
 | SonarQube Offering | Sum of Xmx |
 | ------------------ | ---------- |
-| community build    | 1536M      |
-| developer edition  | 1536M      |
-| enterprise edition | 5G         |
+| community build    | 3072M      |
+| developer edition  | 3072M      |
+| enterprise edition | 8G         |
 
-The default request and limit for this chart are set to 2048M and 6144M, to comply with the 3 editions and the 80% rule mentioned above.
+The default request and limit for this chart are set to 4096M and 10240M, to comply with the 3 editions and the 80% rule mentioned above.
 
 Please feel free to adjust those values to your needs. However, given that memory is a “non-compressible” resource, we advise you to set the memory requests and limits to the **same**, making memory a guaranteed resource. This is needed especially for production use cases.
 
@@ -780,10 +780,10 @@ The following table lists the configurable parameters of the SonarQube chart and
 
 | Parameter                              | Description               | Default |
 | -------------------------------------- | ------------------------- | ------- |
-| `resources.requests.memory`            | SonarQube memory request  | `2048M` |
+| `resources.requests.memory`            | SonarQube memory request  | `4096M` |
 | `resources.requests.cpu`               | SonarQube CPU request     | `400m`  |
 | `resources.requests.ephemeral-storage` | SonarQube storage request | `1536M` |
-| `resources.limits.memory`              | SonarQube memory limit    | `6144M` |
+| `resources.limits.memory`              | SonarQube memory limit    | `10240M` |
 | `resources.limits.cpu`                 | SonarQube CPU limit       | `800m`  |
 | `resources.limits.ephemeral-storage`   | SonarQube storage limit   | `500Gi` |
 

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -447,16 +447,16 @@ annotations: {}
 
 ## We usually don't make specific resource recommendations, as they are heavily dependant on
 ## the usage of SonarQube and the surrounding infrastructure.
-## Those default are based on the default Web -Xmx1G -Xms128m and CE -Xmx2G -Xms128m and Search -Xmx2G -Xms2G settings of SQ sub processes
+## Those default are based on the default Web -Xmx2G -Xms128m and CE -Xmx4G -Xms128m and Search -Xmx2G -Xms2G settings of SQ sub processes
 ## Adjust these values to your needs, you can find more details on the main README of the chart.
 resources:
   limits:
     cpu: 800m
-    memory: 6144M
+    memory: 10240M
     ephemeral-storage: 512000M
   requests:
     cpu: 400m
-    memory: 2048M
+    memory: 4096M
     ephemeral-storage: 1536M
 
 persistence:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-static-hazelcast-values.yaml
@@ -422,11 +422,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/application-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-configmap.yaml
@@ -493,11 +493,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ca-certificates-secret.yaml
@@ -402,11 +402,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/change-admin-password-hook-values.yaml
@@ -381,11 +381,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/config-values.yaml
@@ -409,11 +409,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/custom-image-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/default-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/deprecation-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/duplicated-env-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: FOOBAR
               valueFrom:

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/extraconfig-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/hpa-values.yaml
@@ -366,11 +366,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-default-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /sonarqube/

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/http-routes-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/ingress-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/install-plugins-values.yaml
@@ -411,11 +411,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/jdbc-config-values.yaml
@@ -354,11 +354,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-tls-values.yaml
@@ -494,11 +494,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-values.yaml
@@ -498,11 +498,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/mcp-web-context-values.yaml
@@ -498,11 +498,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /sonarqube-pre-prod/

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-new-values.yaml
@@ -519,11 +519,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/networkpolicy-values.yaml
@@ -519,11 +519,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-per-process-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/node-topology-values.yml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/prometheus-monitoring-values.yaml
@@ -443,11 +443,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-secret-values.yaml
@@ -411,11 +411,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/proxies-values.yaml
@@ -487,11 +487,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/pvc-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/restricted-openshift.yaml
@@ -340,11 +340,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/secret-values.yaml
@@ -381,11 +381,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/service-values.yaml
@@ -385,11 +385,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/serviceaccount-values.yaml
@@ -376,11 +376,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-deprecated-values.yaml
@@ -418,11 +418,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /sonarqube-web-context/

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/sonar-web-context-values.yaml
@@ -381,11 +381,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /sonarqube-web-context/

--- a/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube-dce/topology-spread-constraints-values.yaml
@@ -367,11 +367,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 4096M
+              memory: 8192M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 4096M
+              memory: 8192M
           env:
             - name: SONAR_WEB_CONTEXT
               value: /

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-configmap.yaml
@@ -336,11 +336,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ca-certificates-secret.yaml
@@ -236,11 +236,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/change-admin-password-hook-values.yaml
@@ -211,11 +211,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0
@@ -411,8 +411,8 @@ spec:
           limits:
             cpu: 800m
             ephemeral-storage: 512000M
-            memory: 6144M
+            memory: 10240M
           requests:
             cpu: 400m
             ephemeral-storage: 1536M
-            memory: 2048M
+            memory: 4096M

--- a/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/community-build-values.yaml
@@ -197,11 +197,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/config-values.yaml
@@ -245,11 +245,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/custom-image-values.yaml
@@ -197,11 +197,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/default-values.yaml
@@ -197,11 +197,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/deployment-values.yaml
@@ -198,11 +198,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/duplicated-env-values.yaml
@@ -291,11 +291,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/host-path-values.yaml
@@ -265,11 +265,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-default-values.yaml
@@ -197,11 +197,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/http-routes-values.yaml
@@ -197,11 +197,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/ingress-values.yaml
@@ -197,11 +197,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/install-plugins-values.yaml
@@ -243,11 +243,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/jdbc-config-values.yaml
@@ -224,11 +224,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-tls-values.yaml
@@ -324,11 +324,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-values.yaml
@@ -328,11 +328,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/mcp-web-context-values.yaml
@@ -328,11 +328,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-new-values.yaml
@@ -280,11 +280,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/networkpolicy-values.yaml
@@ -280,11 +280,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/non-default-security-context-values.yaml
@@ -337,11 +337,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/openshift-values.yaml
@@ -131,11 +131,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/prometheus-monitoring-values.yaml
@@ -197,11 +197,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-secret-values.yaml
@@ -243,11 +243,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/proxies-values.yaml
@@ -323,11 +323,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/pvc-values.yaml
@@ -267,11 +267,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/secret-values.yaml
@@ -211,11 +211,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/service-values.yaml
@@ -204,11 +204,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/serviceaccount-values.yaml
@@ -211,11 +211,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-deployment-deprecated-values.yaml
@@ -212,11 +212,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0
@@ -434,8 +434,8 @@ spec:
           limits:
             cpu: 800m
             ephemeral-storage: 512000M
-            memory: 6144M
+            memory: 10240M
           requests:
             cpu: 400m
             ephemeral-storage: 1536M
-            memory: 2048M
+            memory: 4096M

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-sts-deprecated-values.yaml
@@ -211,11 +211,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0
@@ -433,8 +433,8 @@ spec:
           limits:
             cpu: 800m
             ephemeral-storage: 512000M
-            memory: 6144M
+            memory: 10240M
           requests:
             cpu: 400m
             ephemeral-storage: 1536M
-            memory: 2048M
+            memory: 4096M

--- a/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/sonar-web-context-values.yaml
@@ -211,11 +211,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0
@@ -433,8 +433,8 @@ spec:
           limits:
             cpu: 800m
             ephemeral-storage: 512000M
-            memory: 6144M
+            memory: 10240M
           requests:
             cpu: 400m
             ephemeral-storage: 1536M
-            memory: 2048M
+            memory: 4096M

--- a/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
+++ b/tests/unit-compatibility-test/fixtures/sonarqube/template-refactoring-values.yaml
@@ -274,11 +274,11 @@ spec:
             limits:
               cpu: 800m
               ephemeral-storage: 512000M
-              memory: 6144M
+              memory: 10240M
             requests:
               cpu: 400m
               ephemeral-storage: 1536M
-              memory: 2048M
+              memory: 4096M
           env:
             - name: SONAR_HELM_CHART_VERSION
               value: 2026.5.0


### PR DESCRIPTION
## Summary
`sonar-enterprise#18818` (SONAR-24525) raises SonarQube's default `-Xmx` for the Web and Compute Engine processes to reduce the probability of hitting an OOM that permanently breaks the bundled Elasticsearch HTTP client (see USER-96):
- Community / Developer: web 512m -> 1G, ce 512m -> 1.5G (out of scope for this chart, see below)
- **Enterprise / Data Center: web 1G -> 2G, ce 2G -> 4G** (this is what `charts/sonarqube` and `charts/sonarqube-dce` are sized for)

This chart already documents a sizing methodology tying `resources.requests/limits.memory` to a per-edition "Sum of Xmx" table and a "~80% rule" (Xmx sum should be ~80% of the pod's memory). Updated accordingly:

- **`charts/sonarqube`** (community/developer/enterprise, single container running web+ce+search): enterprise-tier Xmx sum goes from `1G+2G+2G=5G` to `2G+4G+2G=8G`. Applying the chart's existing ~80% rule: `requests.memory` 2048M -> 4096M, `limits.memory` 6144M -> 10240M (8192M / 10240M = exactly 80%). Updated the doc comment and README's Xmx-sum table/parameter table to match.
- **`charts/sonarqube-dce`** `applicationNodes` (web+ce only, no search on app nodes): Xmx sum goes from `1G+2G=3G` to `2G+4G=6G`. Same request=limit pattern as before: 4096M -> 8192M (6144M/8192M = 75%, matching the existing ratio used for this block). `searchNodes` is untouched since Search's `-Xmx` (2G) did not change.
- Regenerated the `tests/unit-compatibility-test/fixtures` golden snapshots via `.github/scripts/generate_helm_fixtures.sh`. Note: a plain regeneration on current `master` (without any of my changes) already produces unrelated churn in these fixtures (stale `checksum/config` etc., likely a pre-existing helm-version/tooling drift, not something this PR touches) — I diffed a "regenerated from unmodified values" pass against a "regenerated from my edited values" pass and hand-applied only the isolated `resources.*.memory` line changes onto the committed fixtures, so this PR's fixture diff is scoped to exactly the memory values (144 lines across 68 files, 2 lines each) and doesn't carry unrelated pre-existing drift.

## Test plan
- [x] `helm lint charts/sonarqube --set monitoringPasscode=test,edition=enterprise` passes
- [x] `helm lint charts/sonarqube-dce` passes (pre-existing mandatory-value guard messages are unrelated to this change, verified present on unmodified `master` too)
- [x] Fixture diff reviewed to confirm only `resources.*.memory` values changed, no other template output regressed