### PR TITLE
SONAR-32220 Pin agent runtime HPA name to avoid 63-char overflow

### DIFF
--- a/charts/sonarqube-dce/templates/agent-runtime-scaledobject.yaml
+++ b/charts/sonarqube-dce/templates/agent-runtime-scaledobject.yaml
@@ -21,6 +21,10 @@ spec:
   pollingInterval: {{ $cfg.autoscaling.pollingInterval }}
   advanced:
     horizontalPodAutoscalerConfig:
+      {{- /* KEDA otherwise derives the HPA name as "keda-hpa-<scaledobject name>", whose 9-char
+             prefix can push it past the 63-char name limit even though the ScaledObject name
+             itself fits. Reuse the (already-truncated) ScaledObject name directly instead. */}}
+      name: {{ include "sonarqube.agentRuntime.fullname" (dict "ctx" $ "family" $family) }}
       behavior:
         scaleDown:
           stabilizationWindowSeconds: {{ $cfg.autoscaling.scaleDownStabilizationSeconds }}

--- a/charts/sonarqube/templates/agent-runtime-scaledobject.yaml
+++ b/charts/sonarqube/templates/agent-runtime-scaledobject.yaml
@@ -21,6 +21,10 @@ spec:
   pollingInterval: {{ $cfg.autoscaling.pollingInterval }}
   advanced:
     horizontalPodAutoscalerConfig:
+      {{- /* KEDA otherwise derives the HPA name as "keda-hpa-<scaledobject name>", whose 9-char
+             prefix can push it past the 63-char name limit even though the ScaledObject name
+             itself fits. Reuse the (already-truncated) ScaledObject name directly instead. */}}
+      name: {{ include "sonarqube.agentRuntime.fullname" (dict "ctx" $ "family" $family) }}
       behavior:
         scaleDown:
           stabilizationWindowSeconds: {{ $cfg.autoscaling.scaleDownStabilizationSeconds }}

--- a/tests/unit-test/agent_autoscaling_test.go
+++ b/tests/unit-test/agent_autoscaling_test.go
@@ -16,6 +16,14 @@ type scaledObjectScaleTargetRef struct {
 	Name string `json:"name"`
 }
 
+type scaledObjectHorizontalPodAutoscalerConfig struct {
+	Name string `json:"name"`
+}
+
+type scaledObjectAdvanced struct {
+	HorizontalPodAutoscalerConfig scaledObjectHorizontalPodAutoscalerConfig `json:"horizontalPodAutoscalerConfig"`
+}
+
 // scaledObject captures only the fields these tests assert on - there is no k8s.io/api type for a
 // KEDA CRD, and the full KEDA client types are not worth adding as a dependency for this.
 type scaledObject struct {
@@ -28,12 +36,8 @@ type scaledObject struct {
 		MinReplicaCount int64                      `json:"minReplicaCount"`
 		MaxReplicaCount int64                      `json:"maxReplicaCount"`
 		PollingInterval int64                      `json:"pollingInterval"`
-		Advanced        struct {
-			HorizontalPodAutoscalerConfig struct {
-				Name string `json:"name"`
-			} `json:"horizontalPodAutoscalerConfig"`
-		} `json:"advanced"`
-		Triggers []struct {
+		Advanced        scaledObjectAdvanced       `json:"advanced"`
+		Triggers        []struct {
 			Type     string            `json:"type"`
 			Metadata map[string]string `json:"metadata"`
 		} `json:"triggers"`

--- a/tests/unit-test/agent_autoscaling_test.go
+++ b/tests/unit-test/agent_autoscaling_test.go
@@ -28,7 +28,12 @@ type scaledObject struct {
 		MinReplicaCount int64                      `json:"minReplicaCount"`
 		MaxReplicaCount int64                      `json:"maxReplicaCount"`
 		PollingInterval int64                      `json:"pollingInterval"`
-		Triggers        []struct {
+		Advanced        struct {
+			HorizontalPodAutoscalerConfig struct {
+				Name string `json:"name"`
+			} `json:"horizontalPodAutoscalerConfig"`
+		} `json:"advanced"`
+		Triggers []struct {
 			Type     string            `json:"type"`
 			Metadata map[string]string `json:"metadata"`
 		} `json:"triggers"`
@@ -238,6 +243,7 @@ func TestAgentRuntimeScaledObjectRendersWhenEnabled(t *testing.T) {
 					expectedName := chart.fullnamePrefix() + "-agent-runtime-" + family
 					assert.Equal(t, expectedName, so.Metadata.Name)
 					assert.Equal(t, expectedName, so.Spec.ScaleTargetRef.Name)
+					assert.Equal(t, expectedName, so.Spec.Advanced.HorizontalPodAutoscalerConfig.Name)
 					assert.EqualValues(t, 4, so.Spec.MinReplicaCount)
 					assert.EqualValues(t, 9, so.Spec.MaxReplicaCount)
 					assert.EqualValues(t, 20, so.Spec.PollingInterval)
@@ -249,6 +255,32 @@ func TestAgentRuntimeScaledObjectRendersWhenEnabled(t *testing.T) {
 					assert.Equal(t, family+".unfinished", trigger.Metadata["valueLocation"])
 				})
 			}
+		})
+	}
+}
+
+// KEDA defaults the underlying HPA's name to "keda-hpa-<scaledobject name>" - that 9-char prefix
+// can push the *HPA's* name past the 63-char Kubernetes name limit even when the ScaledObject's
+// own (already-truncated-to-63) name fits, and KEDA's admission webhook rejects the ScaledObject
+// outright when that happens. horizontalPodAutoscalerConfig.name must be pinned to the
+// ScaledObject's own name so no extra prefix is ever added.
+func TestAgentRuntimeScaledObjectHPANameStaysWithinLimit(t *testing.T) {
+	const longRelease = "next-prod-linas"
+	for _, chart := range agentCharts {
+		t.Run(chart.name, func(t *testing.T) {
+			so, err := renderAgentRuntimeScaledObject(t, agentChart{
+				name:      chart.name,
+				path:      chart.path,
+				release:   longRelease,
+				valuesDir: chart.valuesDir,
+			}, "remediation", map[string]string{
+				"remediationAgent.autoscaling.enabled": "true",
+				"agentKeda.assumeInstalled":            "true",
+			})
+			require.NoError(t, err)
+
+			assert.LessOrEqual(t, len(so.Spec.Advanced.HorizontalPodAutoscalerConfig.Name), 63)
+			assert.Equal(t, so.Metadata.Name, so.Spec.Advanced.HorizontalPodAutoscalerConfig.Name)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- KEDA derives the underlying HPA's name as `keda-hpa-<scaledobject-name>`; that 9-char prefix can push it past Kubernetes' 63-char name limit even when the ScaledObject's own (already-truncated) name fits, and KEDA's admission webhook rejects the ScaledObject outright.
- Pin `spec.advanced.horizontalPodAutoscalerConfig.name` to the ScaledObject's own fullname in both `sonarqube` and `sonarqube-dce` charts so KEDA reuses it verbatim instead of adding the prefix.
- Reproduced with the `next-prod-linas` DCE release (see SONAR-32220).

## Test plan
- [x] `cd tests/unit-test && go test ./...` passes
- [x] Added `TestAgentRuntimeScaledObjectHPANameStaysWithinLimit` reproducing the real failing release name, asserting the HPA name is ≤63 chars
- [x] Verified via `helm template` against the actual failing values file that `horizontalPodAutoscalerConfig.name` now renders within limits

Fixes SONAR-32220