### PR TITLE
Hash only the config data in checksum/* pod annotations

### DIFF
--- a/charts/sonarqube-dce/CHANGELOG.md
+++ b/charts/sonarqube-dce/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.5.1]
+* Hash only the ConfigMap and Secret data in the `checksum/*` pod annotations, so that a chart version bump on its own no longer restarts the pods
+
 ## [2026.5.0]
 * Upgrade Chart's version to 2026.5.0
 * **Breaking**: Remove the deprecated `ingress-nginx.enabled`/`nginx.enabled` bundled ingress-nginx controller subchart dependency. `ingress.enabled` remains supported for use with a self-managed ingress controller; `httproute.enabled` (Gateway API) is also available

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube-dce
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.5.0
+version: 2026.5.1
 appVersion: 2026.4.0
 keywords:
   - coverage

--- a/charts/sonarqube-dce/Chart.yaml
+++ b/charts/sonarqube-dce/Chart.yaml
@@ -35,10 +35,8 @@ maintainers:
     email: navya.otturu@sonarsource.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Upgrade Chart's version to 2026.5.0"
-    - kind: removed
-      description: "Remove the deprecated ingress-nginx.enabled/nginx.enabled bundled ingress-nginx controller subchart dependency; ingress.enabled remains supported for a self-managed controller, or use httproute (Gateway API)"
+    - kind: fixed
+      description: "Hash only the ConfigMap and Secret data in the checksum/* pod annotations, so a chart version bump on its own no longer restarts the pods"
   artifacthub.io/links: |
     - name: support
       url: https://community.sonarsource.com/

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -581,3 +581,11 @@ User-provided properties take precedence over automatically generated ones.
 {{- end -}}
 {{- toYaml $merged -}}
 {{- end -}}
+
+{{/*
+Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
+Hashing the whole manifest includes the chart labels, which change on every chart version bump.
+*/}}
+{{- define "sonarqube.configMapOrSecretContentHash" -}}
+{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
+{{- end -}}

--- a/charts/sonarqube-dce/templates/_helpers.tpl
+++ b/charts/sonarqube-dce/templates/_helpers.tpl
@@ -585,7 +585,12 @@ User-provided properties take precedence over automatically generated ones.
 {{/*
 Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
 Hashing the whole manifest includes the chart labels, which change on every chart version bump.
+The template may render several documents, so hash the data of each one.
 */}}
 {{- define "sonarqube.configMapOrSecretContentHash" -}}
-{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
+{{- $data := list -}}
+{{- range regexSplit "(?m)^---$" (include (print .ctx.Template.BasePath .name) .ctx) -1 -}}
+{{- $data = append $data (pick (fromYaml .) "data" "stringData") -}}
+{{- end -}}
+{{ $data | toYaml | sha256sum }}
 {{- end -}}

--- a/charts/sonarqube-dce/templates/sonarqube-application.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-application.yaml
@@ -40,12 +40,12 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        checksum/plugins: {{ include (print $.Template.BasePath "/install-plugins.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/plugins: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/install-plugins.yaml") }}
+        checksum/config: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/config.yaml") }}
+        checksum/secret: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/secret.yaml") }}
 {{- if .Values.ApplicationNodes.prometheusExporter.enabled }}
-        checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-config.yaml") . | sha256sum }}
-        checksum/prometheus-ce-config: {{ include (print $.Template.BasePath "/prometheus-ce-config.yaml") . | sha256sum }}
+        checksum/prometheus-config: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/prometheus-config.yaml") }}
+        checksum/prometheus-ce-config: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/prometheus-ce-config.yaml") }}
 {{- end }}
 {{- with .Values.annotations }}
 {{ toYaml . | indent 8 }}

--- a/charts/sonarqube-dce/templates/sonarqube-search.yaml
+++ b/charts/sonarqube-dce/templates/sonarqube-search.yaml
@@ -64,13 +64,13 @@ spec:
 {{- end }}
       annotations:
         {{- if and .Values.initSysctl.enabled (not .Values.OpenShift.enabled) }}
-        checksum/init-sysctl: {{ include (print $.Template.BasePath "/init-sysctl.yaml") . | sha256sum }}
+        checksum/init-sysctl: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/init-sysctl.yaml") }}
         {{- end }}
         {{- if and .Values.searchNodes.persistence.enabled .Values.initFs.enabled (not .Values.OpenShift.enabled) }}
-        checksum/init-fs: {{ include (print $.Template.BasePath "/init-fs.yaml") . | sha256sum }}
+        checksum/init-fs: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/init-fs.yaml") }}
         {{- end }}
-        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/config.yaml") }}
+        checksum/secret: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/secret.yaml") }}
 {{- with .Values.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [2026.5.1]
+* Hash only the ConfigMap and Secret data in the `checksum/*` pod annotations, so that a chart version bump on its own no longer restarts the pods
+
 ## [2026.5.0]
 * Upgrade Chart's version to 2026.5.0
 * Upgrade SonarQube Community build to 26.9.0.129388

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarqube
 description: SonarQube is a self-managed, automatic code review tool that systematically helps you deliver clean code. As a core element of our Sonar solution, SonarQube integrates into your existing workflow and detects issues in your code to help you perform continuous code inspections of your projects. The tool analyses 30+ different programming languages and integrates into your CI pipeline and DevOps platform to ensure that your code meets high-quality standards.
 type: application
-version: 2026.5.0
+version: 2026.5.1
 appVersion: 2026.4.0
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -40,12 +40,8 @@ annotations:
     - name: Chart Source
       url: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Upgrade Chart's version to 2026.5.0"
-    - kind: changed
-      description: "Upgrade SonarQube Community build to 26.9.0.129388"
-    - kind: removed
-      description: "Remove the deprecated ingress-nginx.enabled/nginx.enabled bundled ingress-nginx controller subchart dependency; ingress.enabled remains supported for a self-managed controller, or use httproute (Gateway API)"
+    - kind: fixed
+      description: "Hash only the ConfigMap and Secret data in the checksum/* pod annotations, so a chart version bump on its own no longer restarts the pods"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/images: |
     - name: sonarqube-community

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -443,7 +443,12 @@ Create the fully qualified name for the MCP service.
 {{/*
 Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
 Hashing the whole manifest includes the chart labels, which change on every chart version bump.
+The template may render several documents, so hash the data of each one.
 */}}
 {{- define "sonarqube.configMapOrSecretContentHash" -}}
-{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
+{{- $data := list -}}
+{{- range regexSplit "(?m)^---$" (include (print .ctx.Template.BasePath .name) .ctx) -1 -}}
+{{- $data = append $data (pick (fromYaml .) "data" "stringData") -}}
+{{- end -}}
+{{ $data | toYaml | sha256sum }}
 {{- end -}}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -439,3 +439,11 @@ Create the fully qualified name for the MCP service.
 {{- $accountDeprecation := (include "deepMerge" (dict "map1" $map1 "map2" $map2)) -}}
 {{- $accountDeprecation }}
 {{- end -}}
+
+{{/*
+Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
+Hashing the whole manifest includes the chart labels, which change on every chart version bump.
+*/}}
+{{- define "sonarqube.configMapOrSecretContentHash" -}}
+{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
+{{- end -}}

--- a/charts/sonarqube/templates/_pod.tpl
+++ b/charts/sonarqube/templates/_pod.tpl
@@ -1,18 +1,18 @@
 {{- define "sonarqube.pod" -}}
 metadata:
   annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+    checksum/config: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/config.yaml") }}
     {{- if and .Values.persistence.enabled .Values.initFs.enabled (not .Values.OpenShift.enabled) }}
-    checksum/init-fs: {{ include (print $.Template.BasePath "/init-fs.yaml") . | sha256sum }}
+    checksum/init-fs: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/init-fs.yaml") }}
     {{- end }}
     {{- if and .Values.initSysctl.enabled (not .Values.OpenShift.enabled) }}
-    checksum/init-sysctl: {{ include (print $.Template.BasePath "/init-sysctl.yaml") . | sha256sum }}
+    checksum/init-sysctl: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/init-sysctl.yaml") }}
     {{- end }}
-    checksum/plugins: {{ include (print $.Template.BasePath "/install-plugins.yaml") . | sha256sum }}
-    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    checksum/plugins: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/install-plugins.yaml") }}
+    checksum/secret: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/secret.yaml") }}
     {{- if .Values.prometheusExporter.enabled }}
-    checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-config.yaml") . | sha256sum }}
-    checksum/prometheus-ce-config: {{ include (print $.Template.BasePath "/prometheus-ce-config.yaml") . | sha256sum }}
+    checksum/prometheus-config: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/prometheus-config.yaml") }}
+    checksum/prometheus-ce-config: {{ include "sonarqube.configMapOrSecretContentHash" (dict "ctx" . "name" "/prometheus-ce-config.yaml") }}
     {{- end }}
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
The `checksum/*` pod annotations hash the entire rendered ConfigMap or Secret, and the manifest's `metadata.labels` include `helm.sh/chart`. That value changes on every chart version bump, so SonarQube is restarted on `helm upgrade` even when no configuration has changed — an expensive restart for a single stateful instance with a slow startup.

This adds a `sonarqube.configMapOrSecretContentHash` helper to both charts that hashes only the `data`/`stringData` sections, and uses it for all 16 `checksum/*` annotations (7 in `sonarqube`, 9 in `sonarqube-dce`). A pure chart version bump no longer changes the checksums; a real config change — `plugins.install`, `sonarProperties`, the monitoring passcode — still does. Upgrading to 2026.5.1 restarts the pods once as the annotation values change.

The same fix was recently made in the argo-cd chart (argoproj/argo-helm#4044), and the loki chart uses the same data-only hashing.

Verified by rendering both charts with their `ci/ci-values.yaml` against a bumped chart version: checksums unchanged, and `helm lint` passes for both.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Document your Changes in the `CHANGELOG.md` file of the respected chart as well as the `Chart.yaml`